### PR TITLE
Add live ADS-B dashboard and decoder

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,8 +1,8 @@
 # OrcSDR project status
 
-Snapshot date: **2026-08-09**
-Source branch: **`codex/sdr-bandwidth-navigation`**
-Mainline baseline: **`origin/main` at `bda29fd`**
+Snapshot date: **2026-08-10**
+Source branch: **`codex/ads-b-dashboard`**
+Mainline baseline: **`origin/main` at `929abc7`**
 
 This is the authoritative current-status and roadmap index. Historical design,
 research, and validation documents remain useful evidence, but do not override
@@ -45,6 +45,7 @@ this file when their paths, versions, or completion claims differ.
 | AM/HF fidelity | **Experimental** | Do not claim calibrated HF/direct-sampling support |
 | Second ESP32-P4 board | **Planned** | No second-board hardware evidence yet |
 | rtl_tcp over Ethernet | **Planned** | App does not exist yet |
+| ADS-B 1090 | **Flashed — live pipeline implemented; acceptance pending** | COM17 upload hash-verified. Five-minute 1090 MHz run sustained 2,047,654 S/s (99.98% of 2.048 MS/s) with five startup drops and none afterward. A live RF trace reconstructed to CRC-valid DF17 `8DA2955158B505036BFB54BC90AC` (ICAO `A29551`, 35,000 ft), matching ASA1310's simultaneous independent track; the same captured magnitude waveform now passes the on-device fractional-sample replay check. The bounded aircraft table and revisioned dashboard snapshot are flashed. Dynamic updates no longer clear the full screen each second. A 315,547-record FAA index and the complete supplied FAA archive are SD hash-verified; live ICAO `A31111` resolved to `N297SF`. The UI honestly remains `DEMO` until a new on-device live frame passes CRC; physical view/touch acceptance remains open. |
 
 ## Roadmap
 
@@ -100,9 +101,25 @@ no duplicate USB implementation.
 - [ ] Sustain at least 1.0 MS/s for ten minutes and document drop rate.
 - [ ] Add mDNS discovery; evaluate Wi-Fi IQ only after Ethernet is stable.
 
+### P3 — ADS-B 1090
+
+- [x] Add an explicitly labeled deterministic-demo shell for Radar, List,
+      Target, RF Stats, and persisted receiver settings.
+- [x] Measure the 2.048 MS/s driver path at 1090 MHz for five minutes.
+- [x] Complete replay-tested Mode-S/DF17 decode: validated 56-bit DF11 and
+      112-bit DF17 extraction, CRC/ICAO, identity/altitude/velocity, global
+      CPR, captured-waveform replay, and bounded 64-aircraft state.
+- [x] Connect the decoder table to a revisioned live dashboard snapshot while
+      preserving the explicit `DEMO` gate until a live CRC-valid frame arrives.
+- [x] Add SD-backed FAA registration, model, and registered-owner enrichment
+      without dropping the complete source database or blocking the IQ callback.
+- [ ] Accept live aircraft against an independent receiver on the Tab5.
+
+Detailed gates and clean-room boundaries live in `phasing.md` Phase 6.
+
 ### Deferred until measurements justify them
 
-- Bias tee, direct sampling/HF, gain/PPM controls, SpyServer, WebSDR, ADS-B,
+- Bias tee, direct sampling/HF, gain/PPM controls, SpyServer, WebSDR, 978 MHz UAT,
   multi-client IQ fanout, and ESP32-S2/S3 production-rate claims.
 - LP-core DSP offload: the P4 LP core is intended for low-power service work and
   is not the first choice for the 960 kS/s floating-point demodulation path.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -86,6 +86,36 @@ surface specifically.
 (tool-shell abstraction, sequenced after the split lands so it has stable
 module boundaries to plug into).
 
+## Product initiative — ADS-B 1090 dashboard
+
+The supplied four-panel concept is accepted as the product contract for an
+on-device **1090 MHz Mode-S/ADS-B** tool: Radar, Aircraft List, selected
+Target, and RF Statistics share one aircraft snapshot and one selected ICAO.
+Settings is a fifth control view for receiver coordinates and radar range,
+not another data panel. The first implementation is deliberately marked
+`DEMO`; it exercises navigation and persistence without claiming live RF.
+
+Peer projects establish useful boundaries:
+
+- [T-Display-P4 ADS-B](https://github.com/jstockdale/T-Display-P4) proves the
+  ESP32-P4 + RTL-SDR vertical-app shape and informs product/reliability goals.
+- [dump1090](https://github.com/antirez/dump1090) and
+  [readsb](https://github.com/wiedehopf/readsb) inform frame validation,
+  bounded recently-seen aircraft state, and replay-first decoder checks.
+- [tar1090](https://github.com/wiedehopf/tar1090) reinforces the separation
+  between decoder state and selectable radar/list/detail views.
+
+These are architecture and behavior references only. OrcSDR does not copy
+GPL tuner, decoder, or UI source, and it does not bundle airline logos or
+aircraft photos. The 2.048 MS/s path is implemented and hardware-measured. The
+clean-room decoder, bounded state table, and live snapshot path are flashed;
+the dashboard keeps its `DEMO` badge until a newly received frame passes CRC,
+so replay and build evidence cannot be mistaken for current live aircraft.
+
+**Status: Live pipeline flashed; physical acceptance pending.** See `phasing.md`
+Phase 6.1 for the shell and Phase 6.2–6.6 for high-rate input, decoding,
+enrichment, and hardware acceptance.
+
 ## Summary table
 
 | Gap | New or already tracked | Phase |
@@ -95,3 +125,4 @@ module boundaries to plug into).
 | No CI | New | Phase 2 |
 | Open performance gates | Already tracked (`PROJECT_STATUS.md` P0/P1) | Unchanged |
 | No tool-shell abstraction | New | Phase 3 |
+| ADS-B 1090 dashboard | Product initiative | Phase 6 |

--- a/apps/orcsdr-tab5/ui/adsb_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/adsb_dashboard.cpp
@@ -1,0 +1,733 @@
+#include "adsb_dashboard.hpp"
+
+#include <M5Unified.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+
+namespace orcsdr::adsb {
+namespace {
+
+constexpr uint16_t kBg = TFT_BLACK;
+constexpr uint16_t kPanel = 0x0861;
+constexpr uint16_t kBorder = 0x2945;
+constexpr uint16_t kBlue = 0x04ff;
+constexpr uint16_t kGreen = 0x6fe8;
+constexpr uint16_t kMuted = 0x9cf3;
+constexpr int kHeaderH = 76;
+constexpr int kTabsY = 646;
+constexpr int kTabW = 256;
+constexpr uint16_t kRanges[] = {10, 25, 50, 100};
+
+enum class View : uint8_t { radar, list, target, stats, settings, count };
+enum class EditField : uint8_t { none, latitude, longitude };
+
+struct DisplayAircraft {
+  uint32_t icao;
+  char callsign[9];
+  char registration[9];
+  char type[49];
+  char op[51];
+  int altitude_ft;
+  int speed_kts;
+  int heading_deg;
+  int vertical_rate_fpm;
+  float range_nm;
+  int bearing_deg;
+  float latitude;
+  float longitude;
+  float signal_dbfs;
+  bool has_altitude;
+  bool has_speed;
+  bool has_heading;
+  bool has_vertical_rate;
+  bool has_position;
+  bool stale;
+};
+
+constexpr DisplayAircraft kDemoAircraft[] = {
+    {0xA1B2C3, "DAL123", "N123DA", "A320", "DELTA AIR LINES", 34000, 452, 45, 1280,
+     23.0f, 45, 37.7749f, -122.4194f, -45.0f, true, true, true, true, true, false},
+    {0xA4B5C6, "UAL456", "N456UA", "B738", "UNITED AIRLINES", 37000, 468, 310, -320,
+     31.0f, 310, 37.9550f, -122.7200f, -50.0f, true, true, true, true, true, false},
+    {0xA7B8C9, "AAL789", "N789AA", "A321", "AMERICAN AIRLINES", 28000, 425, 278, 640,
+     18.0f, 278, 37.7200f, -122.7300f, -53.0f, true, true, true, true, true, false},
+    {0xAA11BB, "SWA234", "N234SW", "B737", "SOUTHWEST AIRLINES", 31000, 410, 122, 0,
+     45.0f, 122, 37.2400f, -121.9100f, -58.0f, true, true, true, true, true, false},
+    {0xCC22DD, "N12345", "N12345", "C172", "PRIVATE", 12500, 250, 196, -160,
+     12.0f, 196, 37.5800f, -122.4100f, -61.0f, true, true, true, true, true, false},
+    {0xEE33FF, "FFT567", "N567FF", "A20N", "FRONTIER AIRLINES", 41000, 490, 70, 320,
+     67.0f, 70, 38.2100f, -121.6000f, -64.0f, true, true, true, true, false, false},
+};
+
+static_assert(static_cast<uint8_t>(View::count) == 5);
+static_assert(kRanges[0] == 10 && kRanges[1] == 25 && kRanges[2] == 50 &&
+              kRanges[3] == 100);
+
+Settings g_settings;
+View g_view = View::radar;
+EditField g_edit = EditField::none;
+size_t g_selected = 0;
+bool g_locked = false;
+bool g_active = false;
+bool g_latitude_set = false;
+bool g_longitude_set = false;
+char g_entry[20]{};
+DisplayAircraft g_aircraft[kVisibleAircraft]{};
+size_t g_aircraft_count = std::size(kDemoAircraft);
+Snapshot g_live_snapshot{};
+uint32_t g_drawn_revision = 0;
+bool g_live = false;
+
+bool hit(int32_t x, int32_t y, int bx, int by, int bw, int bh) {
+  return x >= bx && x < bx + bw && y >= by && y < by + bh;
+}
+
+bool valid_coordinate(EditField field, double value) {
+  return field == EditField::latitude ? value >= -90.0 && value <= 90.0
+                                      : value >= -180.0 && value <= 180.0;
+}
+
+int aircraft_index(uint32_t icao) {
+  for (size_t i = 0; i < g_aircraft_count; ++i)
+    if (g_aircraft[i].icao == icao) return static_cast<int>(i);
+  return -1;
+}
+
+bool keep_stale_selection(bool locked, bool stale) { return !stale || locked; }
+
+void update_geometry(DisplayAircraft& aircraft) {
+  if (!aircraft.has_position || !g_settings.location_configured) return;
+  constexpr double kEarthNm = 3440.065;
+  const double lat1 = g_settings.latitude_e7 / 10000000.0 * DEG_TO_RAD;
+  const double lon1 = g_settings.longitude_e7 / 10000000.0 * DEG_TO_RAD;
+  const double lat2 = aircraft.latitude * DEG_TO_RAD;
+  const double lon2 = aircraft.longitude * DEG_TO_RAD;
+  const double dlat = lat2 - lat1, dlon = lon2 - lon1;
+  const double a = sin(dlat / 2) * sin(dlat / 2) +
+                   cos(lat1) * cos(lat2) * sin(dlon / 2) * sin(dlon / 2);
+  const double bounded_a = std::clamp(a, 0.0, 1.0);
+  aircraft.range_nm = static_cast<float>(
+      kEarthNm * 2 * atan2(sqrt(bounded_a), sqrt(1 - bounded_a)));
+  aircraft.bearing_deg = static_cast<int>(lround(
+      fmod(atan2(sin(dlon) * cos(lat2),
+                 cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dlon)) /
+                   DEG_TO_RAD + 360.0,
+           360.0)));
+}
+
+void apply_live_snapshot() {
+  const uint32_t selected_icao = g_aircraft_count ? g_aircraft[g_selected].icao : 0;
+  const DisplayAircraft selected_aircraft = g_aircraft_count ? g_aircraft[g_selected]
+                                                              : DisplayAircraft{};
+  g_aircraft_count = std::min<size_t>(g_live_snapshot.visible_count, kVisibleAircraft);
+  for (size_t i = 0; i < g_aircraft_count; ++i) {
+    const auto& source = g_live_snapshot.aircraft[i];
+    auto& target = g_aircraft[i];
+    target = {};
+    target.icao = source.icao;
+    strlcpy(target.registration, source.registration, sizeof(target.registration));
+    if (source.has_callsign) strlcpy(target.callsign, source.callsign, sizeof(target.callsign));
+    else if (source.registration[0])
+      strlcpy(target.callsign, source.registration, sizeof(target.callsign));
+    else
+      snprintf(target.callsign, sizeof(target.callsign), "%06lX",
+               static_cast<unsigned long>(source.icao));
+    strlcpy(target.type, source.type[0] ? source.type : "--", sizeof(target.type));
+    if (source.owner[0]) strlcpy(target.op, source.owner, sizeof(target.op));
+    else snprintf(target.op, sizeof(target.op), "ICAO %06lX",
+                  static_cast<unsigned long>(source.icao));
+    target.altitude_ft = source.altitude_ft;
+    target.speed_kts = source.speed_kts;
+    target.heading_deg = source.heading_deg;
+    target.vertical_rate_fpm = source.vertical_rate_fpm;
+    target.latitude = source.latitude;
+    target.longitude = source.longitude;
+    target.signal_dbfs = source.signal_dbfs;
+    target.has_altitude = source.has_altitude;
+    target.has_speed = source.has_speed;
+    target.has_heading = source.has_heading;
+    target.has_vertical_rate = source.has_vertical_rate;
+    target.has_position = source.has_position;
+    update_geometry(target);
+  }
+  int selected = aircraft_index(selected_icao);
+  if (selected < 0 && g_locked && selected_icao) {
+    selected = static_cast<int>(std::min(g_aircraft_count, kVisibleAircraft - 1));
+    g_aircraft[selected] = selected_aircraft;
+    g_aircraft[selected].stale = true;
+    if (g_aircraft_count < kVisibleAircraft) ++g_aircraft_count;
+  }
+  g_selected = selected >= 0 ? static_cast<size_t>(selected) : 0;
+}
+
+void toggle_lock() {
+  g_locked = !g_locked;
+  if (!g_locked && g_live && g_aircraft_count && g_aircraft[g_selected].stale)
+    apply_live_snapshot();
+}
+
+void text(const char* value, int x, int y, uint16_t color = TFT_WHITE,
+          int size = 2, textdatum_t datum = middle_center) {
+  M5.Display.setTextDatum(datum);
+  M5.Display.setTextSize(size);
+  M5.Display.setTextColor(color, kBg);
+  M5.Display.drawString(value, x, y);
+}
+
+void card(int x, int y, int w, int h) {
+  M5.Display.fillRoundRect(x, y, w, h, 12, kPanel);
+  M5.Display.drawRoundRect(x, y, w, h, 12, kBorder);
+}
+
+void button(const char* label, int x, int y, int w, int h, uint16_t color) {
+  M5.Display.fillRoundRect(x, y, w, h, 8, color);
+  M5.Display.drawRoundRect(x, y, w, h, 8, TFT_LIGHTGREY);
+  text(label, x + w / 2, y + h / 2, TFT_WHITE, 2);
+}
+
+void plane(int x, int y, int scale, uint16_t color) {
+  M5.Display.fillRect(x - scale / 8, y - scale / 2, scale / 4, scale, color);
+  M5.Display.fillTriangle(x, y - scale / 2, x - scale / 5, y - scale / 3,
+                          x + scale / 5, y - scale / 3, color);
+  M5.Display.fillTriangle(x - scale, y, x + scale, y, x, y + scale / 5, color);
+  M5.Display.fillTriangle(x - scale / 2, y + scale / 2,
+                          x + scale / 2, y + scale / 2, x, y + scale / 3, color);
+}
+
+void draw_header() {
+  M5.Display.fillRect(0, 0, 1280, kHeaderH, kBg);
+  M5.Display.drawFastHLine(20, kHeaderH - 1, 1240, kBorder);
+  text("OrcSDR", 24, 37, TFT_WHITE, 3, middle_left);
+  text("ADS-B 1090", 250, 37, kBlue, 3);
+  M5.Display.fillCircle(423, 37, 7, kGreen);
+  char count[24];
+  snprintf(count, sizeof(count), "%u AIRCRAFT", static_cast<unsigned>(
+      g_live ? g_live_snapshot.aircraft_count : g_aircraft_count));
+  text(count, 445, 37, TFT_WHITE, 2, middle_left);
+  text("MSG RATE", 660, 37, kMuted, 2, middle_left);
+  char rate[20];
+  snprintf(rate, sizeof(rate), "%.1f/s", g_live ? g_live_snapshot.message_rate : 58.7f);
+  text(rate, 785, 37, kGreen, 2, middle_left);
+  button(g_live ? "LIVE" : "DEMO", 1045, 14, 100, 44,
+         g_live ? TFT_DARKGREEN : TFT_MAROON);
+  char range[24];
+  snprintf(range, sizeof(range), "%u NM", g_settings.radar_range_nm);
+  text(range, 1235, 37, TFT_LIGHTGREY, 2, middle_right);
+}
+
+void draw_header_live_values() {
+  M5.Display.fillRect(440, 12, 175, 48, kBg);
+  M5.Display.fillRect(780, 12, 130, 48, kBg);
+  char value[24];
+  snprintf(value, sizeof(value), "%u AIRCRAFT", static_cast<unsigned>(
+      g_live ? g_live_snapshot.aircraft_count : g_aircraft_count));
+  text(value, 445, 37, TFT_WHITE, 2, middle_left);
+  snprintf(value, sizeof(value), "%.1f/s", g_live ? g_live_snapshot.message_rate : 58.7f);
+  text(value, 785, 37, kGreen, 2, middle_left);
+  button(g_live ? "LIVE" : "DEMO", 1045, 14, 100, 44,
+         g_live ? TFT_DARKGREEN : TFT_MAROON);
+}
+
+void draw_tabs() {
+  static constexpr const char* labels[] = {"RADAR", "LIST", "TARGET", "STATS", "SETTINGS"};
+  M5.Display.fillRect(0, kTabsY, 1280, 74, kBg);
+  M5.Display.drawFastHLine(0, kTabsY, 1280, kBorder);
+  for (int i = 0; i < 5; ++i) {
+    if (static_cast<int>(g_view) == i) M5.Display.fillRect(i * kTabW, kTabsY + 1, kTabW, 73, 0x08a4);
+    text(labels[i], i * kTabW + kTabW / 2, kTabsY + 39,
+         static_cast<int>(g_view) == i ? kBlue : TFT_LIGHTGREY, 2);
+  }
+}
+
+void draw_selected_summary(int x, int y, int w, int h) {
+  if (g_aircraft_count == 0) {
+    card(x, y, w, h);
+    text("SEARCHING", x + w / 2, y + h / 2 - 20, kBlue, 4);
+    text("No aircraft in the last 60 seconds", x + w / 2, y + h / 2 + 35,
+         TFT_LIGHTGREY, 2);
+    return;
+  }
+  const DisplayAircraft& a = g_aircraft[g_selected];
+  card(x, y, w, h);
+  text(a.callsign, x + 28, y + 45, kGreen, 4, middle_left);
+  button(a.stale ? "STALE" : (g_locked ? "LOCKED" : "LOCK"),
+         x + w - 122, y + 20, 96, 42,
+         a.stale ? TFT_MAROON : (g_locked ? TFT_DARKGREEN : TFT_DARKGREY));
+  plane(x + 55, y + 115, 26, TFT_WHITE);
+  char identity[32];
+  snprintf(identity, sizeof(identity), "%s | %06lX",
+           a.registration[0] ? a.registration : "--",
+           static_cast<unsigned long>(a.icao));
+  text(identity, x + 105, y + 90, TFT_WHITE, 2, middle_left);
+  text(a.type, x + 105, y + 116, TFT_LIGHTGREY, 2, middle_left);
+  text(a.op, x + 105, y + 140, TFT_LIGHTGREY, 2, middle_left);
+  M5.Display.drawFastHLine(x + 24, y + 158, w - 48, kBorder);
+  char value[32];
+  text("ALTITUDE", x + 28, y + 185, kBlue, 2, middle_left);
+  if (a.has_altitude) snprintf(value, sizeof(value), "%d ft", a.altitude_ft);
+  else strlcpy(value, "--", sizeof(value));
+  text(value, x + 28, y + 221, TFT_WHITE, 3, middle_left);
+  text("SPEED", x + w / 2 + 12, y + 185, kBlue, 2, middle_left);
+  if (a.has_speed) snprintf(value, sizeof(value), "%d kts", a.speed_kts);
+  else strlcpy(value, "--", sizeof(value));
+  text(value, x + w / 2 + 12, y + 221, TFT_WHITE, 3, middle_left);
+  text("RANGE / BEARING", x + 28, y + 270, kBlue, 2, middle_left);
+  if (a.has_position && g_settings.location_configured) {
+    snprintf(value, sizeof(value), "%.0f NM   %03d deg", a.range_nm, a.bearing_deg);
+  } else {
+    strlcpy(value, "--", sizeof(value));
+  }
+  text(value, x + 28, y + 307, TFT_WHITE, 3, middle_left);
+}
+
+void draw_radar() {
+  const int cx = 345, cy = 354, radius = 245;
+  card(18, 92, 675, 532);
+  for (int ring = 1; ring <= 4; ++ring) M5.Display.drawCircle(cx, cy, radius * ring / 4, 0x2382);
+  M5.Display.drawFastHLine(cx - radius, cy, radius * 2, 0x2382);
+  M5.Display.drawFastVLine(cx, cy - radius, radius * 2, 0x2382);
+  text("N", cx, cy - radius - 17, TFT_WHITE, 2);
+  text("S", cx, cy + radius + 17, TFT_WHITE, 2);
+  text("W", cx - radius - 20, cy, TFT_WHITE, 2);
+  text("E", cx + radius + 20, cy, TFT_WHITE, 2);
+  plane(cx, cy, 22, kBlue);
+  for (size_t i = 0; i < g_aircraft_count; ++i) {
+    if (!g_aircraft[i].has_position || !g_settings.location_configured) continue;
+    const float distance = fminf(g_aircraft[i].range_nm / g_settings.radar_range_nm, 1.0f);
+    const float angle = (g_aircraft[i].bearing_deg - 90.0f) * DEG_TO_RAD;
+    const int px = cx + static_cast<int>(cosf(angle) * distance * (radius - 18));
+    const int py = cy + static_cast<int>(sinf(angle) * distance * (radius - 18));
+    plane(px, py, i == g_selected ? 16 : 12, i == g_selected ? kBlue : kGreen);
+    if (i == g_selected) M5.Display.drawRect(px - 25, py - 25, 50, 50, kGreen);
+  }
+  draw_selected_summary(720, 112, 542, 472);
+  if (!g_settings.location_configured) {
+    button("SET RECEIVER LOCATION FOR RANGE / BEARING", 160, 560, 500, 42, TFT_MAROON);
+  }
+}
+
+void draw_list() {
+  card(18, 92, 820, 532);
+  text("AIRCRAFT", 54, 122, kBlue, 2, middle_left);
+  text("ALTITUDE", 315, 122, kBlue, 2, middle_left);
+  text("SPEED", 500, 122, kBlue, 2, middle_left);
+  text("RANGE", 650, 122, kBlue, 2, middle_left);
+  for (size_t i = 0; i < g_aircraft_count; ++i) {
+    const int y = 150 + static_cast<int>(i) * 72;
+    if (i == g_selected) M5.Display.fillRoundRect(30, y, 795, 62, 8, TFT_NAVY);
+    plane(58, y + 31, 10, kGreen);
+    text(g_aircraft[i].callsign, 86, y + 20, kGreen, 2, middle_left);
+    char identity[32];
+    snprintf(identity, sizeof(identity), "%s | %06lX",
+             g_aircraft[i].registration[0] ? g_aircraft[i].registration : "--",
+             static_cast<unsigned long>(g_aircraft[i].icao));
+    text(identity, 86, y + 45, TFT_LIGHTGREY, 2, middle_left);
+    char value[24];
+    if (g_aircraft[i].has_altitude) snprintf(value, sizeof(value), "%d ft", g_aircraft[i].altitude_ft);
+    else strlcpy(value, "--", sizeof(value));
+    text(value, 315, y + 31, TFT_WHITE, 2, middle_left);
+    if (g_aircraft[i].has_speed) snprintf(value, sizeof(value), "%d kts", g_aircraft[i].speed_kts);
+    else strlcpy(value, "--", sizeof(value));
+    text(value, 500, y + 31, TFT_WHITE, 2, middle_left);
+    if (g_aircraft[i].has_position && g_settings.location_configured)
+      snprintf(value, sizeof(value), "%.0f NM", g_aircraft[i].range_nm);
+    else
+      strlcpy(value, "--", sizeof(value));
+    text(value, 650, y + 31, TFT_WHITE, 2, middle_left);
+  }
+  draw_selected_summary(860, 112, 402, 472);
+}
+
+void draw_target() {
+  if (g_aircraft_count == 0) {
+    card(18, 92, 1244, 532);
+    text("SEARCHING FOR AIRCRAFT", 640, 340, kBlue, 4);
+    return;
+  }
+  const DisplayAircraft& a = g_aircraft[g_selected];
+  card(18, 92, 1244, 532);
+  text(a.callsign, 48, 145, kGreen, 5, middle_left);
+  button(a.stale ? "STALE" : (g_locked ? "LOCKED" : "LOCK"), 305, 112, 110, 46,
+         a.stale ? TFT_MAROON : (g_locked ? TFT_DARKGREEN : TFT_DARKGREY));
+  text(a.op, 48, 185, TFT_WHITE, 2, middle_left);
+  char identity[64];
+  snprintf(identity, sizeof(identity), "%s | %06lX",
+           a.registration[0] ? a.registration : "--",
+           static_cast<unsigned long>(a.icao));
+  text(identity, 48, 215, TFT_LIGHTGREY, 2, middle_left);
+  text(a.type, 48, 245, TFT_LIGHTGREY, 2, middle_left);
+  plane(380, 330, 95, TFT_LIGHTGREY);
+  card(610, 118, 620, 455);
+  const char* labels[] = {"ALTITUDE", "SPEED", "HEADING", "VERT RATE",
+                          "RANGE", "BEARING", "LATITUDE", "LONGITUDE"};
+  char values[8][32];
+  if (a.has_altitude) snprintf(values[0], sizeof(values[0]), "%d ft", a.altitude_ft);
+  else strlcpy(values[0], "--", sizeof(values[0]));
+  if (a.has_speed) snprintf(values[1], sizeof(values[1]), "%d kts", a.speed_kts);
+  else strlcpy(values[1], "--", sizeof(values[1]));
+  if (a.has_heading) snprintf(values[2], sizeof(values[2]), "%03d deg", a.heading_deg);
+  else strlcpy(values[2], "--", sizeof(values[2]));
+  if (a.has_vertical_rate)
+    snprintf(values[3], sizeof(values[3]), "%+d ft/min", a.vertical_rate_fpm);
+  else
+    strlcpy(values[3], "--", sizeof(values[3]));
+  if (a.has_position && g_settings.location_configured) {
+    snprintf(values[4], sizeof(values[4]), "%.0f NM", a.range_nm);
+    snprintf(values[5], sizeof(values[5]), "%03d deg", a.bearing_deg);
+  } else {
+    strlcpy(values[4], "--", sizeof(values[4]));
+    strlcpy(values[5], "--", sizeof(values[5]));
+  }
+  if (a.has_position) {
+    snprintf(values[6], sizeof(values[6]), "%.4f", a.latitude);
+    snprintf(values[7], sizeof(values[7]), "%.4f", a.longitude);
+  } else {
+    strlcpy(values[6], "--", sizeof(values[6]));
+    strlcpy(values[7], "--", sizeof(values[7]));
+  }
+  for (int i = 0; i < 8; ++i) {
+    const int col = i % 4, row = i / 4;
+    const int x = 635 + col * 145, y = 155 + row * 190;
+    text(labels[i], x, y, kBlue, 2, middle_left);
+    text(values[i], x, y + 48, TFT_WHITE, 2, middle_left);
+  }
+}
+
+void draw_stats() {
+  char value[32];
+  card(18, 92, 392, 270);
+  text("SIGNAL STRENGTH", 42, 124, kBlue, 2, middle_left);
+  snprintf(value, sizeof(value), "%.1f dBFS",
+           g_live ? g_live_snapshot.strongest_signal_dbfs : -48.0f);
+  text(value, 42, 174, TFT_WHITE, 4, middle_left);
+  for (int i = 0; i < 10; ++i) M5.Display.fillRect(48 + i * 28, 290 - i * 10, 20, 25 + i * 10,
+                                                   i < 7 ? kGreen : TFT_DARKGREY);
+  card(428, 92, 402, 270);
+  text("MESSAGE RATE", 452, 124, kBlue, 2, middle_left);
+  snprintf(value, sizeof(value), "%.1f msg/sec",
+           g_live ? g_live_snapshot.message_rate : 58.7f);
+  text(value, 452, 174, TFT_WHITE, 3, middle_left);
+  int py = 300;
+  for (int x = 458; x < 805; x += 28) {
+    const int ny = 250 + ((x / 28) % 4) * 12;
+    M5.Display.drawLine(x - 28, py, x, ny, kBlue);
+    py = ny;
+  }
+  card(848, 92, 414, 270);
+  text("MODE-S ACTIVITY", 872, 124, kBlue, 2, middle_left);
+  for (int i = 0; i < 8; ++i) {
+    const int x = 880 + i * 43;
+    M5.Display.drawRect(x, 185, 20, i % 3 == 0 ? 90 : 55, kBlue);
+  }
+  char aircraft[12], messages[20], strongest[20];
+  snprintf(aircraft, sizeof(aircraft), "%u", static_cast<unsigned>(
+      g_live ? g_live_snapshot.aircraft_count : g_aircraft_count));
+  snprintf(messages, sizeof(messages), "%lu", static_cast<unsigned long>(
+      g_live ? g_live_snapshot.total_messages : 15892));
+  snprintf(strongest, sizeof(strongest), "%.1f dBFS",
+           g_live ? g_live_snapshot.strongest_signal_dbfs : -45.0f);
+  struct Metric { const char* label; const char* value; uint16_t color; };
+  const Metric metrics[] = {{"AIRCRAFT", aircraft, TFT_WHITE},
+                            {"MESSAGES", messages, TFT_WHITE},
+                            {"STRONGEST", strongest, kGreen},
+                            {"CPU", "N/A", TFT_LIGHTGREY}, {"GAIN", "AUTO", kGreen}};
+  for (int i = 0; i < 5; ++i) {
+    const int x = 18 + i * 250;
+    card(x, 382, 230, 220);
+    text(metrics[i].label, x + 18, 420, kBlue, 2, middle_left);
+    text(metrics[i].value, x + 115, 510, metrics[i].color, 3);
+  }
+}
+
+void start_edit(EditField field) {
+  g_edit = field;
+  const int32_t e7 = field == EditField::latitude ? g_settings.latitude_e7
+                                                  : g_settings.longitude_e7;
+  snprintf(g_entry, sizeof(g_entry), "%.7f", e7 / 10000000.0);
+}
+
+void draw_keypad() {
+  card(690, 102, 570, 510);
+  text(g_edit == EditField::latitude ? "EDIT LATITUDE" : "EDIT LONGITUDE",
+       975, 138, kBlue, 3);
+  button(g_entry[0] ? g_entry : "0", 730, 170, 490, 55, TFT_NAVY);
+  static constexpr const char* keys[] = {"1", "2", "3", "4", "5", "6",
+                                          "7", "8", "9", "+/-", "0", ".", "<"};
+  for (int i = 0; i < 13; ++i) {
+    const int col = i % 4, row = i / 4;
+    button(keys[i], 730 + col * 122, 245 + row * 64, 112, 54, TFT_DARKGREY);
+  }
+  button("CANCEL", 730, 508, 230, 58, TFT_MAROON);
+  button("SAVE", 990, 508, 230, 58, TFT_DARKGREEN);
+}
+
+void draw_settings() {
+  card(18, 92, 620, 532);
+  text("ADS-B SETTINGS", 48, 130, kBlue, 3, middle_left);
+  text("RECEIVER LATITUDE", 48, 190, kMuted, 2, middle_left);
+  text("RECEIVER LONGITUDE", 48, 285, kMuted, 2, middle_left);
+  char value[40];
+  if (g_latitude_set)
+    snprintf(value, sizeof(value), "%.7f", g_settings.latitude_e7 / 10000000.0);
+  else
+    strlcpy(value, "NOT SET", sizeof(value));
+  button(value, 300, 165, 300, 58, TFT_NAVY);
+  if (g_longitude_set)
+    snprintf(value, sizeof(value), "%.7f", g_settings.longitude_e7 / 10000000.0);
+  else
+    strlcpy(value, "NOT SET", sizeof(value));
+  button(value, 300, 260, 300, 58, TFT_NAVY);
+  text("RADAR RANGE", 48, 380, kMuted, 2, middle_left);
+  snprintf(value, sizeof(value), "%u NM", g_settings.radar_range_nm);
+  button(value, 300, 355, 300, 58, TFT_DARKCYAN);
+  text("RF GAIN", 48, 475, kMuted, 2, middle_left);
+  button("AUTO  (READ ONLY)", 300, 450, 300, 58, TFT_DARKGREY);
+  button("EXIT ADS-B", 300, 545, 300, 58, TFT_MAROON);
+  if (g_edit != EditField::none) draw_keypad();
+  else {
+    card(690, 102, 570, 510);
+    text(g_live ? "LIVE RECEIVER" : "DEMO MODE", 975, 190,
+         g_live ? kGreen : TFT_ORANGE, 4);
+    text(g_live ? "1090 MHz Mode-S capture active" : "Waiting for a CRC-valid live frame",
+         975, 260, TFT_LIGHTGREY, 2);
+    text("Gain is automatic and read only.", 975, 380, TFT_LIGHTGREY, 2);
+  }
+}
+
+void redraw_content() {
+  M5.Display.fillRect(0, kHeaderH, 1280, kTabsY - kHeaderH, kBg);
+  switch (g_view) {
+    case View::radar: draw_radar(); break;
+    case View::list: draw_list(); break;
+    case View::target: draw_target(); break;
+    case View::stats: draw_stats(); break;
+    case View::settings: draw_settings(); break;
+    default: break;
+  }
+}
+
+void redraw() {
+  M5.Display.fillScreen(kBg);
+  draw_header();
+  redraw_content();
+  draw_tabs();
+}
+
+Action handle_keypad(int32_t x, int32_t y) {
+  if (hit(x, y, 730, 508, 230, 58)) {
+    g_edit = EditField::none;
+    redraw();
+    return Action::none;
+  }
+  if (hit(x, y, 990, 508, 230, 58)) {
+    char* end = nullptr;
+    const double value = strtod(g_entry, &end);
+    if (end != g_entry && *end == '\0' && valid_coordinate(g_edit, value)) {
+      const int32_t e7 = static_cast<int32_t>(llround(value * 10000000.0));
+      if (g_edit == EditField::latitude) {
+        g_settings.latitude_e7 = e7;
+        g_latitude_set = true;
+      } else {
+        g_settings.longitude_e7 = e7;
+        g_longitude_set = true;
+      }
+      g_settings.location_configured = g_latitude_set && g_longitude_set;
+      g_edit = EditField::none;
+      if (g_live) apply_live_snapshot();
+      redraw();
+      return g_settings.location_configured ? Action::settings_changed : Action::none;
+    }
+    return Action::none;
+  }
+  static constexpr char keys[] = {'1', '2', '3', '4', '5', '6', '7', '8', '9',
+                                   '-', '0', '.', '\b'};
+  for (int i = 0; i < 13; ++i) {
+    const int col = i % 4, row = i / 4;
+    if (!hit(x, y, 730 + col * 122, 245 + row * 64, 112, 54)) continue;
+    const size_t len = strlen(g_entry);
+    if (keys[i] == '\b') {
+      if (len) g_entry[len - 1] = '\0';
+    } else if (keys[i] == '-') {
+      if (g_entry[0] == '-') memmove(g_entry, g_entry + 1, len);
+      else if (len + 1 < sizeof(g_entry)) {
+        memmove(g_entry + 1, g_entry, len + 1);
+        g_entry[0] = '-';
+      }
+    } else if (len + 1 < sizeof(g_entry) &&
+               (keys[i] != '.' || strchr(g_entry, '.') == nullptr)) {
+      g_entry[len] = keys[i];
+      g_entry[len + 1] = '\0';
+    }
+    draw_keypad();
+    return Action::none;
+  }
+  return Action::none;
+}
+
+}  // namespace
+
+void enter(const Settings& settings_value) {
+  g_settings = settings_value;
+  g_view = View::radar;
+  g_edit = EditField::none;
+  g_selected = 0;
+  g_locked = false;
+  g_active = true;
+  g_latitude_set = settings_value.location_configured;
+  g_longitude_set = settings_value.location_configured;
+  if (g_live) {
+    apply_live_snapshot();
+    g_drawn_revision = g_live_snapshot.revision;
+  } else {
+    std::copy(std::begin(kDemoAircraft), std::end(kDemoAircraft), g_aircraft);
+    g_aircraft_count = std::size(kDemoAircraft);
+  }
+  redraw();
+}
+
+void draw() { if (g_active) redraw(); }
+
+void update() {
+  if (!g_active || !g_live || g_drawn_revision == g_live_snapshot.revision) return;
+  static uint32_t last_draw_ms = 0;
+  if (millis() - last_draw_ms < 1000) return;
+  last_draw_ms = millis();
+  apply_live_snapshot();
+  g_drawn_revision = g_live_snapshot.revision;
+  draw_header_live_values();
+  // Live repaint deliberately skips redraw_content()'s full black clear.
+  switch (g_view) {
+    case View::radar: draw_radar(); break;
+    case View::list: draw_list(); break;
+    case View::target: draw_target(); break;
+    case View::stats: draw_stats(); break;
+    case View::settings: draw_settings(); break;
+    default: break;
+  }
+}
+
+void set_live_snapshot(const Snapshot& snapshot) {
+  g_live_snapshot = snapshot;
+  if (snapshot.visible_count) g_live = true;
+}
+
+Action handle_touch(int32_t x, int32_t y) {
+  if (!g_active) return Action::none;
+  if (g_edit != EditField::none) return handle_keypad(x, y);
+  if (y >= kTabsY) {
+    g_view = static_cast<View>(constrain(x / kTabW, 0, 4));
+    redraw();
+    return Action::none;
+  }
+  if (g_view == View::radar) {
+    const int cx = 345, cy = 354, radius = 245;
+    for (size_t i = 0; i < g_aircraft_count; ++i) {
+      if (!g_aircraft[i].has_position || !g_settings.location_configured) continue;
+      const float distance = fminf(g_aircraft[i].range_nm / g_settings.radar_range_nm, 1.0f);
+      const float angle = (g_aircraft[i].bearing_deg - 90.0f) * DEG_TO_RAD;
+      const int px = cx + static_cast<int>(cosf(angle) * distance * (radius - 18));
+      const int py = cy + static_cast<int>(sinf(angle) * distance * (radius - 18));
+      const int dx = x - px, dy = y - py;
+      if (dx * dx + dy * dy <= 32 * 32) {
+        g_selected = i;
+        redraw_content();
+        return Action::none;
+      }
+    }
+    if (hit(x, y, 720 + 542 - 122, 132, 96, 42)) {
+      toggle_lock();
+      redraw_content();
+    }
+  } else if (g_view == View::list) {
+    for (size_t i = 0; i < g_aircraft_count; ++i) {
+      if (hit(x, y, 30, 150 + static_cast<int>(i) * 72, 795, 62)) {
+        g_selected = i;
+        redraw_content();
+        return Action::none;
+      }
+    }
+    if (hit(x, y, 860 + 402 - 122, 132, 96, 42)) {
+      toggle_lock();
+      redraw_content();
+    }
+  } else if (g_view == View::target) {
+    if (hit(x, y, 305, 112, 110, 46)) {
+      toggle_lock();
+      redraw_content();
+    }
+  } else if (g_view == View::settings) {
+    if (hit(x, y, 300, 165, 300, 58)) { start_edit(EditField::latitude); redraw(); }
+    else if (hit(x, y, 300, 260, 300, 58)) { start_edit(EditField::longitude); redraw(); }
+    else if (hit(x, y, 300, 355, 300, 58)) {
+      size_t index = 0;
+      while (index < std::size(kRanges) && kRanges[index] != g_settings.radar_range_nm) ++index;
+      g_settings.radar_range_nm = kRanges[(index + 1) % std::size(kRanges)];
+      redraw();
+      return Action::settings_changed;
+    } else if (hit(x, y, 300, 545, 300, 58)) {
+      g_active = false;
+      return Action::exit;
+    }
+  }
+  return Action::none;
+}
+
+const Settings& settings() { return g_settings; }
+bool active() { return g_active; }
+
+bool self_check() {
+  for (size_t i = 0; i < std::size(kDemoAircraft); ++i) {
+    if (kDemoAircraft[i].icao == 0 || kDemoAircraft[i].callsign[0] == '\0') return false;
+    for (size_t j = i + 1; j < std::size(kDemoAircraft); ++j)
+      if (kDemoAircraft[i].icao == kDemoAircraft[j].icao) return false;
+  }
+  DisplayAircraft saved_aircraft[kVisibleAircraft];
+  std::copy(std::begin(g_aircraft), std::end(g_aircraft), saved_aircraft);
+  const size_t saved_count = g_aircraft_count;
+  const Snapshot saved_snapshot = g_live_snapshot;
+  const size_t saved_selected = g_selected;
+  const bool saved_locked = g_locked, saved_live = g_live;
+  Snapshot test{};
+  test.visible_count = test.aircraft_count = 1;
+  test.aircraft[0].icao = 0x123456;
+  strlcpy(test.aircraft[0].callsign, "TEST123", sizeof(test.aircraft[0].callsign));
+  test.aircraft[0].has_callsign = true;
+  g_live_snapshot = test;
+  g_live = true;
+  g_locked = false;
+  apply_live_snapshot();
+  bool model_ok = g_aircraft_count == 1 && g_aircraft[0].icao == 0x123456 &&
+                  aircraft_index(0x123456) == 0;
+  test.aircraft[0].has_callsign = false;
+  strlcpy(test.aircraft[0].registration, "N12345", sizeof(test.aircraft[0].registration));
+  g_live_snapshot = test;
+  apply_live_snapshot();
+  model_ok = model_ok && strcmp(g_aircraft[0].callsign, "N12345") == 0;
+  g_locked = true;
+  g_live_snapshot.visible_count = g_live_snapshot.aircraft_count = 0;
+  apply_live_snapshot();
+  model_ok = model_ok && g_aircraft_count == 1 && g_aircraft[0].stale;
+  g_locked = false;
+  apply_live_snapshot();
+  model_ok = model_ok && g_aircraft_count == 0;
+  std::copy(std::begin(saved_aircraft), std::end(saved_aircraft), g_aircraft);
+  g_aircraft_count = saved_count;
+  g_live_snapshot = saved_snapshot;
+  g_selected = saved_selected;
+  g_locked = saved_locked;
+  g_live = saved_live;
+
+  return model_ok && kDemoAircraft[2].icao == 0xA7B8C9 &&
+         keep_stale_selection(true, true) && !keep_stale_selection(false, true) &&
+         keep_stale_selection(false, false) &&
+         valid_coordinate(EditField::latitude, -90.0) &&
+         valid_coordinate(EditField::latitude, 90.0) &&
+         !valid_coordinate(EditField::latitude, 90.01) &&
+         valid_coordinate(EditField::longitude, -180.0) &&
+         !valid_coordinate(EditField::longitude, 180.01);
+}
+
+}  // namespace orcsdr::adsb

--- a/apps/orcsdr-tab5/ui/adsb_dashboard.hpp
+++ b/apps/orcsdr-tab5/ui/adsb_dashboard.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+namespace orcsdr::adsb {
+
+struct Settings {
+  bool location_configured = false;
+  int32_t latitude_e7 = 0;
+  int32_t longitude_e7 = 0;
+  uint16_t radar_range_nm = 25;
+};
+
+constexpr size_t kVisibleAircraft = 6;
+
+struct Aircraft {
+  uint32_t icao = 0;
+  char callsign[9]{};
+  char registration[9]{};
+  char type[49]{};
+  char owner[51]{};
+  int altitude_ft = 0;
+  int speed_kts = 0;
+  int heading_deg = 0;
+  int vertical_rate_fpm = 0;
+  float latitude = 0;
+  float longitude = 0;
+  float signal_dbfs = 0;
+  bool has_callsign = false;
+  bool has_altitude = false;
+  bool has_speed = false;
+  bool has_heading = false;
+  bool has_vertical_rate = false;
+  bool has_position = false;
+};
+
+struct Snapshot {
+  Aircraft aircraft[kVisibleAircraft]{};
+  uint32_t revision = 0;
+  uint32_t total_messages = 0;
+  float message_rate = 0;
+  float strongest_signal_dbfs = 0;
+  uint8_t visible_count = 0;
+  uint8_t aircraft_count = 0;
+};
+
+enum class Action : uint8_t { none, settings_changed, exit };
+
+void enter(const Settings& settings);
+void draw();
+void update();
+void set_live_snapshot(const Snapshot& snapshot);
+Action handle_touch(int32_t x, int32_t y);
+const Settings& settings();
+bool active();
+bool self_check();
+
+}  // namespace orcsdr::adsb

--- a/apps/orcsdr-tab5/ui/adsb_decoder.cpp
+++ b/apps/orcsdr-tab5/ui/adsb_decoder.cpp
@@ -1,0 +1,321 @@
+#include "adsb_decoder.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace orcsdr::adsb_rx {
+namespace {
+
+constexpr uint32_t kCrcPolynomial = 0xfff409u;
+
+uint32_t bits(const uint8_t* frame, int first, int length) {
+  uint32_t value = 0;
+  for (int i = 0; i < length; ++i)
+    value = (value << 1) | ((frame[(first + i) / 8] >> (7 - (first + i) % 8)) & 1u);
+  return value;
+}
+
+uint32_t crc_payload(const uint8_t* frame, int data_bits) {
+  uint32_t crc = 0;
+  for (int i = 0; i < data_bits; ++i) {
+    const bool feedback = ((crc >> 23) & 1u) != ((frame[i / 8] >> (7 - i % 8)) & 1u);
+    crc = (crc << 1) & 0xffffffu;
+    if (feedback) crc ^= kCrcPolynomial;
+  }
+  return crc;
+}
+
+uint32_t interpolate(const uint16_t* samples, size_t milli_index) {
+  const size_t index = milli_index / 1000u;
+  const uint32_t fraction = static_cast<uint32_t>(milli_index % 1000u);
+  return static_cast<uint32_t>(samples[index]) * (1000u - fraction) +
+         static_cast<uint32_t>(samples[index + 1]) * fraction;
+}
+
+bool parse(const uint8_t* bytes, uint8_t bit_length, uint16_t signal, Frame* out) {
+  const uint8_t df = bytes[0] >> 3;
+  const int data_bits = bit_length - 24;
+  const uint32_t syndrome = crc_payload(bytes, data_bits) ^ bits(bytes, data_bits, 24);
+  if (!((df == 17 && bit_length == 112 && syndrome == 0) ||
+        (df == 11 && bit_length == 56 && syndrome <= 0x7f)))
+    return false;
+  std::memcpy(out->bytes, bytes, bit_length / 8);
+  out->bit_length = bit_length;
+  out->icao = bits(bytes, 8, 24);
+  if (df != 17) {
+    out->signal = signal;
+    return true;
+  }
+  out->type_code = static_cast<uint8_t>(bits(bytes, 32, 5));
+  out->signal = signal;
+
+  if (out->type_code >= 1 && out->type_code <= 4) {
+    size_t length = 8;
+    for (size_t i = 0; i < 8; ++i) {
+      const uint8_t code = static_cast<uint8_t>(bits(bytes, 40 + static_cast<int>(i) * 6, 6));
+      out->callsign[i] = code >= 1 && code <= 26 ? static_cast<char>('A' + code - 1)
+                         : code >= 48 && code <= 57 ? static_cast<char>('0' + code - 48)
+                                                    : ' ';
+    }
+    while (length && out->callsign[length - 1] == ' ') --length;
+    out->callsign[length] = '\0';
+    out->has_callsign = length != 0;
+  } else if (out->type_code >= 9 && out->type_code <= 18) {
+    const uint16_t encoded = static_cast<uint16_t>(bits(bytes, 40, 12));
+    if ((encoded & 0x10u) != 0) {
+      const int n = ((encoded & 0xfe0u) >> 1) | (encoded & 0x0fu);
+      out->altitude_ft = n * 25 - 1000;
+      out->has_altitude = true;
+    }
+    out->cpr_odd = bits(bytes, 53, 1) != 0;
+    out->cpr_latitude = bits(bytes, 54, 17);
+    out->cpr_longitude = bits(bytes, 71, 17);
+    out->has_cpr = true;
+  } else if (out->type_code == 19) {
+    const uint8_t subtype = static_cast<uint8_t>(bits(bytes, 37, 3));
+    const int scale = (subtype == 2 || subtype == 4) ? 4 : 1;
+    if (subtype == 1 || subtype == 2) {
+      const int ew_raw = static_cast<int>(bits(bytes, 46, 10));
+      const int ns_raw = static_cast<int>(bits(bytes, 57, 10));
+      if (ew_raw && ns_raw) {
+        const int ew = (bits(bytes, 45, 1) ? -1 : 1) * (ew_raw - 1) * scale;
+        const int ns = (bits(bytes, 56, 1) ? -1 : 1) * (ns_raw - 1) * scale;
+        out->speed_kts = static_cast<int>(std::lround(std::sqrt(ew * ew + ns * ns)));
+        out->heading_deg = static_cast<int>(std::lround(
+            std::fmod(std::atan2(static_cast<double>(ew), static_cast<double>(ns)) *
+                              180.0 / 3.14159265358979323846 + 360.0,
+                      360.0)));
+        out->has_speed = out->has_heading = true;
+      }
+    }
+    const int vr = static_cast<int>(bits(bytes, 69, 9));
+    if (vr) {
+      out->vertical_rate_fpm = (bits(bytes, 68, 1) ? -1 : 1) * (vr - 1) * 64;
+      out->has_vertical_rate = true;
+    }
+  }
+  return true;
+}
+
+}  // namespace
+
+bool decode_global_cpr(const Frame& first, const Frame& second, bool use_odd,
+                       double* latitude, double* longitude) {
+  if (!latitude || !longitude || !first.has_cpr || !second.has_cpr ||
+      first.cpr_odd == second.cpr_odd || first.icao != second.icao)
+    return false;
+  const Frame& even = first.cpr_odd ? second : first;
+  const Frame& odd = first.cpr_odd ? first : second;
+  const double yz_even = even.cpr_latitude / 131072.0;
+  const double yz_odd = odd.cpr_latitude / 131072.0;
+  const int j = static_cast<int>(std::floor(59.0 * yz_even - 60.0 * yz_odd + 0.5));
+  auto positive_mod = [](int value, int divisor) {
+    const int result = value % divisor;
+    return result < 0 ? result + divisor : result;
+  };
+  double lat_even = 6.0 * (positive_mod(j, 60) + yz_even);
+  double lat_odd = (360.0 / 59.0) * (positive_mod(j, 59) + yz_odd);
+  if (lat_even >= 270.0) lat_even -= 360.0;
+  if (lat_odd >= 270.0) lat_odd -= 360.0;
+  auto longitude_zones = [](double latitude_value) {
+    constexpr double kPi = 3.14159265358979323846;
+    const double latitude_radians = std::abs(latitude_value) * kPi / 180.0;
+    if (latitude_radians >= 87.0 * kPi / 180.0) return 1;
+    const double numerator = 1.0 - std::cos(kPi / 30.0);
+    const double denominator = std::cos(latitude_radians) * std::cos(latitude_radians);
+    return static_cast<int>(std::floor(2.0 * kPi / std::acos(1.0 - numerator / denominator)));
+  };
+  const int nl_even = longitude_zones(lat_even);
+  const int nl_odd = longitude_zones(lat_odd);
+  if (nl_even != nl_odd) return false;
+  const double xz_even = even.cpr_longitude / 131072.0;
+  const double xz_odd = odd.cpr_longitude / 131072.0;
+  const int m = static_cast<int>(
+      std::floor(xz_even * (nl_even - 1) - xz_odd * nl_even + 0.5));
+  const int ni = std::max(nl_even - (use_odd ? 1 : 0), 1);
+  double lon = (360.0 / ni) *
+               (positive_mod(m, ni) + (use_odd ? xz_odd : xz_even));
+  if (lon > 180.0) lon -= 360.0;
+  *latitude = use_odd ? lat_odd : lat_even;
+  *longitude = lon;
+  return true;
+}
+
+void Decoder::reset() {
+  overlap_ = 0;
+  stats_ = {};
+}
+
+void Decoder::process_cu8(const uint8_t* data, size_t bytes, FrameCallback callback,
+                          void* context) {
+  if (!data) return;
+  bytes &= ~size_t{1};
+  size_t count = overlap_;
+  for (size_t i = 0; i < bytes; i += 2) {
+    const int iv = static_cast<int>(data[i]) - 127;
+    const int qv = static_cast<int>(data[i + 1]) - 127;
+    if (count < kMagnitudeCapacity) {
+      const uint16_t magnitude = static_cast<uint16_t>(std::abs(iv) + std::abs(qv));
+      stats_.magnitude_min = std::min(stats_.magnitude_min, magnitude);
+      stats_.magnitude_max = std::max(stats_.magnitude_max, magnitude);
+      magnitudes_[count++] = magnitude;
+    }
+  }
+  constexpr size_t kFrameSamples = 246;
+  for (size_t pos = 0; pos + kFrameSamples <= count; ++pos) {
+    const uint16_t* sample = magnitudes_ + pos;
+    if (sample[0] <= sample[1] || sample[2] <= sample[1] || sample[2] <= sample[3] ||
+        sample[7] <= sample[6] || sample[7] <= sample[8] || sample[9] <= sample[8] ||
+        sample[9] <= sample[10])
+      continue;
+    const uint16_t pulse = static_cast<uint16_t>(
+        (sample[0] + sample[2] + sample[7] + sample[9]) / 4u);
+    const uint16_t quiet = static_cast<uint16_t>(
+        (sample[11] + sample[12] + sample[13] + sample[14] + sample[15]) / 5u);
+    if (pulse <= static_cast<uint32_t>(quiet) * 2u + 8u) continue;
+    ++stats_.preambles;
+
+    ++stats_.frames;
+    Frame decoded{};
+    bool valid = false;
+    bool saw_df17 = false;
+    uint8_t valid_bits = 0;
+    // Preamble peak alignment constrains the data-center phase to this narrow
+    // range. Interpolation avoids the five hard-decision errors measured in a
+    // live 2.048 MS/s frame without weakening CRC acceptance.
+    for (size_t first_center = 15946; first_center <= 16846; first_center += 100) {
+      uint8_t frame[14]{};
+      for (int bit = 0; bit < 112; ++bit) {
+        const size_t center = first_center + static_cast<size_t>(bit) * 2048u;
+        if (interpolate(sample, center) > interpolate(sample, center + 1024u))
+          frame[bit / 8] |= static_cast<uint8_t>(0x80u >> (bit % 8));
+      }
+      const uint8_t df = frame[0] >> 3;
+      saw_df17 |= df == 17;
+      const uint8_t frame_bits = df == 11 ? 56 : 112;
+      if (parse(frame, frame_bits, pulse - quiet, &decoded)) {
+        valid = true;
+        valid_bits = frame_bits;
+        break;
+      }
+    }
+    if (saw_df17) ++stats_.df17;
+    if (!valid) continue;
+    ++stats_.crc_ok;
+    if (callback) callback(decoded, context);
+    pos += (valid_bits == 56 ? 131 : kFrameSamples) - 1;
+  }
+  overlap_ = std::min(count, kFrameSamples - 1);
+  std::memmove(magnitudes_, magnitudes_ + count - overlap_, overlap_ * sizeof(uint16_t));
+}
+
+bool Decoder::self_check() {
+  const uint8_t identity[] = {0x8d, 0x48, 0x40, 0xd6, 0x20, 0x2c, 0xc3,
+                              0x71, 0xc3, 0x2c, 0xe0, 0x57, 0x60, 0x98};
+  const uint8_t position[] = {0x8d, 0x40, 0x62, 0x1d, 0x58, 0xc3, 0x82,
+                              0xd6, 0x90, 0xc8, 0xac, 0x28, 0x63, 0xa7};
+  const uint8_t odd_position[] = {0x8d, 0x40, 0x62, 0x1d, 0x58, 0xc3, 0x86,
+                                  0x43, 0x5c, 0xc4, 0x12, 0x69, 0x2a, 0xd6};
+  const uint8_t velocity[] = {0x8d, 0x45, 0x1d, 0xbd, 0x99, 0x05, 0xb5,
+                              0x01, 0x80, 0x04, 0x00, 0x59, 0x79, 0xc5};
+  // Live OrcSDR RF capture, 2026-08-11: ASA1310 / ICAO A29551 at 35,000 ft.
+  const uint8_t live_position[] = {0x8d, 0xa2, 0x95, 0x51, 0x58, 0xb5, 0x05,
+                                   0x03, 0x6b, 0xfb, 0x54, 0xbc, 0x90, 0xac};
+  const uint8_t live_magnitudes[] = {
+      111, 32,  98,  9,   15,  14,  22,  101, 24,  97,  37,  9,   12,  10,  5,
+      17,  114, 42,  33,  114, 62,  73,  61,  50,  148, 31,  82,  95,  21,  60,
+      125, 60,  51,  70,  29,  43,  115, 69,  25,  44,  83,  27,  110, 27,  140,
+      105, 14,  18,  125, 123, 8,   18,  112, 38,  106, 145, 37,  16,  96,  127,
+      52,  9,   71,  109, 38,  9,   60,  129, 54,  2,   52,  139, 59,  19,  57,
+      61,  51,  103, 18,  160, 88,  10,  28,  144, 104, 19,  48,  119, 91,  30,
+      82,  13,  18,  82,  20,  82,  40,  92,  111, 16,  6,   81,  138, 41,  78,
+      51,  27,  72,  138, 47,  37,  80,  146, 51,  19,  84,  71,  47,  78,  28,
+      75,  43,  72,  14,  106, 78,  4,   26,  114, 106, 11,  38,  101, 22,  102,
+      24,  92,  26,  104, 34,  88,  46,  102, 154, 40,  91,  50,  15,  87,  138,
+      33,  58,  52,  29,  64,  104, 53,  3,   56,  135, 63,  62,  76,  31,  75,
+      34,  97,  39,  102, 27,  102, 16,  113, 8,   12,  120, 107, 30,  84,  22,
+      9,   94,  99,  18,  11,  102, 99,  48,  19,  101, 129, 35,  24,  86,  56,
+      53,  163, 68,  28,  39,  152, 52,  46,  80,  40,  87,  39,  98,  18,  35,
+      73,  21,  110, 80,  9,   37,  96,  24,  94,  105, 2,   27,  111, 19,  80,
+      19,  102, 45,  83,  134, 23,  6,   102, 128, 37,  14,  79,  123, 46,  67,
+      69,  24,  77,  54,  34,  73};
+  uint8_t all_call[] = {0x5d, 0x48, 0x40, 0xd6, 0, 0, 0};
+  const uint32_t all_call_crc = crc_payload(all_call, 32);
+  all_call[4] = static_cast<uint8_t>(all_call_crc >> 16);
+  all_call[5] = static_cast<uint8_t>(all_call_crc >> 8);
+  all_call[6] = static_cast<uint8_t>(all_call_crc);
+  Frame a{}, b{}, c{}, odd{}, live{}, short_reply{};
+  double latitude = 0.0, longitude = 0.0;
+  if (!(parse(identity, 112, 1, &a) && a.icao == 0x4840d6 && a.has_callsign &&
+         std::strcmp(a.callsign, "KLM1023") == 0 && parse(position, 112, 1, &b) &&
+         b.has_altitude && b.altitude_ft == 38000 && parse(velocity, 112, 1, &c) &&
+         c.icao == 0x451dbd && c.has_speed && c.speed_kts == 436 &&
+         c.has_heading && c.heading_deg == 271 && parse(odd_position, 112, 1, &odd) &&
+         decode_global_cpr(b, odd, true, &latitude, &longitude) &&
+         std::abs(latitude - 52.2658) < 0.001 && std::abs(longitude - 3.9389) < 0.001 &&
+         parse(live_position, 112, 1, &live) &&
+         live.icao == 0xa29551 && live.has_altitude && live.altitude_ft == 35000 &&
+         parse(all_call, 56, 1, &short_reply) && short_reply.bit_length == 56 &&
+         short_reply.icao == 0x4840d6))
+    return false;
+
+  uint8_t cu8[246 * 2]{};
+  for (size_t i = 0; i < sizeof(cu8); i += 2) cu8[i] = cu8[i + 1] = 127;
+  for (const size_t index : {size_t{0}, size_t{2}, size_t{7}, size_t{9}})
+    cu8[index * 2] = 220;
+  for (int bit = 0; bit < 112; ++bit) {
+    const bool one = (identity[bit / 8] & (0x80u >> (bit % 8))) != 0;
+    const size_t first = (16246u + static_cast<size_t>(bit) * 2048u + 500u) / 1000u;
+    const size_t second =
+        (16246u + static_cast<size_t>(bit) * 2048u + 1024u + 500u) / 1000u;
+    cu8[(one ? first : second) * 2] = 220;
+  }
+  Decoder* decoder = new Decoder;
+  if (!decoder) return false;
+  Frame replay{};
+  decoder->process_cu8(
+      cu8, sizeof(cu8),
+      [](const Frame& frame, void* context) { *static_cast<Frame*>(context) = frame; },
+      &replay);
+  bool ok = decoder->stats().crc_ok == 1 && replay.icao == 0x4840d6;
+  if (ok) {
+    for (size_t i = 0; i < sizeof(live_magnitudes); ++i) {
+      const uint8_t i_part = std::min<uint8_t>(live_magnitudes[i], 127);
+      cu8[i * 2] = static_cast<uint8_t>(127 + i_part);
+      cu8[i * 2 + 1] = static_cast<uint8_t>(127 + live_magnitudes[i] - i_part);
+    }
+    decoder->reset();
+    replay = {};
+    decoder->process_cu8(
+        cu8, sizeof(cu8),
+        [](const Frame& frame, void* context) { *static_cast<Frame*>(context) = frame; },
+        &replay);
+    ok = decoder->stats().crc_ok == 1 && replay.icao == 0xa29551 &&
+         replay.has_altitude && replay.altitude_ft == 35000;
+  }
+  if (ok) {
+    std::fill(cu8, cu8 + sizeof(cu8), uint8_t{127});
+    for (const size_t index : {size_t{0}, size_t{2}, size_t{7}, size_t{9}})
+      cu8[index * 2] = 220;
+    for (int bit = 0; bit < 56; ++bit) {
+      const bool one = (all_call[bit / 8] & (0x80u >> (bit % 8))) != 0;
+      const size_t first = (16246u + static_cast<size_t>(bit) * 2048u + 500u) / 1000u;
+      const size_t second =
+          (16246u + static_cast<size_t>(bit) * 2048u + 1024u + 500u) / 1000u;
+      cu8[(one ? first : second) * 2] = 220;
+    }
+    decoder->reset();
+    replay = {};
+    decoder->process_cu8(
+        cu8, sizeof(cu8),
+        [](const Frame& frame, void* context) { *static_cast<Frame*>(context) = frame; },
+        &replay);
+    ok = decoder->stats().crc_ok == 1 && replay.bit_length == 56 &&
+         replay.icao == 0x4840d6;
+  }
+  delete decoder;
+  return ok;
+}
+
+}  // namespace orcsdr::adsb_rx

--- a/apps/orcsdr-tab5/ui/adsb_decoder.hpp
+++ b/apps/orcsdr-tab5/ui/adsb_decoder.hpp
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace orcsdr::adsb_rx {
+
+struct Frame {
+  uint8_t bytes[14]{};
+  uint8_t bit_length = 0;
+  uint32_t icao = 0;
+  uint8_t type_code = 0;
+  char callsign[9]{};
+  bool has_callsign = false;
+  int altitude_ft = 0;
+  bool has_altitude = false;
+  int speed_kts = 0;
+  bool has_speed = false;
+  int heading_deg = 0;
+  bool has_heading = false;
+  int vertical_rate_fpm = 0;
+  bool has_vertical_rate = false;
+  uint32_t cpr_latitude = 0;
+  uint32_t cpr_longitude = 0;
+  bool cpr_odd = false;
+  bool has_cpr = false;
+  uint16_t signal = 0;
+};
+
+bool decode_global_cpr(const Frame& first, const Frame& second, bool use_odd,
+                       double* latitude, double* longitude);
+
+struct Stats {
+  uint32_t preambles = 0;
+  uint32_t frames = 0;
+  uint32_t df17 = 0;
+  uint32_t crc_ok = 0;
+  uint16_t magnitude_min = 0xffff;
+  uint16_t magnitude_max = 0;
+};
+
+using FrameCallback = void (*)(const Frame&, void*);
+
+class Decoder {
+ public:
+  void reset();
+  void process_cu8(const uint8_t* data, size_t bytes, FrameCallback callback, void* context);
+  const Stats& stats() const { return stats_; }
+ static bool self_check();
+
+ private:
+  static constexpr size_t kMagnitudeCapacity = 16640;
+  uint16_t magnitudes_[kMagnitudeCapacity]{};
+  size_t overlap_ = 0;
+  Stats stats_{};
+};
+
+}  // namespace orcsdr::adsb_rx

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -33,6 +33,8 @@
 
 #include "rtl_sdr_v4_transfers.h"
 #include "orcsdr_splash.hpp"
+#include "adsb_dashboard.hpp"
+#include "adsb_decoder.hpp"
 #if !RTL_USE_LEGACY_USB
 #include "rtl_sdr_v4_esp.h"
 #endif
@@ -484,11 +486,12 @@ constexpr uint32_t kRtlBrowseDefaultHz = 146520000;
 constexpr uint32_t kLoraMinHz = 902000000;
 constexpr uint32_t kLoraMaxHz = 928000000;
 constexpr uint32_t kLoraDefaultHz = 906875000;  // Meshtastic US LongFast default slot
+constexpr uint32_t kAdsbDefaultHz = 1090000000;
 // Clean-room LO offset: LO = RF + 1.814972 MHz (from 100 MHz observation).
 constexpr double kRtlIfOffsetHz = 1814972.0;
 constexpr double kRtlXtalHz = 28800000.0;
 
-enum class RtlBand : uint8_t { fm, am, wx, cb, lora, browse };
+enum class RtlBand : uint8_t { fm, am, wx, cb, lora, browse, adsb };
 enum class CbMode : uint8_t { am, usb, lsb };
 
 constexpr uint32_t kCbChannelsHz[] = {
@@ -540,7 +543,7 @@ constexpr RfBandGuide kRfBandGuide[] = {
     {462550000, 467725000, 462562500, RtlBand::browse, "FRS / GMRS", "UHF / personal two-way", false},
     {kLoraMinHz, kLoraMaxHz, kLoraDefaultHz, RtlBand::lora, "LORA / ISM", "UHF / LoRa CSS and mesh data", true},
     {977900000, 978100000, 978000000, RtlBand::browse, "ADS-B UAT", "UHF / aircraft position", false},
-    {1089900000, 1090100000, 1090000000, RtlBand::browse, "ADS-B / MODE S", "L-band / aircraft tracking", true},
+    {1089900000, 1090100000, kAdsbDefaultHz, RtlBand::adsb, "ADS-B / MODE S", "L-band / aircraft tracking", true},
     {1525000000, 1559000000, 1545000000, RtlBand::browse, "SATCOM", "L-band / satellite downlinks", true},
     {1575000000, 1576000000, 1575420000, RtlBand::browse, "GNSS / GPS", "L-band / navigation", false},
     {1610600000, 1626500000, 1620000000, RtlBand::browse, "SATCOM", "L-band / mobile satellite", false},
@@ -988,6 +991,8 @@ bool paired = false;
 bool authenticated = false;
 bool offline_transition_handled = false;
 Preferences preferences;
+orcsdr::adsb::Settings adsb_settings;
+std::atomic<bool> adsb_settings_persist_pending{false};
 JournalState journal{};
 WorkflowState workflow{};
 uint8_t pairing_key[32];
@@ -1094,6 +1099,236 @@ uint8_t rtl_capture_max = 0;
 double rtl_capture_mean = 0;
 char rtl_capture_sha256[65]{};
 char rtl_capture_error[64] = "not run";
+orcsdr::adsb_rx::Decoder adsb_decoder;
+constexpr size_t kAdsbIqBlockBytes = 32768;
+constexpr uint8_t kAdsbIqBlockCount = 4;
+uint8_t* adsb_iq_blocks[kAdsbIqBlockCount]{};
+size_t adsb_iq_sizes[kAdsbIqBlockCount]{};
+QueueHandle_t adsb_iq_free = nullptr;
+QueueHandle_t adsb_iq_ready = nullptr;
+std::atomic<uint32_t> adsb_iq_drops{0};
+
+struct AdsbTrack {
+  bool used = false;
+  uint32_t icao = 0;
+  char callsign[9]{};
+  bool has_callsign = false;
+  int altitude_ft = 0;
+  bool has_altitude = false;
+  int speed_kts = 0;
+  bool has_speed = false;
+  int heading_deg = 0;
+  bool has_heading = false;
+  int vertical_rate_fpm = 0;
+  bool has_vertical_rate = false;
+  double latitude = 0;
+  double longitude = 0;
+  bool has_position = false;
+  orcsdr::adsb_rx::Frame even_cpr{};
+  orcsdr::adsb_rx::Frame odd_cpr{};
+  uint32_t even_cpr_ms = 0;
+  uint32_t odd_cpr_ms = 0;
+  uint32_t last_seen_ms = 0;
+  uint16_t signal = 0;
+  bool metadata_pending = false;
+  char registration[9]{};
+  char type[49]{};
+  char owner[51]{};
+};
+
+constexpr size_t kAdsbTrackCount = 64;
+AdsbTrack adsb_tracks[kAdsbTrackCount]{};
+portMUX_TYPE adsb_tracks_mux = portMUX_INITIALIZER_UNLOCKED;
+std::atomic<uint32_t> adsb_track_revision{0};
+std::atomic<uint32_t> adsb_total_messages{0};
+std::atomic<uint8_t> adsb_aircraft_count{0};
+
+void reset_adsb_tracks() {
+  portENTER_CRITICAL(&adsb_tracks_mux);
+  std::memset(adsb_tracks, 0, sizeof(adsb_tracks));
+  portEXIT_CRITICAL(&adsb_tracks_mux);
+  adsb_track_revision.store(0, std::memory_order_relaxed);
+  adsb_total_messages.store(0, std::memory_order_relaxed);
+  adsb_aircraft_count.store(0, std::memory_order_relaxed);
+}
+
+void expire_adsb_tracks(uint32_t now) {
+  uint8_t count = 0;
+  bool changed = false;
+  portENTER_CRITICAL(&adsb_tracks_mux);
+  for (auto& track : adsb_tracks) {
+    if (track.used && now - track.last_seen_ms > 60000u) {
+      track = {};
+      changed = true;
+    }
+    if (track.used) ++count;
+  }
+  portEXIT_CRITICAL(&adsb_tracks_mux);
+  adsb_aircraft_count.store(count, std::memory_order_relaxed);
+  if (changed) adsb_track_revision.fetch_add(1, std::memory_order_release);
+}
+
+void publish_adsb_snapshot(uint32_t now) {
+  static uint32_t last_sample_ms = 0;
+  static uint32_t last_sample_messages = 0;
+  static uint32_t last_state_revision = UINT32_MAX;
+  static float published_rate = -1;
+  static uint32_t ui_revision = 0;
+  if (now - last_sample_ms < 1000u) return;
+
+  const uint32_t messages = adsb_total_messages.load(std::memory_order_relaxed);
+  const uint32_t state_revision = adsb_track_revision.load(std::memory_order_acquire);
+  const float message_rate = (messages - last_sample_messages) * 1000.0f /
+                             static_cast<float>(now - last_sample_ms);
+  last_sample_messages = messages;
+  last_sample_ms = now;
+  if (state_revision == last_state_revision && fabsf(message_rate - published_rate) < 0.05f)
+    return;
+
+  orcsdr::adsb::Snapshot snapshot{};
+  portENTER_CRITICAL(&adsb_tracks_mux);
+  for (const auto& track : adsb_tracks) {
+    if (!track.used || snapshot.visible_count == orcsdr::adsb::kVisibleAircraft) continue;
+    auto& aircraft = snapshot.aircraft[snapshot.visible_count++];
+    aircraft.icao = track.icao;
+    strlcpy(aircraft.callsign, track.callsign, sizeof(aircraft.callsign));
+    strlcpy(aircraft.registration, track.registration, sizeof(aircraft.registration));
+    strlcpy(aircraft.type, track.type, sizeof(aircraft.type));
+    strlcpy(aircraft.owner, track.owner, sizeof(aircraft.owner));
+    aircraft.altitude_ft = track.altitude_ft;
+    aircraft.speed_kts = track.speed_kts;
+    aircraft.heading_deg = track.heading_deg;
+    aircraft.vertical_rate_fpm = track.vertical_rate_fpm;
+    aircraft.latitude = static_cast<float>(track.latitude);
+    aircraft.longitude = static_cast<float>(track.longitude);
+    aircraft.has_callsign = track.has_callsign;
+    aircraft.has_altitude = track.has_altitude;
+    aircraft.has_speed = track.has_speed;
+    aircraft.has_heading = track.has_heading;
+    aircraft.has_vertical_rate = track.has_vertical_rate;
+    aircraft.has_position = track.has_position;
+  }
+  portEXIT_CRITICAL(&adsb_tracks_mux);
+
+  snapshot.total_messages = messages;
+  snapshot.aircraft_count = adsb_aircraft_count.load(std::memory_order_relaxed);
+  snapshot.message_rate = message_rate;
+  snapshot.strongest_signal_dbfs = rtl_signal_dbfs.load(std::memory_order_relaxed);
+  snapshot.revision = ++ui_revision;
+  last_state_revision = state_revision;
+  published_rate = message_rate;
+  orcsdr::adsb::set_live_snapshot(snapshot);
+}
+
+void on_adsb_frame(const orcsdr::adsb_rx::Frame& frame, void*) {
+  const uint32_t now = millis();
+  bool added = false;
+  bool decode_position = false;
+  orcsdr::adsb_rx::Frame even_cpr{}, odd_cpr{};
+  bool use_odd = false;
+  portENTER_CRITICAL(&adsb_tracks_mux);
+  AdsbTrack* track = nullptr;
+  AdsbTrack* oldest = &adsb_tracks[0];
+  for (auto& candidate : adsb_tracks) {
+    if (candidate.used && candidate.icao == frame.icao) {
+      track = &candidate;
+      break;
+    }
+    if (!candidate.used) oldest = &candidate;
+    else if (oldest->used && candidate.last_seen_ms < oldest->last_seen_ms) oldest = &candidate;
+  }
+  if (!track) {
+    track = oldest;
+    added = !track->used;
+    *track = {};
+    track->used = true;
+    track->icao = frame.icao;
+    track->metadata_pending = true;
+  }
+  track->last_seen_ms = now;
+  track->signal = frame.signal;
+  if (frame.has_callsign) {
+    strlcpy(track->callsign, frame.callsign, sizeof(track->callsign));
+    track->has_callsign = true;
+  }
+  if (frame.has_altitude) {
+    track->altitude_ft = frame.altitude_ft;
+    track->has_altitude = true;
+  }
+  if (frame.has_speed) {
+    track->speed_kts = frame.speed_kts;
+    track->has_speed = true;
+  }
+  if (frame.has_heading) {
+    track->heading_deg = frame.heading_deg;
+    track->has_heading = true;
+  }
+  if (frame.has_vertical_rate) {
+    track->vertical_rate_fpm = frame.vertical_rate_fpm;
+    track->has_vertical_rate = true;
+  }
+  if (frame.has_cpr) {
+    if (frame.cpr_odd) {
+      track->odd_cpr = frame;
+      track->odd_cpr_ms = now;
+    } else {
+      track->even_cpr = frame;
+      track->even_cpr_ms = now;
+    }
+    const uint32_t pair_age = track->even_cpr_ms > track->odd_cpr_ms
+                                  ? track->even_cpr_ms - track->odd_cpr_ms
+                                  : track->odd_cpr_ms - track->even_cpr_ms;
+    if (track->even_cpr_ms && track->odd_cpr_ms && pair_age <= 10000u) {
+      even_cpr = track->even_cpr;
+      odd_cpr = track->odd_cpr;
+      use_odd = track->odd_cpr_ms > track->even_cpr_ms;
+      decode_position = true;
+    }
+  }
+  portEXIT_CRITICAL(&adsb_tracks_mux);
+  if (decode_position) {
+    double latitude = 0, longitude = 0;
+    if (orcsdr::adsb_rx::decode_global_cpr(even_cpr, odd_cpr, use_odd,
+                                           &latitude, &longitude)) {
+      portENTER_CRITICAL(&adsb_tracks_mux);
+      if (track->used && track->icao == frame.icao) {
+        track->latitude = latitude;
+        track->longitude = longitude;
+        track->has_position = true;
+      }
+      portEXIT_CRITICAL(&adsb_tracks_mux);
+    }
+  }
+  if (added) adsb_aircraft_count.fetch_add(1, std::memory_order_relaxed);
+  adsb_total_messages.fetch_add(1, std::memory_order_relaxed);
+  adsb_track_revision.fetch_add(1, std::memory_order_release);
+
+  static uint32_t last_log_ms = 0;
+  if (now - last_log_ms < 250) return;
+  last_log_ms = now;
+  char raw[29]{};
+  for (size_t i = 0; i < frame.bit_length / 8; ++i)
+    snprintf(raw + i * 2, sizeof(raw) - i * 2, "%02X", frame.bytes[i]);
+  Serial.printf("RTL_ADSB_FRAME raw=%s icao=%06lX tc=%u callsign=%s "
+                "altitude_ft=%d altitude_valid=%d speed_kts=%d speed_valid=%d "
+                "heading_deg=%d heading_valid=%d vertical_fpm=%d vertical_valid=%d signal=%u\n",
+                raw, static_cast<unsigned long>(frame.icao), frame.type_code,
+                frame.has_callsign ? frame.callsign : "-", frame.altitude_ft,
+                frame.has_altitude ? 1 : 0, frame.speed_kts, frame.has_speed ? 1 : 0,
+                frame.heading_deg, frame.has_heading ? 1 : 0, frame.vertical_rate_fpm,
+                frame.has_vertical_rate ? 1 : 0, frame.signal);
+}
+
+void adsb_decoder_task(void*) {
+  uint8_t index = 0;
+  while (true) {
+    if (xQueueReceive(adsb_iq_ready, &index, portMAX_DELAY) == pdTRUE) {
+      adsb_decoder.process_cu8(adsb_iq_blocks[index], adsb_iq_sizes[index], on_adsb_frame,
+                              nullptr);
+      (void)xQueueSend(adsb_iq_free, &index, portMAX_DELAY);
+    }
+  }
+}
 
 void emit_identity();
 bool decode_hex(const char* value, uint8_t* output, size_t output_size);
@@ -1129,6 +1364,7 @@ bool audio_rec_stop_and_export();
 void audio_rec_append(const int16_t* samples, size_t count);
 void audio_rec_status_print();
 bool ensure_tab5_sd();
+void enrich_one_adsb_track();
 void bump_rtl_ui();
 const char* orc_tool_name(OrcTool tool);
 OrcTool orc_tool_current();
@@ -1409,6 +1645,7 @@ const char* rtl_band_name(RtlBand band) {
     case RtlBand::cb: return "CB";
     case RtlBand::lora: return "LORA";
     case RtlBand::browse: return "BROWSE";
+    case RtlBand::adsb: return "ADSB";
     default: return "FM";
   }
 }
@@ -1422,6 +1659,7 @@ bool rtl_band_from_name(const char* name, RtlBand* out_band) {
   if (strcmp(name, "CB") == 0) { *out_band = RtlBand::cb; return true; }
   if (strcmp(name, "LORA") == 0) { *out_band = RtlBand::lora; return true; }
   if (strcmp(name, "BROWSE") == 0) { *out_band = RtlBand::browse; return true; }
+  if (strcmp(name, "ADSB") == 0) { *out_band = RtlBand::adsb; return true; }
   return false;
 }
 
@@ -1435,6 +1673,7 @@ const char* rtl_mode_name(RtlBand band) {
                                                                       : "AM";
     case RtlBand::lora: return "CSS";
     case RtlBand::browse: return "NFM";
+    case RtlBand::adsb: return "1090";
     default: return "WBFM";
   }
 }
@@ -1446,6 +1685,7 @@ uint32_t rtl_band_default_frequency(RtlBand band) {
     case RtlBand::cb: return kCbDefaultHz;
     case RtlBand::lora: return kLoraDefaultHz;
     case RtlBand::browse: return kRtlBrowseDefaultHz;
+    case RtlBand::adsb: return kAdsbDefaultHz;
     default: return rtl_saved_fm_hz;
   }
 }
@@ -1453,7 +1693,8 @@ uint32_t rtl_band_default_frequency(RtlBand band) {
 uint32_t rtl_filter_default_hz(RtlBand band) {
   if (band == RtlBand::lora) return lora_bandwidth_hz.load(std::memory_order_relaxed);
   if (band == RtlBand::am || band == RtlBand::cb) return kRtlAmFilterDefaultHz;
-  if (band == RtlBand::wx || band == RtlBand::browse) return kRtlWxFilterDefaultHz;
+  if (band == RtlBand::wx || band == RtlBand::browse || band == RtlBand::adsb)
+    return kRtlWxFilterDefaultHz;
   return kRtlFmFilterDefaultHz;
 }
 
@@ -1500,6 +1741,8 @@ uint32_t rtl_clamp_frequency(RtlBand band, uint32_t frequency_hz) {
       return frequency_hz;
     case RtlBand::wx:
       return kRtlWxHz;
+    case RtlBand::adsb:
+      return kAdsbDefaultHz;
     case RtlBand::browse:
       return constrain(frequency_hz, kRtlBrowseMinHz, kRtlBrowseMaxHz);
     default:
@@ -1700,6 +1943,79 @@ bool ensure_tab5_sd() {
   g_sd_ready = true;
   Serial.println("RTL_REC_SD ready bus=spi");
   return true;
+}
+
+#pragma pack(push, 1)
+struct AdsbIndexHeader {
+  char magic[8];
+  uint32_t record_size;
+  uint32_t record_count;
+};
+
+struct AdsbIndexRecord {
+  uint32_t icao;
+  char registration[9];
+  char type[49];
+  char owner[51];
+};
+#pragma pack(pop)
+
+bool lookup_adsb_metadata(uint32_t icao, AdsbIndexRecord* result) {
+  constexpr const char* kPath = "/orcsdr/adsb_aircraft.idx";
+  if (!result || !ensure_tab5_sd() || !g_sd_fs->exists(kPath)) return false;
+  File file = g_sd_fs->open(kPath, FILE_READ);
+  AdsbIndexHeader header{};
+  if (!file || file.read(reinterpret_cast<uint8_t*>(&header), sizeof(header)) != sizeof(header) ||
+      std::memcmp(header.magic, "ORCADSB1", 8) != 0 ||
+      header.record_size != sizeof(AdsbIndexRecord)) {
+    file.close();
+    return false;
+  }
+  uint32_t low = 0, high = header.record_count;
+  while (low < high) {
+    const uint32_t middle = low + (high - low) / 2;
+    if (!file.seek(sizeof(header) + middle * sizeof(AdsbIndexRecord)) ||
+        file.read(reinterpret_cast<uint8_t*>(result), sizeof(*result)) != sizeof(*result)) {
+      file.close();
+      return false;
+    }
+    if (result->icao < icao) low = middle + 1;
+    else high = middle;
+  }
+  const bool found = low < header.record_count && result->icao == icao;
+  file.close();
+  return found;
+}
+
+void enrich_one_adsb_track() {
+  uint32_t icao = 0;
+  portENTER_CRITICAL(&adsb_tracks_mux);
+  for (auto& track : adsb_tracks) {
+    if (!track.used || !track.metadata_pending) continue;
+    track.metadata_pending = false;
+    icao = track.icao;
+    break;
+  }
+  portEXIT_CRITICAL(&adsb_tracks_mux);
+  if (!icao) return;
+
+  AdsbIndexRecord metadata{};
+  const bool found = lookup_adsb_metadata(icao, &metadata);
+  if (found) {
+    portENTER_CRITICAL(&adsb_tracks_mux);
+    for (auto& track : adsb_tracks) {
+      if (!track.used || track.icao != icao) continue;
+      strlcpy(track.registration, metadata.registration, sizeof(track.registration));
+      strlcpy(track.type, metadata.type, sizeof(track.type));
+      strlcpy(track.owner, metadata.owner, sizeof(track.owner));
+      break;
+    }
+    portEXIT_CRITICAL(&adsb_tracks_mux);
+    adsb_track_revision.fetch_add(1, std::memory_order_release);
+  }
+  Serial.printf("RTL_ADSB_META icao=%06lX found=%d registration=%s\n",
+                static_cast<unsigned long>(icao), found ? 1 : 0,
+                found ? metadata.registration : "-");
 }
 
 size_t format_lora_csv(char* output, size_t output_size,
@@ -4084,6 +4400,11 @@ void draw_fm_dashboard(bool static_panel) {
 }
 
 void draw_sdr_screen(RtlBand band, uint32_t frequency_hz, uint8_t volume) {
+  if (band == RtlBand::adsb) {
+    if (!orcsdr::adsb::active()) orcsdr::adsb::enter(adsb_settings);
+    else orcsdr::adsb::draw();
+    return;
+  }
   if (!rtl_spectrum_window_ready) {
     constexpr float kPi = 3.14159265358979323846f;
     for (size_t index = 0; index < kRtlSpectrumBins; ++index) {
@@ -5536,6 +5857,8 @@ void usb_host_task(void*) {
 }
 
 void initialize_rtl_sdr_host() {
+  M5.Power.setExtOutput(false, m5::ext_USB);
+  delay(100);
   M5.Power.setExtOutput(true, m5::ext_USB);
   set_rtl_sdr_status("RTL-SDR: USB-A power enabled");
   if (xTaskCreate(usb_host_task, "rtl_usb_host", 8192, nullptr, 4, nullptr) != pdPASS) {
@@ -5582,9 +5905,19 @@ static void on_rtl_driver_event(rtl_sdr_v4_esp_event_t event, const void *payloa
       if (iq == nullptr || iq->data == nullptr || iq->bytes == 0) break;
       const size_t n =
           iq->bytes <= sizeof(rtl_iq_processing) ? iq->bytes : sizeof(rtl_iq_processing);
+      if (g_stream_band == RtlBand::adsb && adsb_iq_free && adsb_iq_ready) {
+        uint8_t index = 0;
+        if (xQueueReceive(adsb_iq_free, &index, 0) == pdTRUE) {
+          std::memcpy(adsb_iq_blocks[index], iq->data, n);
+          adsb_iq_sizes[index] = n;
+          (void)xQueueSend(adsb_iq_ready, &index, 0);
+        } else {
+          adsb_iq_drops.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
       update_signal_level_from_iq(iq->data, n);
-      /* The callback owns this borrowed block until return; avoid a full-URB copy. */
-      spectrum_offer_iq_snapshot(iq->data, n);
+      /* ADS-B needs the full callback budget; it has no spectrum or audio path. */
+      if (g_stream_band != RtlBand::adsb) spectrum_offer_iq_snapshot(iq->data, n);
       if (g_stream_band == RtlBand::lora) lora_iq_offer(iq->data, n);
       if (g_stream_band != RtlBand::lora &&
           (rtl_audio_enabled.load(std::memory_order_relaxed) ||
@@ -5672,10 +6005,15 @@ static void rtl_driver_app_task(void *) {
       rtl_rds_good_blocks.store(0, std::memory_order_relaxed);
       rtl_rds_total_blocks.store(0, std::memory_order_relaxed);
       if (band == RtlBand::lora) lora_iq_reset_detector();
+      if (band == RtlBand::adsb) {
+        adsb_decoder.reset();
+        adsb_iq_drops.store(0, std::memory_order_relaxed);
+        reset_adsb_tracks();
+      }
       rtl_capture_state.store(RtlCaptureState::running, std::memory_order_release);
       rtl_ui_active.store(true, std::memory_order_release);
       set_rtl_sdr_status("RTL-SDR V4: continuous listening (driver)");
-      draw_sdr_screen(band, frequency_hz, volume);
+      if (band != RtlBand::adsb) draw_sdr_screen(band, frequency_hz, volume);
       M5.Speaker.stop();
       if (rtl_audio_enabled.load(std::memory_order_acquire)) {
         delay(20);
@@ -5686,9 +6024,11 @@ static void rtl_driver_app_task(void *) {
       rtl_sdr_v4_esp_stream_config_default(&st);
       st.preset = RTL_SDR_V4_ESP_PRESET_CUSTOM_HZ;
       st.frequency_hz = frequency_hz;
-      st.sample_rate_sps = RTL_SDR_V4_ESP_RATE_960K;
+      st.sample_rate_sps = band == RtlBand::adsb ? RTL_SDR_V4_ESP_RATE_2048K
+                                                  : RTL_SDR_V4_ESP_RATE_960K;
       esp_err_t err = rtl_sdr_v4_esp_start(g_rtl, &st);
-      Serial.printf("RTL_START %s\n", rtl_sdr_v4_esp_err_to_name(err));
+      Serial.printf("RTL_START %s rate=%u frequency_hz=%u\n",
+                    rtl_sdr_v4_esp_err_to_name(err), st.sample_rate_sps, frequency_hz);
       if (err == ESP_OK && band == RtlBand::fm) {
         Serial.printf("RTL_WBFM_DSP rate=%u filter_hz=%u iq_lpf_k=%.2f audio_lpf_k=%.2f "
                       "decim=%u/%u note=app_side_filter\n",
@@ -5706,6 +6046,7 @@ static void rtl_driver_app_task(void *) {
         /* Stay on radio UI so power/home chrome cannot paint over controls. */
       } else {
         uint32_t spectrum_last_ms = 0;
+        uint32_t adsb_metrics_last_ms = 0;
         uint32_t last_lo_applied_hz = frequency_hz;
         uint32_t last_lo_apply_ms = 0;
         bool auto_fm_scanning = false;
@@ -5850,15 +6191,41 @@ static void rtl_driver_app_task(void *) {
           }
 
           const uint32_t ui_revision = rtl_ui_revision.load(std::memory_order_acquire);
-          if (ui_revision != drawn_rtl_ui_revision) {
+          if (g_stream_band != RtlBand::adsb && ui_revision != drawn_rtl_ui_revision) {
             drawn_rtl_ui_revision = ui_revision;
             draw_sdr_header(g_stream_band, rtl_ui_frequency_hz,
                             rtl_live_volume.load(std::memory_order_acquire));
           }
 
           const uint32_t now = millis();
+          if (g_stream_band == RtlBand::adsb && now - adsb_metrics_last_ms >= 5000) {
+            adsb_metrics_last_ms = now;
+            expire_adsb_tracks(now);
+            rtl_sdr_v4_esp_metrics_t metrics{};
+            if (rtl_sdr_v4_esp_get_metrics(g_rtl, &metrics) == ESP_OK) {
+              const auto& decode = adsb_decoder.stats();
+              Serial.printf("RTL_ADSB_STATUS uptime_ms=%u effective_sps=%u bytes=%llu "
+                            "blocks=%u short=%u overruns=%u drops=%u signal_dbfs=%.1f "
+                            "sample_min=%u sample_max=%u sample_mean=%.1f iq_queue_drops=%u "
+                            "mag_min=%u mag_max=%u preambles=%u frames=%u df17=%u crc_ok=%u "
+                            "aircraft=%u messages=%u\n",
+                            metrics.uptime_ms, metrics.effective_sps,
+                            static_cast<unsigned long long>(metrics.bytes_total),
+                            metrics.blocks_total, metrics.short_transfers, metrics.overruns,
+                            metrics.consumer_drops,
+                            static_cast<double>(rtl_signal_dbfs.load(std::memory_order_relaxed)),
+                            metrics.sample_min, metrics.sample_max,
+                            static_cast<double>(metrics.sample_mean),
+                            adsb_iq_drops.load(std::memory_order_relaxed),
+                            decode.magnitude_min, decode.magnitude_max, decode.preambles,
+                            decode.frames, decode.df17, decode.crc_ok,
+                            adsb_aircraft_count.load(std::memory_order_relaxed),
+                            adsb_total_messages.load(std::memory_order_relaxed));
+            }
+          }
           /* SIG meter stays on even with GFX off (antenna peaking). */
-          if (now - rtl_signal_meter_last_ms >= kRtlSignalMeterIntervalMs) {
+          if (g_stream_band != RtlBand::adsb &&
+              now - rtl_signal_meter_last_ms >= kRtlSignalMeterIntervalMs) {
             rtl_signal_meter_last_ms = now;
             draw_signal_meter(false);
             /* Capture tool owns the screen below the header while active —
@@ -5881,7 +6248,8 @@ static void rtl_driver_app_task(void *) {
             draw_lora_dashboard(false);
           }
           const bool gfx_on = rtl_graphics_enabled.load(std::memory_order_acquire);
-          if (gfx_on && orc_tool_current() != OrcTool::Capture) {
+          if (g_stream_band != RtlBand::adsb && gfx_on &&
+              orc_tool_current() != OrcTool::Capture) {
             const bool sound_on = rtl_audio_enabled.load(std::memory_order_relaxed);
             const bool audio_stressed =
                 sound_on && rtl_audio.dropped_chunks > 0 &&
@@ -5909,7 +6277,8 @@ static void rtl_driver_app_task(void *) {
         rtl_capture_state.store(RtlCaptureState::complete, std::memory_order_release);
         set_rtl_sdr_status("RTL-SDR V4: stopped");
         /* Keep rtl_ui_active true so home/power does not paint over SDR controls. */
-        draw_sdr_controls(g_stream_band, false);
+        if (rtl_ui_band == RtlBand::adsb) orcsdr::adsb::draw();
+        else draw_sdr_controls(g_stream_band, false);
         Serial.printf("RTL_STOP bytes=%llu\n",
                       static_cast<unsigned long long>(rtl_capture_bytes));
       }
@@ -5929,9 +6298,32 @@ static void rtl_driver_app_task(void *) {
 }
 
 void initialize_rtl_sdr_host() {
+  M5.Power.setExtOutput(false, m5::ext_USB);
+  delay(100);
   M5.Power.setExtOutput(true, m5::ext_USB);
   set_rtl_sdr_status("RTL-SDR: USB-A power enabled");
   delay(200);
+
+  adsb_iq_free = xQueueCreate(kAdsbIqBlockCount, sizeof(uint8_t));
+  adsb_iq_ready = xQueueCreate(kAdsbIqBlockCount, sizeof(uint8_t));
+  if (!adsb_iq_free || !adsb_iq_ready) {
+    set_rtl_sdr_status("ADS-B: queue allocation failed");
+    return;
+  }
+  for (uint8_t i = 0; i < kAdsbIqBlockCount; ++i) {
+    adsb_iq_blocks[i] = static_cast<uint8_t*>(
+        heap_caps_malloc(kAdsbIqBlockBytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    if (!adsb_iq_blocks[i]) {
+      set_rtl_sdr_status("ADS-B: PSRAM allocation failed");
+      return;
+    }
+    (void)xQueueSend(adsb_iq_free, &i, 0);
+  }
+  if (xTaskCreatePinnedToCore(adsb_decoder_task, "adsb_decode", 6144, nullptr, 4, nullptr, 1) !=
+      pdPASS) {
+    set_rtl_sdr_status("ADS-B: decoder task failed");
+    return;
+  }
 
   rtl_sdr_v4_esp_config_t cfg;
   rtl_sdr_v4_esp_config_default(&cfg);
@@ -6258,12 +6650,25 @@ void load_state() {
   rtl_ui_frequency_hz = rtl_saved_fm_hz;
   rtl_requested_frequency_hz.store(rtl_saved_fm_hz, std::memory_order_release);
   Serial.printf("RTL_FM_LOAD frequency_hz=%u\n", rtl_saved_fm_hz);
+  adsb_settings.location_configured = preferences.getBool("adsb_loc_set", false);
+  adsb_settings.latitude_e7 = preferences.getInt("adsb_lat_e7", 0);
+  adsb_settings.longitude_e7 = preferences.getInt("adsb_lon_e7", 0);
+  adsb_settings.radar_range_nm = preferences.getUShort("adsb_range", 25);
+  if (adsb_settings.latitude_e7 < -900000000 || adsb_settings.latitude_e7 > 900000000 ||
+      adsb_settings.longitude_e7 < -1800000000 ||
+      adsb_settings.longitude_e7 > 1800000000 ||
+      (adsb_settings.radar_range_nm != 10 && adsb_settings.radar_range_nm != 25 &&
+       adsb_settings.radar_range_nm != 50 && adsb_settings.radar_range_nm != 100)) {
+    adsb_settings = {};
+    adsb_settings.radar_range_nm = 25;
+  }
   if (preferences.isKey("last_band")) {
     const auto stored_band = static_cast<RtlBand>(
         preferences.getUInt("last_band", static_cast<uint32_t>(RtlBand::fm)));
     if (stored_band == RtlBand::fm || stored_band == RtlBand::am ||
         stored_band == RtlBand::wx || stored_band == RtlBand::cb ||
-        stored_band == RtlBand::lora || stored_band == RtlBand::browse) {
+        stored_band == RtlBand::lora || stored_band == RtlBand::browse ||
+        stored_band == RtlBand::adsb) {
       rtl_ui_band = stored_band;
       rtl_requested_band.store(stored_band, std::memory_order_release);
       Serial.printf("RTL_BAND_RESTORE band=%s\n", rtl_band_name(stored_band));
@@ -6345,6 +6750,14 @@ bool point_in_button(int32_t x, int32_t y) {
 }
 
 void queue_local_rtl_listen(RtlBand band, uint32_t frequency_hz) {
+  if (band == RtlBand::adsb) {
+    rtl_audio_enabled.store(false, std::memory_order_release);
+    rtl_audio_play_count = 0;
+    M5.Speaker.stop();
+    orcsdr::adsb::enter(adsb_settings);
+    frequency_hz = kAdsbDefaultHz;
+    Serial.println("RTL_ADSB_CAPTURE live_rf=true ui_data=demo");
+  }
 #if RTL_USE_LEGACY_USB
   if (rtl_sdr_device == nullptr) return;
 #else
@@ -6392,6 +6805,7 @@ void queue_local_rtl_listen(RtlBand band, uint32_t frequency_hz) {
                  : band == RtlBand::cb     ? "sdr_cb"
                  : band == RtlBand::lora   ? "sdr_lora"
                  : band == RtlBand::browse ? "sdr_browse"
+                 : band == RtlBand::adsb   ? "sdr_adsb"
                                            : "sdr_fm");
 }
 
@@ -6415,6 +6829,7 @@ void adjust_rtl_volume(int delta) {
 }
 
 bool point_in_scope(int32_t x, int32_t y) {
+  if (rtl_ui_band == RtlBand::adsb) return false;
   // FM's dashboard is a full custom 1152x470 surface (presets, scan, tuner) —
   // it has no pan/zoom gesture area, so every touch must reach handle_fm_touch.
   if (rtl_ui_band == RtlBand::fm) return false;
@@ -6546,7 +6961,7 @@ bool handle_fm_touch(int32_t x, int32_t y) {
 }
 
 void request_hot_retune(uint32_t frequency_hz) {
-  if (rtl_ui_band == RtlBand::wx) return;
+  if (rtl_ui_band == RtlBand::wx || rtl_ui_band == RtlBand::adsb) return;
   frequency_hz = rtl_clamp_frequency(rtl_ui_band, frequency_hz);
   if (frequency_hz == 0) return;
   /* UI: 1 kHz display quantize. */
@@ -6584,6 +6999,7 @@ void request_hot_retune(uint32_t frequency_hz) {
 // Only this path may call M5.update() while rtl_ui_active — concurrent update
 // from loop() was silencing the ES8388 speaker path after 0.8.26.
 void poll_sdr_touch_from_stream() {
+  if (rtl_ui_band == RtlBand::adsb && orcsdr::adsb::active()) return;
   static uint32_t last_touch_poll_ms = 0;
   static bool flick_thresh_set = false;
   static bool scope_dragging = false;
@@ -6763,6 +7179,17 @@ void poll_sdr_touch_from_stream() {
 }
 
 void handle_sdr_touch(int32_t x, int32_t y) {
+  if (rtl_ui_band == RtlBand::adsb) {
+    const orcsdr::adsb::Action action = orcsdr::adsb::handle_touch(x, y);
+    if (action == orcsdr::adsb::Action::settings_changed) {
+      adsb_settings = orcsdr::adsb::settings();
+      adsb_settings_persist_pending.store(true, std::memory_order_release);
+    } else if (action == orcsdr::adsb::Action::exit) {
+      rtl_ui_active.store(false, std::memory_order_release);
+      queue_local_rtl_listen(RtlBand::browse, kAdsbDefaultHz);
+    }
+    return;
+  }
   if (handle_tool_tab_touch(x, y)) return;
   if (handle_cb_touch(x, y)) return;
   if (handle_lora_touch(x, y)) return;
@@ -6974,6 +7401,34 @@ void set_online() {
 }
 
 void process_command(char* command) {
+  if (strncmp(command, "RTL_ADSB_LOCATION ", 18) == 0) {
+    double latitude = 0, longitude = 0;
+    char trailing = 0;
+    if (sscanf(command + 18, "%lf %lf %c", &latitude, &longitude, &trailing) != 2 ||
+        latitude < -90.0 || latitude > 90.0 || longitude < -180.0 || longitude > 180.0) {
+      Serial.println("RTL_ADSB_LOCATION_ERROR invalid_coordinate");
+      return;
+    }
+    adsb_settings.location_configured = true;
+    adsb_settings.latitude_e7 = static_cast<int32_t>(llround(latitude * 10000000.0));
+    adsb_settings.longitude_e7 = static_cast<int32_t>(llround(longitude * 10000000.0));
+    preferences.putBool("adsb_loc_set", true);
+    preferences.putInt("adsb_lat_e7", adsb_settings.latitude_e7);
+    preferences.putInt("adsb_lon_e7", adsb_settings.longitude_e7);
+    if (orcsdr::adsb::active()) orcsdr::adsb::enter(adsb_settings);
+    Serial.println("RTL_ADSB_LOCATION_OK");
+    return;
+  }
+  if (strcmp(command, "RTL_ADSB_STOP") == 0 && rtl_ui_band == RtlBand::adsb) {
+    rtl_stop_requested.store(true, std::memory_order_release);
+    Serial.println("RTL_ADSB_STOPPING");
+    return;
+  }
+  if (strcmp(command, "RTL_ADSB_START") == 0) {
+    queue_local_rtl_listen(RtlBand::adsb, kAdsbDefaultHz);
+    Serial.println("RTL_ADSB_STARTING");
+    return;
+  }
   if (strcmp(command, "SD_LIST") == 0) {
     sd_list();
     return;
@@ -7290,7 +7745,7 @@ void process_command(char* command) {
   if (strcmp(command, "RTL_HELP") == 0) {
     Serial.println("RTL_HELP_BEGIN");
     Serial.println("RTL_STATUS                    - device connection info");
-    Serial.println("RTL_TUNE <BAND> <HZ>           - tune band+freq (auth) BAND=FM|AM|WX|CB|LORA|BROWSE");
+    Serial.println("RTL_TUNE <BAND> <HZ>           - tune band+freq (auth) BAND=FM|AM|WX|CB|LORA|BROWSE|ADSB");
     Serial.println("RTL_FREQ                       - query current band/frequency/mode");
     Serial.println("RTL_FREQ <HZ>                  - hot-retune within current band (auth)");
     Serial.println("RTL_VOLUME                     - query current volume");
@@ -7319,10 +7774,10 @@ void process_command(char* command) {
     }
     RtlBand band;
     if (!rtl_band_from_name(band_name, &band)) {
-      Serial.println("RTL_TUNE_INVALID unknown band (FM|AM|WX|CB|LORA|BROWSE)");
+      Serial.println("RTL_TUNE_INVALID unknown band (FM|AM|WX|CB|LORA|BROWSE|ADSB)");
       return;
     }
-    if (!rtl_device_ready()) {
+    if (band != RtlBand::adsb && !rtl_device_ready()) {
       Serial.println("RTL_TUNE_UNAVAILABLE device not ready");
       return;
     }
@@ -7677,6 +8132,11 @@ void setup() {
   M5.begin(config);
   M5.Display.setRotation(1);
   M5.Display.setBrightness(180);
+  if (!orcsdr::adsb::self_check() || !orcsdr::adsb_rx::Decoder::self_check()) {
+    Serial.println("RTL_ADSB_SELF_CHECK_FAIL");
+    abort();
+  }
+  Serial.println("RTL_ADSB_SELF_CHECK_OK");
 
 #if ORC_LORA_TEST_BUILD
   g_suppress_home_paint = true;
@@ -7779,24 +8239,42 @@ void setup() {
 }
 
 void loop() {
+  const bool adsb_ui = rtl_ui_band == RtlBand::adsb && orcsdr::adsb::active();
   const bool radio_ui = rtl_ui_active.load(std::memory_order_acquire);
   // Single-owner rule: while radio UI streams, only the USB task may M5.update().
   // Dual M5.update() (loop + stream) was correlated with total speaker silence.
-  if (!radio_ui) {
+  if (!radio_ui || adsb_ui) {
     M5.update();
   }
   poll_serial();
   poll_wifi();
+  if (adsb_settings_persist_pending.exchange(false, std::memory_order_acq_rel)) {
+    preferences.putBool("adsb_loc_set", adsb_settings.location_configured);
+    preferences.putInt("adsb_lat_e7", adsb_settings.latitude_e7);
+    preferences.putInt("adsb_lon_e7", adsb_settings.longitude_e7);
+    preferences.putUShort("adsb_range", adsb_settings.radar_range_nm);
+    Serial.printf("RTL_ADSB_SETTINGS_SAVE configured=%d range_nm=%u\n",
+                  adsb_settings.location_configured ? 1 : 0,
+                  adsb_settings.radar_range_nm);
+  }
 
   const uint32_t current_rtl_sdr_status_revision =
       rtl_sdr_status_revision.load(std::memory_order_acquire);
   if (drawn_rtl_sdr_status_revision != current_rtl_sdr_status_revision) {
     drawn_rtl_sdr_status_revision = current_rtl_sdr_status_revision;
-    if (!radio_ui) draw_rtl_sdr_state();
+    if (!radio_ui && !adsb_ui) draw_rtl_sdr_state();
   }
 
+  if (adsb_ui) {
+    enrich_one_adsb_track();
+    publish_adsb_snapshot(millis());
+    orcsdr::adsb::update();
+    const auto touch = M5.Touch.getDetail(0);
+    const bool pressed = touch.isPressed() || touch.wasPressed();
+    if (pressed && !was_pressed) handle_sdr_touch(touch.x, touch.y);
+    was_pressed = pressed;
   // Home-screen taps when radio UI is not active.
-  if (!radio_ui) {
+  } else if (!radio_ui) {
     // One-shot auto-start once the RTL-SDR is ready, restoring the band the
     // device was last on instead of waiting for a home-screen tap (that tap
     // gate was blocking every autonomous flash-reboot-resume cycle during
@@ -7809,9 +8287,11 @@ void loop() {
       // enabled -- see the EVT_IQ_BLOCK gate in the streaming task. Without
       // this, RDS status stays at floor forever regardless of how strong
       // the RF signal is, since demodulate_fm() itself never executes.
-      rtl_audio_enabled.store(true, std::memory_order_release);
-      rtl_audio_play_count = 0;
-      (void)ensure_speaker_running(rtl_live_volume.load(std::memory_order_acquire));
+      if (rtl_ui_band != RtlBand::adsb) {
+        rtl_audio_enabled.store(true, std::memory_order_release);
+        rtl_audio_play_count = 0;
+        (void)ensure_speaker_running(rtl_live_volume.load(std::memory_order_acquire));
+      }
     }
     const auto touch = M5.Touch.getDetail(0);
     const bool pressed = touch.isPressed() || touch.wasPressed();

--- a/components/rtl_sdr_v4_esp/private/rtl_sdr_v4_transfers.hpp
+++ b/components/rtl_sdr_v4_esp/private/rtl_sdr_v4_transfers.hpp
@@ -557,8 +557,9 @@ static_assert(sizeof(kRtlCleanupTransfers) / sizeof(kRtlCleanupTransfers[0]) == 
 /** Measured sample-rate slice inside init (indices inclusive). */
 constexpr size_t kRtlSampleRateFirst = 462;
 constexpr size_t kRtlSampleRateLast = 477;
-/** Within the slice, this index is patched for 960 kS/s (measured). */
-constexpr size_t kRtlSampleRate960kPatchIndex = 464;
+/** Within the slice, these indices hold the RTL2832 sample-rate ratio. */
+constexpr size_t kRtlSampleRateRatioHighIndex = 464;
+constexpr size_t kRtlSampleRateRatioLowIndex = 466;
 
 /**
  * Independently observed final-tune skeleton. PLL bytes are patched at runtime

--- a/components/rtl_sdr_v4_esp/src/rtl_sdr_v4_esp.cpp
+++ b/components/rtl_sdr_v4_esp/src/rtl_sdr_v4_esp.cpp
@@ -603,13 +603,19 @@ static esp_err_t run_init_table(rtl_sdr_v4_esp_handle *h)
     return ESP_OK;
 }
 
-static esp_err_t run_sample_rate_960k(rtl_sdr_v4_esp_handle *h)
+static esp_err_t run_sample_rate(rtl_sdr_v4_esp_handle *h, uint32_t sample_rate_sps)
 {
+    constexpr uint64_t kRtlClockHz = 28800000ull;
+    uint32_t ratio = static_cast<uint32_t>((kRtlClockHz << 22) / sample_rate_sps);
+    ratio &= 0x0ffffffcu;
     for (size_t i = kRtlSampleRateFirst; i <= kRtlSampleRateLast; ++i) {
         RtlControlRecord rec = kRtlInitTransfers[i];
-        if (i == kRtlSampleRate960kPatchIndex) {
-            rec.data[0] = 0x07;
-            rec.data[1] = 0x80;
+        if (i == kRtlSampleRateRatioHighIndex) {
+            rec.data[0] = static_cast<uint8_t>(ratio >> 24);
+            rec.data[1] = static_cast<uint8_t>(ratio >> 16);
+        } else if (i == kRtlSampleRateRatioLowIndex) {
+            rec.data[0] = static_cast<uint8_t>(ratio >> 8);
+            rec.data[1] = static_cast<uint8_t>(ratio);
         }
         esp_err_t e = run_record(h, rec, false);
         if (e != ESP_OK) {
@@ -652,14 +658,14 @@ static esp_err_t run_tune(rtl_sdr_v4_esp_handle *h, uint32_t frequency_hz)
     return ESP_OK;
 }
 
-#if defined(ORC_LORA_TEST_BUILD) && ORC_LORA_TEST_BUILD
-static esp_err_t run_lora_uhf_frontend(rtl_sdr_v4_esp_handle *h)
+static esp_err_t run_uhf_frontend(rtl_sdr_v4_esp_handle *h)
 {
     constexpr RtlControlRecord kUhf[] = {
         {0x0074, 0x0610, 0x40, 2, {0x17, 0x28}},
         {0x0074, 0x0610, 0x40, 2, {0x1a, 0x68}},
         {0x0074, 0x0610, 0x40, 2, {0x1b, 0x00}},
         {0x0074, 0x0610, 0x40, 2, {0x05, 0x83}},
+        {0x0074, 0x0610, 0x40, 2, {0x0c, 0x6b}},
     };
     for (const auto &record : kUhf) {
         esp_err_t err = run_record(h, record, false);
@@ -669,7 +675,6 @@ static esp_err_t run_lora_uhf_frontend(rtl_sdr_v4_esp_handle *h)
     }
     return ESP_OK;
 }
-#endif
 
 static void run_cleanup_best_effort(rtl_sdr_v4_esp_handle *h)
 {
@@ -1423,15 +1428,6 @@ esp_err_t rtl_sdr_v4_esp_start(rtl_sdr_v4_esp_handle_t handle,
         return verr;
     }
 
-    /* Only 960k clean-room rate path is measured for continuous stream */
-    if (stream->sample_rate_sps != RTL_SDR_V4_ESP_RATE_960K) {
-        HandleLock lk(handle, kQueryLockTicks);
-        if (lk.ok()) {
-            set_error_unlocked(handle, RTL_SDR_V4_ESP_ERR_BAD_RATE);
-        }
-        return RTL_SDR_V4_ESP_ERR_BAD_RATE;
-    }
-
     HandleLock lk(handle);
     if (!lk.ok()) {
         return RTL_SDR_V4_ESP_ERR_TIMEOUT;
@@ -1471,7 +1467,7 @@ esp_err_t rtl_sdr_v4_esp_start(rtl_sdr_v4_esp_handle_t handle,
         if (ret != ESP_OK) {
             break;
         }
-        ret = run_sample_rate_960k(handle);
+        ret = run_sample_rate(handle, stream->sample_rate_sps);
         if (ret != ESP_OK) {
             break;
         }
@@ -1479,12 +1475,12 @@ esp_err_t rtl_sdr_v4_esp_start(rtl_sdr_v4_esp_handle_t handle,
         if (ret != ESP_OK) {
             break;
         }
-#if defined(ORC_LORA_TEST_BUILD) && ORC_LORA_TEST_BUILD
-        ret = run_lora_uhf_frontend(handle);
-        if (ret != ESP_OK) {
-            break;
+        if (freq >= 300000000u) {
+            ret = run_uhf_frontend(handle);
+            if (ret != ESP_OK) {
+                break;
+            }
         }
-#endif
 
         ret = ensure_ring(handle, handle->cfg.transfer_bytes);
         if (ret != ESP_OK) {

--- a/phasing.md
+++ b/phasing.md
@@ -465,6 +465,154 @@ Exit: an RDS DSP change (filter coefficient, loop gain, decode logic) can
 be tested against a fixed recorded signal without touching live RF or
 asking anyone to re-tune a physical device.
 
+## Phase 6 — ADS-B 1090 dashboard and native decoder
+
+Goal: turn the existing 1090 MHz band-guide entry into a standalone Tab5
+aircraft-tracking tool without importing GPL decoder/tuner code or presenting
+synthetic data as live reception. The four required data views are Radar,
+Aircraft List, Target, and RF Statistics; Settings is a control view.
+
+Research boundary: use [T-Display-P4 ADS-B](https://github.com/jstockdale/T-Display-P4)
+for ESP32-P4 product/reliability patterns, [dump1090](https://github.com/antirez/dump1090)
+and [readsb](https://github.com/wiedehopf/readsb) for externally observable
+decoder/state behavior, and [tar1090](https://github.com/wiedehopf/tar1090)
+for view separation. Do not copy their GPL tuner, decoder, or UI source.
+
+### 6.1 — UI and state contract (implemented; build/hardware gates below)
+
+- [x] Add an isolated `adsb_dashboard` UI module with enter/draw/update/touch
+      seams rather than another dashboard body inside `main.cpp`.
+- [x] Route the existing ADS-B 1090 quick entry to a dedicated 1280x720 tool.
+- [x] Render all four data views from one deterministic aircraft snapshot;
+      radar/list selection follows the same ICAO into Target.
+- [x] Mark every synthetic screen `DEMO`; live RF capture may run behind it,
+      but synthetic aircraft never claim to be received data. The badge changes
+      to `LIVE` only after a CRC-valid aircraft enters the live snapshot.
+- [x] Add Settings for signed receiver coordinates and 10/25/50/100 NM radar
+      range, persisted through the existing NVS namespace. Gain remains an
+      honest read-only `AUTO` until a measured driver API exists.
+- [x] Use generic M5GFX aircraft silhouettes and native primitives. Do not
+      ship airline trademarks, photos, or a new asset pipeline.
+- [x] Render absent/unconfigured values as `--`; retain dBFS wording until an
+      RF calibration supports dBm, and show CPU as `N/A` until measured.
+
+Exit: the targeted PlatformIO environment builds; all views, selection, lock,
+coordinate validation/persistence, range cycling, and Exit ADS-B are accepted
+on the physical Tab5. Until that visual/touch pass occurs, evidence stops at
+Build-verified.
+
+### 6.2 — measured 2.048 MS/s driver path
+
+ADS-B's one-microsecond pulse timing requires a measured high-rate path, not
+only an allowlisted constant.
+
+1. [x] Implement the clean-room 2.048 MS/s rate path using OrcSDR's measured
+      controls/public hardware information; do not import librtlsdr tables.
+2. [x] Stream at 1090 MHz for five minutes at at least 95% effective rate and
+      record drops/fatal USB errors.
+3. [ ] Verify hot stop/replug behavior, keep the existing 960 kS/s FM path
+      unchanged, and rerun its targeted regression gate.
+
+Evidence (2026-08-11, Tab5 COM17 + RTL-SDR Blog V4): 2,047,654 effective S/s
+after 290 seconds (99.98% of target), five startup drops, zero later drops,
+and no fatal USB error.
+
+Exit: named Tab5 + Blog V4 logs prove sustained 2.048 MS/s input. An allowlist
+constant or successful build alone is not evidence for this phase.
+
+### 6.3 — replay-tested Mode-S/DF17 decoder
+
+1. [x] Add a decoder component consuming CU8 IQ blocks, with no display or
+      driver ownership: magnitude/preamble detection, 56/112-bit extraction,
+      CRC/ICAO recovery, DF17 identity/altitude/velocity, and even/odd CPR.
+2. [x] Validate known frames and one short provenance-recorded CU8 fixture
+      before connecting the component to live IQ.
+3. [x] Maintain a fixed 64-aircraft table with per-field validity and a
+      60-second recently-seen expiry. Aircraft without valid positions remain
+      list-visible but never appear on radar.
+
+Data flow is one way:
+
+```text
+IQ callback -> Mode-S decoder -> bounded aircraft table -> revisioned UI snapshot
+```
+
+The IQ callback never draws, allocates an unbounded container, writes NVS, or
+touches the SD card.
+
+Exit: fixed inputs produce deterministic frames, CRC counts, CPR positions,
+and stale-aircraft cleanup without an RTL-SDR attached.
+
+Implemented: fixed-memory CU8 magnitude/preamble extraction, validated 56-bit
+DF11 and 112-bit DF17 extraction, CRC/ICAO, identity, altitude, velocity and
+global even/odd CPR; known-frame and generated CU8 checks; a fixed 64-aircraft
+table with validity flags and 60-second expiry; and a revisioned six-row UI
+snapshot. A 2026-08-11 live trace reconstructed
+to CRC-valid DF17 `8DA2955158B505036BFB54BC90AC` (ICAO `A29551`, altitude
+35,000 ft), matching ASA1310 at 35,000 ft in an independent live feed. The
+fractional-sample decoder now passes that exact captured magnitude waveform
+on-device without weakening CRC acceptance.
+
+### 6.4 — live RF integration
+
+- [x] Feed measured 2.048 MS/s blocks into the decoder and publish snapshots
+      to the existing four views without changing UI touch behavior.
+- [x] Replace demo metrics with real frame rate, aircraft/message counts, and
+      relative strongest signal once live mode is entered. Retain `DEMO` until
+      the first CRC-valid live snapshot rather than switching on RF start alone.
+- [x] Add read-only `RTL_ADSB_STATUS` diagnostics for frames, CRC pass/fail,
+      message rate, aircraft count, drops, and strongest dBFS.
+- [x] Preserve selection by ICAO; locked stale targets retain last-known data
+      with a `STALE` badge, while unlocked stale selections clear.
+
+Live IQ is delivered through a bounded four-block PSRAM queue to a separate
+decoder task. `RTL_ADSB_STATUS` reports transport/decoder/drop, aircraft,
+message, and relative-signal counters. Snapshot publication and stale-selection
+behavior are flashed; a new live CRC-valid frame and physical view/touch pass
+remain the acceptance gates.
+
+Final-pipeline soak (2026-08-11, COM17): at 570 seconds the flashed
+live-snapshot/DF11+DF17 build sustained 2,047,809 S/s, with five driver startup
+drops, three startup UI-queue drops, no later growth, and no panic. It received
+no CRC-valid aircraft during an interval when the independent feed reported no
+aircraft within 50 NM; this is transport evidence, not live-air acceptance.
+
+Exit: live frames update all views while USB/DSP/UI remain responsive and no
+synthetic values appear in live mode.
+
+### 6.5 — optional local aircraft metadata
+
+- [x] Accept the sorted fixed-record `/orcsdr/adsb_aircraft.idx` generated from
+      the FAA `MASTER` and `ACFTREF` files; retain the complete supplied FAA
+      release separately as `/orcsdr/faa_database_full.zip`.
+- [x] Look up only newly seen ICAOs by binary search, cache registration,
+      manufacturer/model, and registered owner in the bounded aircraft table,
+      and keep SD work outside the IQ callback.
+- [x] Fall back to decoded ICAO/callsign cleanly when the file is missing,
+      malformed, or has no match. No online lookup or bundled airline art.
+
+Evidence (2026-08-11, Tab5 COM17): both SD transfers returned device-computed
+SHA-256 values matching their host files. After restarting live 1090 MHz
+reception, ICAO `A31111` resolved from the SD index to registration `N297SF`.
+FAA ownership is labeled as registered-owner data rather than inferred airline
+operation.
+
+Exit: adding/removing the optional file changes enrichment only; reception,
+selection, and radar operation remain identical.
+
+### 6.6 — hardware and RF acceptance
+
+- [ ] Compare live aircraft, callsigns, altitude, velocity, and position
+      against an independent receiver at the same site.
+- [ ] Record five-minute effective sample rate, decoder frame/CRC rates, USB
+      drops, UI responsiveness, and stale cleanup.
+- [ ] Reboot after saving receiver location/range and verify exact restoration.
+- [ ] Accept all four views, Settings, target lock, and exit navigation on the
+      physical Tab5.
+
+Exit: the feature may be labeled Hardware-verified only after both the
+independent-receiver comparison and on-device visual/touch pass are recorded.
+
 ## Explicitly out of scope for this phasing pass
 
 - Gap 2 (dual USB paths) and Gap 4 (performance gates) are already tracked

--- a/tools/build_faa_adsb_index.py
+++ b/tools/build_faa_adsb_index.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Build OrcSDR's fixed-record ADS-B lookup index from the FAA release."""
+
+import argparse
+import csv
+import struct
+from pathlib import Path
+
+
+HEADER = struct.Struct("<8sII")
+RECORD = struct.Struct("<I9s49s51s")
+
+
+def field(value: str, size: int) -> bytes:
+    return value.strip().encode("ascii", "replace")[: size - 1].ljust(size, b"\0")
+
+
+def self_check() -> None:
+    assert HEADER.size == 16
+    assert RECORD.size == 113
+    assert field(" N73063 ", 9) == b"N73063\0\0\0"
+
+
+def main() -> None:
+    self_check()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("source", type=Path, help="directory containing MASTER.txt and ACFTREF.txt")
+    parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+
+    references: dict[str, str] = {}
+    with (args.source / "ACFTREF.txt").open(
+        newline="", encoding="utf-8-sig", errors="replace"
+    ) as source:
+        for row in csv.DictReader(source):
+            references[row["CODE"].strip()] = " ".join(
+                part for part in (row["MFR"].strip(), row["MODEL"].strip()) if part
+            )
+
+    records: list[tuple[int, bytes, bytes, bytes]] = []
+    with (args.source / "MASTER.txt").open(
+        newline="", encoding="utf-8-sig", errors="replace"
+    ) as source:
+        for row in csv.DictReader(source):
+            hex_code = row["MODE S CODE HEX"].strip()
+            if not hex_code:
+                continue
+            records.append(
+                (
+                    int(hex_code, 16),
+                    field("N" + row["N-NUMBER"].strip(), 9),
+                    field(references.get(row["MFR MDL CODE"].strip(), ""), 49),
+                    field(row["NAME"], 51),
+                )
+            )
+
+    records.sort(key=lambda record: record[0])
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("wb") as output:
+        output.write(HEADER.pack(b"ORCADSB1", RECORD.size, len(records)))
+        for record in records:
+            output.write(RECORD.pack(*record))
+    print(f"records={len(records)} bytes={args.output.stat().st_size} record_size={RECORD.size}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What changed
- adds the four-view ADS-B 1090 dashboard with bounded dynamic repaint regions
- adds a clean-room Mode-S/DF17 decoder, CPR tracking, and the measured 2.048 MS/s receive path
- adds receiver location/range persistence and FAA SD-card metadata lookup tooling
- updates Roadmap, phasing, and project status with evidence boundaries

## Why
OrcSDR needs an honest on-device ADS-B workflow that separates RF decoding, aircraft state, UI snapshots, and optional metadata while avoiding periodic full-screen refreshes.

## Validation
- `git diff --check`
- `python tools/build_faa_adsb_index.py --help` (runs fixed-record self-check)
- `python.exe -m platformio run -d F:\Ai\OrcSDR-adsb-dashboard\apps\orcsdr-tab5 -e m5tab5_ui` — SUCCESS
- prior hardware flash/boot: `RTL_ADSB_SELF_CHECK_OK`; 1090 MHz at 2.048 MS/s started successfully
- FAA index and full source archive copied to SD and device hashes verified

## Known limitation
Live ADS-B IQ queue drops remain a measured follow-up risk; this PR does not claim the five-minute >=95% throughput acceptance gate has passed.