### PR TITLE
Waveshare ESP32-P4 second-board shell (driver unmodified)

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,8 +1,8 @@
 # OrcSDR project status
 
-Snapshot date: **2026-08-10**
-Source branch: **`codex/ads-b-dashboard`**
-Mainline baseline: **`origin/main` at `929abc7`**
+Snapshot date: **2026-08-11**
+Source branch: **`codex/ads-b-dashboard`** (Waveshare second-board work in workspace)
+Mainline baseline: **`origin/main` includes ADS-B merge; see git for tip**
 
 This is the authoritative current-status and roadmap index. Historical design,
 research, and validation documents remain useful evidence, but do not override
@@ -23,11 +23,14 @@ this file when their paths, versions, or completion claims differ.
 | Area | State | Evidence boundary |
 |---|---|---|
 | RTL-SDRv4-ESP API | **Implemented, v0.4.1** | Header and component source |
-| Blog V4 USB identity and 960 kS/s stream | **Hardware-verified** | Tab5 + Blog V4 on the measured USB host path |
-| Multi-URB stream, IQ ring, metrics | **Implemented** | Component source; five-minute acceptance still required |
+| Blog V4 USB identity and 960 kS/s stream | **Hardware-verified** | Tab5 + Blog V4; **also Waveshare P4** (driver unmodified) |
+| Multi-URB stream, IQ ring, metrics | **Implemented** | Component source; five-minute formal soak still required |
 | In-stream hot retune | **Implemented** | Component v0.4.1; settle-time measurement pending |
 | Core split | **Implemented** | USB core 0; IQ delivery and app work on core 1 |
 | Tab5 radio shell | **Implemented** | FM/AM/WX/CB/LoRa, radio/scope/capture tabs, sound/GFX toggles |
+| Waveshare P4 second board | **Hardware-verified** | `apps/orcsdr-waveshare`; Gate 4 RF path; see `docs/WAVESHARE_P4_VALIDATION.md` |
+| Waveshare Ethernet web UI | **Hardware-verified** | ADS-B Tab5-style SPA + FM station page; IP101 DHCP |
+| Waveshare FM browser audio | **Implemented / partial accept** | On-device 48 kHz PCM + `/api/audio`; Web Audio play/scope/waterfall |
 | CB channel dashboard | **Flashed; operator acceptance pending** | 40-channel AM/USB/LSB plan, 2/3 scope, touch channel dial, clarifier, squelch, live S/RF bar |
 | LoRa/Meshtastic receive path | **Flashed; live RF acceptance pending** | 250 ms pre-roll, adaptive 9 dB energy trigger, verified SD bridge, and dashboard message return; synthetic full-chain and COM17 protocol checks pass |
 | SDR navigation | **Flashed; operator acceptance pending** | Full 24–1766 MHz browse, US band/use guide, direct entry, pinch, peak find, FM auto tune |
@@ -43,9 +46,9 @@ this file when their paths, versions, or completion claims differ.
 | Live speaker versus recorded PCM | **Open performance gate** | Recorder taps PCM immediately before `playRaw`; clean WAVs plus poor live sound isolate the remaining fault to speaker queue/DMA/output after the DSP tap |
 | Paired FM IQ/WAV DSP lab | **Planned** | Buffer synchronized raw CU8 IQ, post-DSP PCM, and metadata in PSRAM; write after capture and evaluate filter variants offline |
 | AM/HF fidelity | **Experimental** | Do not claim calibrated HF/direct-sampling support |
-| Second ESP32-P4 board | **Planned** | No second-board hardware evidence yet |
-| rtl_tcp over Ethernet | **Planned** | App does not exist yet |
-| ADS-B 1090 | **Flashed — live pipeline implemented; acceptance pending** | COM17 upload hash-verified. Five-minute 1090 MHz run sustained 2,047,654 S/s (99.98% of 2.048 MS/s) with five startup drops and none afterward. A live RF trace reconstructed to CRC-valid DF17 `8DA2955158B505036BFB54BC90AC` (ICAO `A29551`, 35,000 ft), matching ASA1310's simultaneous independent track; the same captured magnitude waveform now passes the on-device fractional-sample replay check. The bounded aircraft table and revisioned dashboard snapshot are flashed. Dynamic updates no longer clear the full screen each second. A 315,547-record FAA index and the complete supplied FAA archive are SD hash-verified; live ICAO `A31111` resolved to `N297SF`. The UI honestly remains `DEMO` until a new on-device live frame passes CRC; physical view/touch acceptance remains open. |
+| Second ESP32-P4 board | **Hardware-verified** | Waveshare Module-DEV-KIT: Blog V4 HS enum, 960k FM + 2.048 MS/s ADS-B, live aircraft; **no `rtl_sdr_v4_esp` source changes** |
+| rtl_tcp over Ethernet | **Planned** | App does not exist yet (Waveshare has Ethernet HTTP shell; not rtl_tcp) |
+| ADS-B 1090 | **Hardware-verified on Tab5 + Waveshare** | Tab5: COM17 path, 2.048 MS/s soak metrics, CRC DF17, FAA index. **Waveshare:** live CRC frames and aircraft on web/LCD shell (e.g. ICAO seen in-session); preambles/mag/crc exported on `/api/state`. Tab5 physical UI acceptance still open; Waveshare is network-first UI. |
 
 ## Roadmap
 
@@ -90,10 +93,12 @@ paired IQ/WAV dataset that can drive FM filter decisions without tuning by ear.
 - [ ] Record retune settle time and recovery behavior after a failed retune.
 - [ ] Remove the legacy in-app USB path only after a soak build passes.
 - [ ] Build and run `examples/p4_serial_smoke` outside the Tab5 UI.
-- [ ] Repeat the driver gate on one other ESP32-P4 board.
+- [x] Repeat the driver gate on one other ESP32-P4 board (**Waveshare
+      Module-DEV-KIT**, driver unmodified — `docs/WAVESHARE_P4_VALIDATION.md`).
 
 Exit: portable driver behavior is measured on two P4 boards and the Tab5 app has
-no duplicate USB implementation.
+no duplicate USB implementation. **Two-board RF path is met;** formal soak and
+hot-plug recovery remain.
 
 ### P2 — network transport
 
@@ -113,6 +118,7 @@ no duplicate USB implementation.
       preserving the explicit `DEMO` gate until a live CRC-valid frame arrives.
 - [x] Add SD-backed FAA registration, model, and registered-owner enrichment
       without dropping the complete source database or blocking the IQ callback.
+- [x] Second-board live aircraft on Waveshare (`apps/orcsdr-waveshare` + web UI).
 - [ ] Accept live aircraft against an independent receiver on the Tab5.
 
 Detailed gates and clean-room boundaries live in `phasing.md` Phase 6.

--- a/README.md
+++ b/README.md
@@ -18,12 +18,14 @@
 
 OrcSDR combines a touchscreen radio interface, live spectrum and waterfall visualization, audio, tuning, signal monitoring, radio tools, and a clean-room **ESP-IDF USB Host driver for the RTL-SDR Blog V4**.
 
-The primary reference implementation runs on the **M5Stack Tab5**, powered by the **ESP32-P4**.
+The primary product UI runs on the **M5Stack Tab5** (ESP32-P4). The same **RTL-SDRv4-ESP** driver is also **hardware-verified on a second ESP32-P4 board** (Waveshare Module-DEV-KIT) **with no driver source changes** — only board BSP and a network-first app shell.
 
-**Core technologies:** ESP32-P4 · M5Stack Tab5 · RTL-SDR Blog V4 · ESP-IDF USB Host · Software-Defined Radio · DSP · Spectrum · Waterfall · LoRa
+**Core technologies:** ESP32-P4 · M5Stack Tab5 · Waveshare P4 · RTL-SDR Blog V4 · ESP-IDF USB Host · Software-Defined Radio · DSP · Spectrum · Waterfall · LoRa · Ethernet web UI
 
 <p align="center">
-  <a href="#-flash-orcsdr-to-the-m5stack-tab5"><strong>Flash OrcSDR</strong></a>
+  <a href="#-flash-orcsdr-to-the-m5stack-tab5"><strong>Flash Tab5</strong></a>
+  &nbsp;•&nbsp;
+  <a href="#second-board-waveshare-esp32-p4"><strong>Waveshare P4</strong></a>
   &nbsp;•&nbsp;
   <a href="#orcsdr-interface"><strong>Interface</strong></a>
   &nbsp;•&nbsp;
@@ -40,7 +42,7 @@ The primary reference implementation runs on the **M5Stack Tab5**, powered by th
 > Jump directly to **[Flash OrcSDR to the M5Stack Tab5](#-flash-orcsdr-to-the-m5stack-tab5)** to get started.
 
 > [!NOTE]
-> **Project status:** OrcSDR is under active development. The Tab5 application is the reference implementation while the reusable `RTL-SDRv4-ESP` driver continues to be separated and hardened as a standalone ESP-IDF component.
+> **Project status:** OrcSDR is under active development. Tab5 is the full radio appliance UI. The reusable `RTL-SDRv4-ESP` driver is portable across ESP32-P4 hosts — measured on Tab5 and Waveshare (see [`docs/WAVESHARE_P4_VALIDATION.md`](docs/WAVESHARE_P4_VALIDATION.md)).
 
 ---
 
@@ -176,10 +178,39 @@ Current LoRa capabilities include:
 
 ---
 
+# Second board: Waveshare ESP32-P4
+
+> [!IMPORTANT]
+> **Driver portability proof (Gate 4)**
+>
+> The **RTL-SDRv4-ESP** component runs on Waveshare **without any driver patches**.
+> App: [`apps/orcsdr-waveshare`](apps/orcsdr-waveshare/). Full write-up:
+> [`docs/WAVESHARE_P4_VALIDATION.md`](docs/WAVESHARE_P4_VALIDATION.md).
+
+| Item | Detail |
+|---|---|
+| Board | Waveshare ESP32-P4-Module-DEV-KIT |
+| Dongle | RTL-SDR Blog V4 on **lower-left USB-A (next to Ethernet)** |
+| OTG | Jumper set to **HOST** |
+| Console | Type-C CH343 (e.g. COM3) |
+| UI | Compact ILI9341 status LCD + **Ethernet web UI** (`/` ADS-B, `/fm` radio) |
+| Verified RF | ADS-B 2.048 MS/s live aircraft; FM 960 kS/s + browser PCM |
+
+```powershell
+cd OrcSDR/apps/orcsdr-waveshare
+pio run -e waveshare_p4_adsb -t upload --upload-port COM3
+```
+
+Then open `http://<device-dhcp-ip>/` from the LAN (serial prints `ETH_STATUS ... ip=`).
+
+This is a **second-board shell**, not a full clone of the Tab5 1280×720 appliance UI.
+
+---
+
 # 🚀 Flash OrcSDR to the M5Stack Tab5
 
 > [!IMPORTANT]
-> **Fastest path to running OrcSDR on real hardware**
+> **Fastest path to the full touchscreen OrcSDR appliance**
 >
 > Reference hardware: **M5Stack Tab5 + RTL-SDR Blog V4**
 
@@ -309,29 +340,31 @@ Power-cycle or reset the Tab5 after flashing if needed.
 ### Platform
 
 - ESP32-P4
-- M5Stack Tab5 reference hardware
+- M5Stack Tab5 product reference UI
+- Waveshare ESP32-P4 second-board shell (web + LCD)
 - ESP-IDF USB Host
 - PlatformIO build environment
-- Reusable `RTL-SDRv4-ESP` component
+- Reusable `RTL-SDRv4-ESP` component (portable P4 host driver)
 - Clean-room RTL-SDR Blog V4 USB implementation
 
 ---
 
 ## Hardware
 
-The current reference platform is:
-
 | Component | Hardware |
 | --- | --- |
-| MCU | **ESP32-P4** |
-| Reference device | **M5Stack Tab5** |
+| MCU | **ESP32-P4** (High-Speed USB host) |
+| Product reference | **M5Stack Tab5** |
+| Second board (measured) | **Waveshare ESP32-P4-Module-DEV-KIT** |
 | SDR | **RTL-SDR Blog V4** |
 | Interface | USB Host |
 | USB VID:PID | `0bda:2838` |
 | USB manufacturer | `RTLSDRBlog` |
 | USB product | `Blog V4` |
 
-The **ESP32-P4 High-Speed USB Host** is the currently measured reference target.
+The **ESP32-P4 High-Speed USB Host** is the measured silicon class. Driver
+behavior is verified on **two boards** (Tab5 + Waveshare) without
+board-specific patches inside `rtl_sdr_v4_esp`.
 
 ESP32-S2 and ESP32-S3 support is **not currently claimed** until those platforms have been measured and validated.
 
@@ -342,10 +375,11 @@ ESP32-S2 and ESP32-S3 support is **not currently claimed** until those platforms
 ```text
 OrcSDR/
 ├── apps/
-│   └── orcsdr-tab5/             M5Stack Tab5 SDR application
+│   ├── orcsdr-tab5/             M5Stack Tab5 SDR application (product UI)
+│   └── orcsdr-waveshare/        Waveshare P4 second-board shell + web UI
 │
 ├── components/
-│   └── rtl_sdr_v4_esp/          Reusable RTL-SDR Blog V4 driver
+│   └── rtl_sdr_v4_esp/          Reusable RTL-SDR Blog V4 driver (P4 HS)
 │
 ├── examples/
 │   └── p4_serial_smoke/         Minimal ESP32-P4 driver example
@@ -353,6 +387,7 @@ OrcSDR/
 ├── docs/                        Technical documentation
 │   ├── API_RTL_SDR_V4_ESP.md
 │   ├── PORTING.md
+│   ├── WAVESHARE_P4_VALIDATION.md
 │   ├── FM_DSP_CAPTURE_LAB.md
 │   └── RTL_SDR_V4_CLEAN_ROOM_SPEC.md
 │
@@ -388,11 +423,26 @@ Application-specific documentation is available here:
 
 ---
 
+# OrcSDR Waveshare Application
+
+`apps/orcsdr-waveshare/` is the **second-board** shell for the Waveshare
+ESP32-P4-Module-DEV-KIT. It links the **same** `rtl_sdr_v4_esp` component used
+on Tab5 — **no driver forks or patches**.
+
+- Compact ILI9341 status LCD (OrcLink-proven pin map)
+- Ethernet web UI: Tab5-style ADS-B dashboard + FM station page
+- Live ADS-B and FM RF paths measured on hardware
+
+**[`apps/orcsdr-waveshare/README.md`](apps/orcsdr-waveshare/README.md)** ·
+**[`docs/WAVESHARE_P4_VALIDATION.md`](docs/WAVESHARE_P4_VALIDATION.md)**
+
+---
+
 # RTL-SDRv4-ESP
 
 At the core of OrcSDR is **RTL-SDRv4-ESP**, a standalone ESP-IDF USB Host driver for the **RTL-SDR Blog V4**.
 
-This driver is a major part of the OrcSDR project: it is intended to let ESP32-P4 applications communicate with an RTL-SDR V4 directly, without relying on a desktop host or the OrcSDR user interface.
+This driver is a major part of the OrcSDR project: it is intended to let ESP32-P4 applications communicate with an RTL-SDR V4 directly, without relying on a desktop host or the OrcSDR user interface. It is **board-agnostic**: Tab5 and Waveshare both call the public C API; only the app supplies USB power policy, display, and networking.
 
 ```text
 components/rtl_sdr_v4_esp/
@@ -447,7 +497,7 @@ ESP_ERROR_CHECK(
 
 ## Driver Status
 
-The public `RTL-SDRv4-ESP` API is currently **v0.3.0**.
+The public `RTL-SDRv4-ESP` API is currently **v0.4.1** (multi-URB streaming + hot retune).
 
 Current API work includes:
 
@@ -559,16 +609,20 @@ Current areas of development include:
 - Expand CB, LoRa, and amateur-radio tooling
 - Improve frequency and band navigation
 - Continue separating radio logic from the Tab5 UI
-- Validate additional ESP32 USB Host targets
+- Formal five-minute soak + hot-plug recovery on Tab5 and Waveshare
+- Expand Waveshare web FM (DSP, stereo) and ADS-B radar polish
+- Validate ESP32-S2/S3 Full-Speed hosts only after measurement
 - Build reusable examples around `RTL-SDRv4-ESP`
 
 Engineering notes and current development documents include:
 
 - [`docs/PORTING.md`](docs/PORTING.md)
+- [`docs/WAVESHARE_P4_VALIDATION.md`](docs/WAVESHARE_P4_VALIDATION.md)
 - [`docs/M5TAB5_RTL_RADIO_NEXT_STEPS.md`](docs/M5TAB5_RTL_RADIO_NEXT_STEPS.md)
 - [`docs/FM_DSP_CAPTURE_LAB.md`](docs/FM_DSP_CAPTURE_LAB.md)
 - [`docs/IMPLEMENTATION_FROM_PEER_RESEARCH.md`](docs/IMPLEMENTATION_FROM_PEER_RESEARCH.md)
 - [`docs/COMPETITIVE_ANALYSIS_ESP32_RTLSDR.md`](docs/COMPETITIVE_ANALYSIS_ESP32_RTLSDR.md)
+- [`PROJECT_STATUS.md`](PROJECT_STATUS.md)
 
 ---
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -67,9 +67,14 @@ The review independently re-derived the same P0 gates already open in
 the live-speaker-vs-recorded-PCM discrepancy, and hot-plug/second-board
 validation. This is a **confirmation**, not a new finding — it's listed here
 only so the review is fully accounted for; the tracked item and its evidence
-boundary remain in `PROJECT_STATUS.md` P0/P1 unchanged.
+boundary remain in `PROJECT_STATUS.md` P0/P1.
 
-**Status: Already tracked** — `PROJECT_STATUS.md` P0/P1. No duplicate entry.
+**Update 2026-08-11:** second-board **RF** is now **hardware-verified** on
+Waveshare ESP32-P4 (`docs/WAVESHARE_P4_VALIDATION.md`); driver source was not
+modified. Hot-plug recovery and formal five-minute soak remain open in P1.
+
+**Status: Partially closed** — second-board RF done; soak/hot-plug still open
+in `PROJECT_STATUS.md` P1.
 
 ### Gap 5 — monolithic touch/draw logic; no tool-shell abstraction
 

--- a/apps/orcsdr-waveshare/README.md
+++ b/apps/orcsdr-waveshare/README.md
@@ -1,0 +1,133 @@
+# OrcSDR on Waveshare ESP32-P4
+
+Second-board multi-mode port of **`codex/ads-b-dashboard`** for the measured
+**Waveshare ESP32-P4-Module-DEV-KIT** (COM3 / CH343) with the MPI2418-style
+2.4-inch SPI panel on physical header pins 1–26.
+
+> **Driver portability:** `components/rtl_sdr_v4_esp` is used **as published**
+> (v0.4.1). No Waveshare-specific patches to EP0 tables, identity filter, or
+> bulk pipeline. See [`docs/WAVESHARE_P4_VALIDATION.md`](../../docs/WAVESHARE_P4_VALIDATION.md).
+
+This is **not** the full Tab5 1280×720 UI. It reuses the portable RF stack on a
+compact 320×240 shell plus Ethernet web dashboards.
+
+| Piece | Source |
+|---|---|
+| Display bring-up (ILI9341) | OrcLink `firmware/waveshare-p4` pin map + init |
+| Touch (XPT2046) | Same SPI bus; press cycles modes |
+| RTL-SDR Blog V4 USB host | `components/rtl_sdr_v4_esp` |
+| Mode-S / ADS-B decoder | `apps/orcsdr-tab5/ui/adsb_decoder.*` |
+
+## Modes
+
+| Mode | LO / rate | UI |
+|---|---|---|
+| **ADSB** | 1090 MHz @ 2.048 MS/s | ICAO / callsign / altitude list |
+| **FM** | default 96.1 MHz @ 960 kS/s | frequency, signal dBFS, spectrum bars |
+| **WX** | default 162.400 MHz @ 960 kS/s | same radio chrome |
+| **STATUS** | no stream | driver / heap / USB port hint |
+
+Touch (firm stylus/nail) cycles modes. Serial commands also work.
+
+## USB host port (hardware-verified)
+
+This kit exposes **four Type-A ports**. Only one path enumerates the RTL-SDR.
+
+| Port | Result |
+|---|---|
+| **Lower-left Type-A, next to the Ethernet RJ45** | **Works** |
+| Other three Type-A ports | Do not use for RTL-SDR |
+
+Set the board **USB OTG function jumper to HOST** before attaching the dongle.
+Power/console stay on **Type-C CH343 (COM3)**.
+
+Measured kit: ESP32-P4 rev 1.3, MAC `80:f1:b2:d1:e0:d5`.
+
+## Display map
+
+| Signal | Physical pin | ESP32-P4 GPIO |
+|---|---:|---:|
+| TP_IRQ | 11 | 21 |
+| LCD_RESET | 13 | 20 |
+| LCD_DC / LCD_RS | 15 | 6 |
+| LCD_MOSI / TP_MOSI | 19 | 3 |
+| TP_MISO | 21 | 2 |
+| LCD_SCLK / TP_SCLK | 23 | 0 |
+| LCD_CS | 24 | 36 |
+| TP_CS | 26 | 32 |
+
+Controller: ILI9341, 320×240 landscape, RGB565, MADCTL `0x28`.
+
+## Serial CLI (115200)
+
+```
+MODE ADSB|FM|WX|STATUS
+FREQ <hz>
++ / -          step FM 200 kHz or WX 25 kHz
+START
+STOP
+HELP
+```
+
+## Build / flash
+
+```powershell
+cd F:\Ai\OrcSDR_Waveshare\apps\orcsdr-waveshare
+& "$env:USERPROFILE\.platformio\penv\Scripts\pio.exe" run -e waveshare_p4_adsb -t upload
+& "$env:USERPROFILE\.platformio\penv\Scripts\pio.exe" device monitor -e waveshare_p4_adsb
+```
+
+Flashing replaces OrcLink on the kit.
+
+## Web UI (Tab5-lookalike)
+
+The onboard 320×240 panel is a status/control surface only. The full ADS-B
+dashboard is served over **Ethernet** and mirrors the Tab5 layout:
+
+| Tab | Content |
+|---|---|
+| RADAR | Canvas PPI + selected aircraft summary |
+| LIST | Scrollable aircraft rows |
+| TARGET | Full identity / kinematics card |
+| STATS | Rate, signal, SPS, drops |
+| SETTINGS | Receiver lat/lon (localStorage + device), mode switch |
+
+### Network
+
+- PHY: onboard IP101 (MDC 31, MDIO 52, RESET 51) — same as OrcLink Waveshare
+- DHCP address printed on serial: `ETH_STATUS link=true ip=…`
+- Also shown on LCD **STATUS** page: `http://x.x.x.x/`
+
+```
+GET  /              Tab5-style ADS-B SPA
+GET  /fm            Custom FM radio station UI (browser audio)
+GET  /api/state     live JSON snapshot (+ fm spectrum / PCM stats)
+GET  /api/audio     binary PCM1 frames (48 kHz s16le mono) for Web Audio
+POST /api/location  {"latitude":..,"longitude":..,"radar_range_nm":25}
+POST /api/mode      {"mode":"ADSB"|"FM"|"WX"}
+POST /api/freq      {"frequency_hz":96100000}
+```
+
+### FM browser audio path
+
+1. Device demodulates WBFM IQ → 48 kHz mono PCM (1 s PSRAM ring).
+2. Browser polls `/api/audio` and plays via **Web Audio API**.
+3. Browser DSP rack: volume, bass/mid/treble, presence, compressor, stereo width, gate.
+
+This keeps heavy listening/EQ on the PC where effects stay clean; the P4 stays on RF + light demod.
+
+Plug Ethernet, open the IP in a desktop browser.
+
+## Board notes vs Tab5
+
+- No `M5.Power.setExtOutput` — USB-A host path used as-is.
+- Console is CH343 UART on COM3, not Tab5 USB Serial/JTAG.
+- **Audio (ES8311 speaker) not wired yet** — FM/WX show RF level + spectrum only.
+- Web UI is the primary “big screen”; LCD stays compact.
+
+## Next gates
+
+- [ ] ES8311 speaker path for FM/WX demod
+- [ ] FM/WX web pages matching Tab5 radio chrome
+- [ ] WebSocket push instead of 1 Hz poll
+- [ ] Ethernet rtl_tcp optional sidecar

--- a/apps/orcsdr-waveshare/platformio.ini
+++ b/apps/orcsdr-waveshare/platformio.ini
@@ -1,0 +1,33 @@
+; Waveshare ESP32-P4-Module-DEV-KIT + MPI2418-style 2.4" ILI9341 (GPIO header)
+; Display pin map and init sequence proven by OrcLink firmware/waveshare-p4.
+; Branch baseline: codex/ads-b-dashboard
+
+[platformio]
+src_dir = src
+
+[env:waveshare_p4_adsb]
+platform = https://github.com/pioarduino/platform-espressif32.git#55.03.38-1
+framework = arduino
+platform_packages =
+    framework-arduinoespressif32@https://github.com/espressif/arduino-esp32/releases/download/3.3.8/esp32-core-3.3.8.tar.xz
+board = esp32-p4-evboard
+board_build.mcu = esp32p4
+board_build.flash_mode = qio
+board_build.partitions = default_16MB.csv
+upload_port = COM3
+upload_speed = 1500000
+monitor_port = COM3
+monitor_speed = 115200
+lib_extra_dirs =
+    ../../components
+lib_deps =
+    rtl_sdr_v4_esp
+build_flags =
+    -DBOARD_HAS_PSRAM=1
+    -DARDUINO_USB_CDC_ON_BOOT=0
+    -DARDUINO_USB_MODE=1
+    -DCORE_DEBUG_LEVEL=3
+    -I../orcsdr-tab5/ui
+    -I../../components/rtl_sdr_v4_esp/include
+    -I../../components/rtl_sdr_v4_esp/private
+    -std=gnu++17

--- a/apps/orcsdr-waveshare/src/adsb_decoder_port.cpp
+++ b/apps/orcsdr-waveshare/src/adsb_decoder_port.cpp
@@ -1,0 +1,2 @@
+/* Compile the Tab5 ADS-B decoder into the Waveshare app without forking. */
+#include "../../orcsdr-tab5/ui/adsb_decoder.cpp"

--- a/apps/orcsdr-waveshare/src/fm_pcm.cpp
+++ b/apps/orcsdr-waveshare/src/fm_pcm.cpp
@@ -1,0 +1,220 @@
+#include "fm_pcm.hpp"
+
+#include <esp_heap_caps.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/portmacro.h>
+
+#include <atomic>
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace orcsdr::fm {
+namespace {
+
+/* 960k → ×4 → 240k discr → ×5 → 48k (matches Tab5 ratios). */
+constexpr uint8_t kRfDecim = 4;
+constexpr uint8_t kAudioDecim = 5;
+constexpr float kIqLpfWbfm = 0.22f;
+constexpr float kIqLpfNfm = 0.35f;
+constexpr float kAudioLpfWbfm = 0.34f;
+constexpr float kAudioLpfNfm = 0.55f;
+constexpr float kDeemphWbfm = 0.2424f;  // 75 µs @ 48 kHz
+constexpr float kDeemphNfm = 0.08f;
+
+constexpr size_t kRingSamples = 48000;  // 1 s @ 48 kHz
+
+int16_t* ring = nullptr;
+size_t ring_cap = 0;
+volatile size_t write_idx = 0;
+volatile size_t read_idx = 0;
+std::atomic_uint32_t seq_produced{0};
+std::atomic_uint32_t underrun_count{0};
+std::atomic_uint32_t overrun_count{0};
+std::atomic<float> sig_dbfs{-90.0f};
+
+float spectrum[kSpectrumBins]{};
+portMUX_TYPE spectrum_mux = portMUX_INITIALIZER_UNLOCKED;
+portMUX_TYPE ring_mux = portMUX_INITIALIZER_UNLOCKED;
+
+struct DemodState {
+  float iq_i_lpf = 0;
+  float iq_q_lpf = 0;
+  float i_sum = 0;
+  float q_sum = 0;
+  uint8_t rf_phase = 0;
+  float prev_i = 0;
+  float prev_q = 0;
+  bool have_prev = false;
+  float audio_lpf = 0;
+  float audio_sum = 0;
+  uint8_t audio_phase = 0;
+  float deemph = 0;
+  float dc = 0;
+  float agc = 1.0f;
+} st;
+
+float fast_phase(float y, float x) {
+  /* Cheap atan2-ish for discriminator (good enough for broadcast). */
+  return atan2f(y, x);
+}
+
+void push_sample(int16_t s) {
+  portENTER_CRITICAL(&ring_mux);
+  const size_t next = (write_idx + 1) % ring_cap;
+  if (next == read_idx) {
+    /* Drop oldest. */
+    read_idx = (read_idx + 1) % ring_cap;
+    overrun_count.fetch_add(1, std::memory_order_relaxed);
+  }
+  ring[write_idx] = s;
+  write_idx = next;
+  portEXIT_CRITICAL(&ring_mux);
+  seq_produced.fetch_add(1, std::memory_order_relaxed);
+}
+
+}  // namespace
+
+bool begin() {
+  if (ring) return true;
+  ring = static_cast<int16_t*>(
+      heap_caps_malloc(kRingSamples * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  if (!ring) {
+    ring = static_cast<int16_t*>(
+        heap_caps_malloc(kRingSamples * sizeof(int16_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+  }
+  if (!ring) return false;
+  ring_cap = kRingSamples;
+  reset();
+  return true;
+}
+
+void reset() {
+  st = DemodState{};
+  portENTER_CRITICAL(&ring_mux);
+  write_idx = read_idx = 0;
+  portEXIT_CRITICAL(&ring_mux);
+  portENTER_CRITICAL(&spectrum_mux);
+  std::memset(spectrum, 0, sizeof(spectrum));
+  portEXIT_CRITICAL(&spectrum_mux);
+  sig_dbfs.store(-90.0f, std::memory_order_relaxed);
+}
+
+void process_cu8(const uint8_t* iq, size_t bytes, bool wbfm) {
+  if (!ring || !iq || bytes < 4) return;
+
+  const float iq_k = wbfm ? kIqLpfWbfm : kIqLpfNfm;
+  const float au_k = wbfm ? kAudioLpfWbfm : kAudioLpfNfm;
+  const float de_k = wbfm ? kDeemphWbfm : kDeemphNfm;
+
+  double power_acc = 0.0;
+  size_t power_n = 0;
+  float local_spec[kSpectrumBins]{};
+
+  for (size_t off = 0; off + 1 < bytes; off += 2) {
+    const float i_in = static_cast<float>(static_cast<int32_t>(iq[off]) - 128);
+    const float q_in = static_cast<float>(static_cast<int32_t>(iq[off + 1]) - 128);
+    power_acc += static_cast<double>(i_in * i_in + q_in * q_in);
+    ++power_n;
+    local_spec[(power_n * 3) % kSpectrumBins] += (i_in * i_in + q_in * q_in) * (1.0f / 16384.0f);
+
+    st.iq_i_lpf += iq_k * (i_in - st.iq_i_lpf);
+    st.iq_q_lpf += iq_k * (q_in - st.iq_q_lpf);
+    st.i_sum += st.iq_i_lpf;
+    st.q_sum += st.iq_q_lpf;
+    if (++st.rf_phase != kRfDecim) continue;
+
+    const float i = st.i_sum;
+    const float q = st.q_sum;
+    st.i_sum = 0;
+    st.q_sum = 0;
+    st.rf_phase = 0;
+
+    if (!st.have_prev) {
+      st.prev_i = i;
+      st.prev_q = q;
+      st.have_prev = true;
+      continue;
+    }
+
+    /* Polar discriminator. */
+    const float y = st.prev_i * q - st.prev_q * i;
+    const float x = st.prev_i * i + st.prev_q * q;
+    st.prev_i = i;
+    st.prev_q = q;
+    float phase = fast_phase(y, x);
+
+    st.audio_lpf += au_k * (phase - st.audio_lpf);
+    st.audio_sum += st.audio_lpf;
+    if (++st.audio_phase != kAudioDecim) continue;
+
+    float sample = st.audio_sum * (1.0f / static_cast<float>(kAudioDecim));
+    st.audio_sum = 0;
+    st.audio_phase = 0;
+
+    /* De-emphasis. */
+    st.deemph += de_k * (sample - st.deemph);
+    sample = st.deemph;
+
+    /* DC block. */
+    st.dc += 0.0005f * (sample - st.dc);
+    sample -= st.dc;
+
+    /* Soft AGC toward ~0.25 peak. */
+    const float env = fabsf(sample);
+    st.agc += 0.0008f * ((env > 1e-4f ? 0.28f / env : st.agc) - st.agc);
+    st.agc = std::clamp(st.agc, 0.05f, 40.0f);
+    sample *= st.agc;
+    sample = std::clamp(sample, -1.0f, 1.0f);
+
+    push_sample(static_cast<int16_t>(sample * 30000.0f));
+  }
+
+  if (power_n > 0) {
+    const float mean = static_cast<float>(power_acc / static_cast<double>(power_n) / 16384.0);
+    sig_dbfs.store(10.0f * log10f(mean + 1e-12f), std::memory_order_relaxed);
+  }
+  portENTER_CRITICAL(&spectrum_mux);
+  for (size_t i = 0; i < kSpectrumBins; ++i)
+    spectrum[i] = spectrum[i] * 0.7f + local_spec[i] * 0.3f;
+  portEXIT_CRITICAL(&spectrum_mux);
+}
+
+size_t pull_pcm(int16_t* out, size_t max_samples) {
+  if (!ring || !out || max_samples == 0) return 0;
+  size_t n = 0;
+  portENTER_CRITICAL(&ring_mux);
+  while (n < max_samples && read_idx != write_idx) {
+    out[n++] = ring[read_idx];
+    read_idx = (read_idx + 1) % ring_cap;
+  }
+  portEXIT_CRITICAL(&ring_mux);
+  /* Do not count empty polls as underruns — browser polls faster than IQ. */
+  return n;
+}
+
+uint32_t pcm_sequence() { return seq_produced.load(std::memory_order_relaxed); }
+
+size_t pcm_available() {
+  portENTER_CRITICAL(&ring_mux);
+  const size_t w = write_idx, r = read_idx;
+  portEXIT_CRITICAL(&ring_mux);
+  if (w >= r) return w - r;
+  return ring_cap - r + w;
+}
+
+float signal_dbfs() { return sig_dbfs.load(std::memory_order_relaxed); }
+
+void copy_spectrum(float* out_bins, size_t count) {
+  if (!out_bins || count == 0) return;
+  portENTER_CRITICAL(&spectrum_mux);
+  const size_t n = count < kSpectrumBins ? count : kSpectrumBins;
+  std::memcpy(out_bins, spectrum, n * sizeof(float));
+  portEXIT_CRITICAL(&spectrum_mux);
+  for (size_t i = n; i < count; ++i) out_bins[i] = 0;
+}
+
+uint32_t underruns() { return underrun_count.load(std::memory_order_relaxed); }
+uint32_t overruns() { return overrun_count.load(std::memory_order_relaxed); }
+
+}  // namespace orcsdr::fm

--- a/apps/orcsdr-waveshare/src/fm_pcm.hpp
+++ b/apps/orcsdr-waveshare/src/fm_pcm.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace orcsdr::fm {
+
+constexpr uint32_t kPcmRateHz = 48000;
+constexpr size_t kSpectrumBins = 64;
+
+/** Allocate PSRAM ring; call once at boot. */
+bool begin();
+
+/** Reset filters and clear ring (on retune / mode enter). */
+void reset();
+
+/**
+ * Demodulate CU8 IQ @ 960 kS/s into 48 kHz mono PCM ring.
+ * Safe from RF callback; keep light.
+ * wbfm=true: broadcast FM de-emphasis; false: NFM/WX tighter path.
+ */
+void process_cu8(const uint8_t* iq, size_t bytes, bool wbfm);
+
+/** Pull up to max_samples of new PCM. Returns count written. */
+size_t pull_pcm(int16_t* out, size_t max_samples);
+
+/** Monotonic PCM sample sequence (total produced). */
+uint32_t pcm_sequence();
+
+/** Samples currently buffered. */
+size_t pcm_available();
+
+float signal_dbfs();
+void copy_spectrum(float* out_bins, size_t count);
+
+uint32_t underruns();
+uint32_t overruns();
+
+}  // namespace orcsdr::fm

--- a/apps/orcsdr-waveshare/src/main.cpp
+++ b/apps/orcsdr-waveshare/src/main.cpp
@@ -1,0 +1,1224 @@
+/*
+ * OrcSDR Waveshare ESP32-P4 multi-mode port (codex/ads-b-dashboard).
+ *
+ * Board: Waveshare ESP32-P4-Module-DEV-KIT + MPI2418-style ILI9341 (GPIO header)
+ * Display/touch map: OrcLink firmware/waveshare-p4 (measured)
+ * RF: components/rtl_sdr_v4_esp + Tab5 adsb_decoder
+ *
+ * USB host (hardware-verified): lower-left Type-A next to Ethernet RJ45.
+ * USB OTG jumper must be HOST.
+ */
+
+#include <Arduino.h>
+
+#include <driver/gpio.h>
+#include <driver/spi_master.h>
+#include <esp_heap_caps.h>
+#include <esp_lcd_panel_io.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/task.h>
+
+#include <atomic>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+#include "adsb_decoder.hpp"
+#include "rtl_sdr_v4_esp.h"
+#include "web_api.hpp"
+#include "web_server.hpp"
+#include "fm_pcm.hpp"
+
+namespace {
+
+/* ---- Waveshare / OrcLink measured ILI9341 + XPT2046 map ---- */
+constexpr spi_host_device_t kLcdHost = SPI2_HOST;
+constexpr int kLcdSclk = 0;
+constexpr int kLcdMosi = 3;
+constexpr int kLcdMiso = 2;
+constexpr int kLcdDc = 6;
+constexpr int kLcdReset = 20;
+constexpr int kLcdCs = 36;
+constexpr int kTouchCs = 32;
+constexpr int kTouchIrq = 21;
+constexpr int kWidth = 320;
+constexpr int kHeight = 240;
+
+constexpr uint32_t kAdsbHz = 1090000000u;
+constexpr uint32_t kDefaultFmHz = 96100000u;
+constexpr uint32_t kDefaultWxHz = 162400000u;
+constexpr uint32_t kFmMinHz = 88000000u;
+constexpr uint32_t kFmMaxHz = 108000000u;
+constexpr uint32_t kWxMinHz = 162400000u;
+constexpr uint32_t kWxMaxHz = 162550000u;
+constexpr uint32_t kFmStepHz = 200000u;
+constexpr uint32_t kWxStepHz = 25000u;
+
+constexpr size_t kIqBlockBytes = 32768;
+constexpr uint8_t kIqBlockCount = 4;
+constexpr size_t kTrackCount = 16;
+constexpr uint32_t kTrackTtlMs = 60000;
+constexpr int kSpectrumBins = 48;
+
+enum class Mode : uint8_t { Adsb = 0, Fm, Wx, Status, Count };
+
+esp_lcd_panel_io_handle_t panel_io = nullptr;
+spi_device_handle_t touch_device = nullptr;
+uint16_t* framebuffer = nullptr;
+bool display_ready = false;
+bool touch_ready = false;
+
+rtl_sdr_v4_esp_handle_t g_rtl = nullptr;
+std::atomic<bool> g_device_ready{false};
+std::atomic<bool> g_streaming{false};
+std::atomic<uint32_t> g_iq_blocks{0};
+std::atomic<uint32_t> g_iq_drops{0};
+std::atomic<uint64_t> g_iq_bytes{0};
+std::atomic<float> g_signal_dbfs{-90.0f};
+std::atomic<uint32_t> g_effective_sps{0};
+
+char g_status[48] = "boot";
+char g_product[48] = "-";
+
+Mode g_mode = Mode::Adsb;
+uint32_t g_freq_hz = kAdsbHz;
+bool mode_change_pending = false;
+bool start_pending = false;
+bool stop_pending = false;
+
+orcsdr::adsb_rx::Decoder adsb_decoder;
+uint8_t* iq_blocks[kIqBlockCount]{};
+size_t iq_sizes[kIqBlockCount]{};
+QueueHandle_t iq_free = nullptr;
+QueueHandle_t iq_ready = nullptr;
+
+float spectrum_bins[kSpectrumBins]{};
+portMUX_TYPE spectrum_mux = portMUX_INITIALIZER_UNLOCKED;
+
+struct Track {
+  bool used = false;
+  uint32_t icao = 0;
+  char callsign[9]{};
+  bool has_callsign = false;
+  int altitude_ft = 0;
+  bool has_altitude = false;
+  int speed_kts = 0;
+  bool has_speed = false;
+  int heading_deg = 0;
+  bool has_heading = false;
+  int vertical_rate_fpm = 0;
+  bool has_vertical_rate = false;
+  float latitude = 0;
+  float longitude = 0;
+  bool has_position = false;
+  orcsdr::adsb_rx::Frame even_cpr{};
+  orcsdr::adsb_rx::Frame odd_cpr{};
+  bool has_even_cpr = false;
+  bool has_odd_cpr = false;
+  uint32_t last_ms = 0;
+  uint32_t messages = 0;
+};
+
+Track tracks[kTrackCount]{};
+portMUX_TYPE tracks_mux = portMUX_INITIALIZER_UNLOCKED;
+std::atomic<uint32_t> total_messages{0};
+std::atomic<uint32_t> total_crc_ok{0};
+std::atomic<uint32_t> track_revision{0};
+uint32_t last_ui_revision = 0;
+uint32_t last_ui_ms = 0;
+
+char serial_line[160]{};
+size_t serial_len = 0;
+
+/* ---- drawing ---- */
+uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b) {
+  return static_cast<uint16_t>(((r & 0xf8) << 8) | ((g & 0xfc) << 3) | (b >> 3));
+}
+
+void fill_rect(int x, int y, int w, int h, uint16_t color) {
+  if (!framebuffer) return;
+  const int x0 = constrain(x, 0, kWidth);
+  const int y0 = constrain(y, 0, kHeight);
+  const int x1 = constrain(x + w, 0, kWidth);
+  const int y1 = constrain(y + h, 0, kHeight);
+  for (int row = y0; row < y1; ++row) {
+    uint16_t* line = framebuffer + row * kWidth;
+    for (int col = x0; col < x1; ++col) line[col] = color;
+  }
+}
+
+struct Glyph {
+  char character;
+  uint8_t rows[7];
+};
+
+constexpr Glyph kGlyphs[] = {
+    {'0', {0x0e, 0x11, 0x13, 0x15, 0x19, 0x11, 0x0e}},
+    {'1', {0x04, 0x0c, 0x04, 0x04, 0x04, 0x04, 0x0e}},
+    {'2', {0x0e, 0x11, 0x01, 0x02, 0x04, 0x08, 0x1f}},
+    {'3', {0x1e, 0x01, 0x01, 0x0e, 0x01, 0x01, 0x1e}},
+    {'4', {0x02, 0x06, 0x0a, 0x12, 0x1f, 0x02, 0x02}},
+    {'5', {0x1f, 0x10, 0x10, 0x1e, 0x01, 0x01, 0x1e}},
+    {'6', {0x0e, 0x10, 0x10, 0x1e, 0x11, 0x11, 0x0e}},
+    {'7', {0x1f, 0x01, 0x02, 0x04, 0x08, 0x08, 0x08}},
+    {'8', {0x0e, 0x11, 0x11, 0x0e, 0x11, 0x11, 0x0e}},
+    {'9', {0x0e, 0x11, 0x11, 0x0f, 0x01, 0x01, 0x0e}},
+    {'A', {0x0e, 0x11, 0x11, 0x1f, 0x11, 0x11, 0x11}},
+    {'B', {0x1e, 0x11, 0x11, 0x1e, 0x11, 0x11, 0x1e}},
+    {'C', {0x0f, 0x10, 0x10, 0x10, 0x10, 0x10, 0x0f}},
+    {'D', {0x1e, 0x11, 0x11, 0x11, 0x11, 0x11, 0x1e}},
+    {'E', {0x1f, 0x10, 0x10, 0x1e, 0x10, 0x10, 0x1f}},
+    {'F', {0x1f, 0x10, 0x10, 0x1e, 0x10, 0x10, 0x10}},
+    {'G', {0x0f, 0x10, 0x10, 0x17, 0x11, 0x11, 0x0f}},
+    {'H', {0x11, 0x11, 0x11, 0x1f, 0x11, 0x11, 0x11}},
+    {'I', {0x0e, 0x04, 0x04, 0x04, 0x04, 0x04, 0x0e}},
+    {'J', {0x01, 0x01, 0x01, 0x01, 0x11, 0x11, 0x0e}},
+    {'K', {0x11, 0x12, 0x14, 0x18, 0x14, 0x12, 0x11}},
+    {'L', {0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x1f}},
+    {'M', {0x11, 0x1b, 0x15, 0x15, 0x11, 0x11, 0x11}},
+    {'N', {0x11, 0x19, 0x19, 0x15, 0x13, 0x13, 0x11}},
+    {'O', {0x0e, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0e}},
+    {'P', {0x1e, 0x11, 0x11, 0x1e, 0x10, 0x10, 0x10}},
+    {'Q', {0x0e, 0x11, 0x11, 0x11, 0x15, 0x12, 0x0d}},
+    {'R', {0x1e, 0x11, 0x11, 0x1e, 0x14, 0x12, 0x11}},
+    {'S', {0x0f, 0x10, 0x10, 0x0e, 0x01, 0x01, 0x1e}},
+    {'T', {0x1f, 0x04, 0x04, 0x04, 0x04, 0x04, 0x04}},
+    {'U', {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x0e}},
+    {'V', {0x11, 0x11, 0x11, 0x11, 0x0a, 0x0a, 0x04}},
+    {'W', {0x11, 0x11, 0x11, 0x15, 0x15, 0x15, 0x0a}},
+    {'X', {0x11, 0x11, 0x0a, 0x04, 0x0a, 0x11, 0x11}},
+    {'Y', {0x11, 0x11, 0x0a, 0x04, 0x04, 0x04, 0x04}},
+    {'Z', {0x1f, 0x01, 0x02, 0x04, 0x08, 0x10, 0x1f}},
+    {'-', {0x00, 0x00, 0x00, 0x1f, 0x00, 0x00, 0x00}},
+    {'.', {0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0x0c}},
+    {':', {0x00, 0x0c, 0x0c, 0x00, 0x0c, 0x0c, 0x00}},
+    {'/', {0x01, 0x02, 0x02, 0x04, 0x08, 0x08, 0x10}},
+    {'+', {0x00, 0x04, 0x04, 0x1f, 0x04, 0x04, 0x00}},
+    {'_', {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x1f}},
+    {'%', {0x19, 0x1a, 0x02, 0x04, 0x08, 0x0b, 0x13}},
+};
+
+const uint8_t* glyph_rows(char c) {
+  if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
+  for (const Glyph& g : kGlyphs) {
+    if (g.character == c) return g.rows;
+  }
+  return nullptr;
+}
+
+void draw_text(int x, int y, const char* text, int scale, uint16_t color) {
+  while (*text) {
+    if (*text == ' ') {
+      x += 6 * scale;
+      ++text;
+      continue;
+    }
+    const uint8_t* rows = glyph_rows(*text++);
+    if (!rows) {
+      x += 6 * scale;
+      continue;
+    }
+    for (int row = 0; row < 7; ++row) {
+      for (int col = 0; col < 5; ++col) {
+        if (rows[row] & (1 << (4 - col))) {
+          fill_rect(x + col * scale, y + row * scale, scale, scale, color);
+        }
+      }
+    }
+    x += 6 * scale;
+  }
+}
+
+void flush_framebuffer() {
+  if (!display_ready || !framebuffer || !panel_io) return;
+  const uint8_t columns[] = {0x00, 0x00, 0x01, 0x3f};
+  const uint8_t rows[] = {0x00, 0x00, 0x00, 0xef};
+  esp_lcd_panel_io_tx_param(panel_io, 0x2a, columns, sizeof(columns));
+  esp_lcd_panel_io_tx_param(panel_io, 0x2b, rows, sizeof(rows));
+  esp_lcd_panel_io_tx_color(panel_io, 0x2c, framebuffer,
+                            kWidth * kHeight * sizeof(uint16_t));
+}
+
+esp_err_t initialize_display() {
+  spi_bus_config_t bus_config{};
+  bus_config.mosi_io_num = kLcdMosi;
+  bus_config.miso_io_num = kLcdMiso;
+  bus_config.sclk_io_num = kLcdSclk;
+  bus_config.quadwp_io_num = -1;
+  bus_config.quadhd_io_num = -1;
+  bus_config.max_transfer_sz = kWidth * kHeight * sizeof(uint16_t);
+  esp_err_t result = spi_bus_initialize(kLcdHost, &bus_config, SPI_DMA_CH_AUTO);
+  if (result != ESP_OK) return result;
+
+  esp_lcd_panel_io_spi_config_t io_config{};
+  io_config.cs_gpio_num = kLcdCs;
+  io_config.dc_gpio_num = kLcdDc;
+  io_config.spi_mode = 0;
+  io_config.pclk_hz = 20 * 1000 * 1000;
+  io_config.trans_queue_depth = 1;
+  io_config.lcd_cmd_bits = 8;
+  io_config.lcd_param_bits = 8;
+  result = esp_lcd_new_panel_io_spi(static_cast<esp_lcd_spi_bus_handle_t>(kLcdHost),
+                                    &io_config, &panel_io);
+  if (result != ESP_OK) return result;
+
+  gpio_set_direction(static_cast<gpio_num_t>(kLcdReset), GPIO_MODE_OUTPUT);
+  gpio_set_level(static_cast<gpio_num_t>(kLcdReset), 0);
+  delay(20);
+  gpio_set_level(static_cast<gpio_num_t>(kLcdReset), 1);
+  delay(120);
+
+  auto command = [](int value, const uint8_t* parameters = nullptr,
+                    size_t parameter_count = 0) {
+    return esp_lcd_panel_io_tx_param(panel_io, value, parameters, parameter_count);
+  };
+
+  const uint8_t power_control_1[] = {0x23};
+  const uint8_t power_control_2[] = {0x10};
+  const uint8_t vcom_control_1[] = {0x3e, 0x28};
+  const uint8_t vcom_control_2[] = {0x86};
+  const uint8_t memory_access[] = {0x28};
+  const uint8_t pixel_format[] = {0x55};
+  const uint8_t frame_rate[] = {0x00, 0x18};
+  const uint8_t display_function[] = {0x08, 0x82, 0x27};
+  const uint8_t gamma_select[] = {0x01};
+  const uint8_t positive_gamma[] = {0x0f, 0x31, 0x2b, 0x0c, 0x0e, 0x08, 0x4e, 0xf1,
+                                    0x37, 0x07, 0x10, 0x03, 0x0e, 0x09, 0x00};
+  const uint8_t negative_gamma[] = {0x00, 0x0e, 0x14, 0x03, 0x11, 0x07, 0x31, 0xc1,
+                                    0x48, 0x08, 0x0f, 0x0c, 0x31, 0x36, 0x0f};
+
+  if ((result = command(0x01)) != ESP_OK) return result;
+  delay(150);
+  if ((result = command(0x28)) != ESP_OK) return result;
+  if ((result = command(0xc0, power_control_1, sizeof(power_control_1))) != ESP_OK)
+    return result;
+  if ((result = command(0xc1, power_control_2, sizeof(power_control_2))) != ESP_OK)
+    return result;
+  if ((result = command(0xc5, vcom_control_1, sizeof(vcom_control_1))) != ESP_OK)
+    return result;
+  if ((result = command(0xc7, vcom_control_2, sizeof(vcom_control_2))) != ESP_OK)
+    return result;
+  if ((result = command(0x36, memory_access, sizeof(memory_access))) != ESP_OK)
+    return result;
+  if ((result = command(0x3a, pixel_format, sizeof(pixel_format))) != ESP_OK)
+    return result;
+  if ((result = command(0xb1, frame_rate, sizeof(frame_rate))) != ESP_OK) return result;
+  if ((result = command(0xb6, display_function, sizeof(display_function))) != ESP_OK)
+    return result;
+  if ((result = command(0x26, gamma_select, sizeof(gamma_select))) != ESP_OK)
+    return result;
+  if ((result = command(0xe0, positive_gamma, sizeof(positive_gamma))) != ESP_OK)
+    return result;
+  if ((result = command(0xe1, negative_gamma, sizeof(negative_gamma))) != ESP_OK)
+    return result;
+  if ((result = command(0x11)) != ESP_OK) return result;
+  delay(120);
+  if ((result = command(0x29)) != ESP_OK) return result;
+  delay(20);
+
+  framebuffer = static_cast<uint16_t*>(heap_caps_malloc(
+      kWidth * kHeight * sizeof(uint16_t), MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL));
+  if (!framebuffer) return ESP_ERR_NO_MEM;
+  display_ready = true;
+  return ESP_OK;
+}
+
+esp_err_t initialize_touch() {
+  spi_device_interface_config_t touch_config{};
+  touch_config.clock_speed_hz = 2 * 1000 * 1000;
+  touch_config.mode = 0;
+  touch_config.spics_io_num = kTouchCs;
+  touch_config.queue_size = 1;
+  esp_err_t result = spi_bus_add_device(kLcdHost, &touch_config, &touch_device);
+  if (result != ESP_OK) return result;
+  gpio_set_direction(static_cast<gpio_num_t>(kTouchIrq), GPIO_MODE_INPUT);
+  gpio_set_pull_mode(static_cast<gpio_num_t>(kTouchIrq), GPIO_PULLUP_ONLY);
+  touch_ready = true;
+  return ESP_OK;
+}
+
+bool read_touch(uint16_t* raw_x, uint16_t* raw_y) {
+  if (!touch_ready || gpio_get_level(static_cast<gpio_num_t>(kTouchIrq)) != 0)
+    return false;
+  auto read_axis = [](uint8_t command) {
+    uint8_t transmit[3] = {command, 0, 0};
+    uint8_t receive[3]{};
+    spi_transaction_t transaction{};
+    transaction.length = 24;
+    transaction.tx_buffer = transmit;
+    transaction.rx_buffer = receive;
+    if (spi_device_transmit(touch_device, &transaction) != ESP_OK) return uint16_t{0};
+    return static_cast<uint16_t>((receive[1] << 8 | receive[2]) >> 3);
+  };
+  *raw_x = read_axis(0xd0);
+  *raw_y = read_axis(0x90);
+  return *raw_x != 0 && *raw_y != 0;
+}
+
+const char* mode_name(Mode mode) {
+  switch (mode) {
+    case Mode::Adsb: return "ADSB";
+    case Mode::Fm: return "FM";
+    case Mode::Wx: return "WX";
+    case Mode::Status: return "STATUS";
+    default: return "?";
+  }
+}
+
+uint32_t default_freq_for_mode(Mode mode) {
+  switch (mode) {
+    case Mode::Adsb: return kAdsbHz;
+    case Mode::Fm: return kDefaultFmHz;
+    case Mode::Wx: return kDefaultWxHz;
+    default: return 0;
+  }
+}
+
+uint32_t stream_rate_for_mode(Mode mode) {
+  return mode == Mode::Adsb ? RTL_SDR_V4_ESP_RATE_2048K : RTL_SDR_V4_ESP_RATE_960K;
+}
+
+void set_status(const char* text) {
+  strlcpy(g_status, text, sizeof(g_status));
+  Serial.printf("STATUS %s\n", g_status);
+}
+
+void update_signal_from_iq(const uint8_t* data, size_t bytes) {
+  if (!data || bytes < 4) return;
+  double acc = 0.0;
+  size_t pairs = 0;
+  float local_bins[kSpectrumBins]{};
+  const size_t step = 8;  // every 4th complex sample
+  for (size_t i = 0; i + 1 < bytes; i += step) {
+    const float fi = (static_cast<int>(data[i]) - 128) * (1.0f / 128.0f);
+    const float fq = (static_cast<int>(data[i + 1]) - 128) * (1.0f / 128.0f);
+    const float p = fi * fi + fq * fq;
+    acc += p;
+    ++pairs;
+    const int bin = static_cast<int>((pairs * kSpectrumBins) % kSpectrumBins);
+    local_bins[bin] += p;
+  }
+  if (pairs == 0) return;
+  const float mean = static_cast<float>(acc / static_cast<double>(pairs));
+  const float dbfs = 10.0f * log10f(mean + 1.0e-12f);
+  g_signal_dbfs.store(dbfs, std::memory_order_relaxed);
+
+  portENTER_CRITICAL(&spectrum_mux);
+  for (int i = 0; i < kSpectrumBins; ++i) {
+    spectrum_bins[i] = spectrum_bins[i] * 0.75f + local_bins[i] * 0.25f;
+  }
+  portEXIT_CRITICAL(&spectrum_mux);
+}
+
+void draw_spectrum(int x, int y, int w, int h) {
+  fill_rect(x, y, w, h, rgb565(10, 16, 12));
+  float bins[kSpectrumBins]{};
+  portENTER_CRITICAL(&spectrum_mux);
+  memcpy(bins, spectrum_bins, sizeof(bins));
+  portEXIT_CRITICAL(&spectrum_mux);
+
+  float peak = 1.0e-9f;
+  for (float v : bins)
+    if (v > peak) peak = v;
+  const int bar_w = max(1, w / kSpectrumBins);
+  for (int i = 0; i < kSpectrumBins; ++i) {
+    const int bh = static_cast<int>((bins[i] / peak) * (h - 2));
+    if (bh <= 0) continue;
+    const uint16_t color = bh > h * 2 / 3 ? rgb565(157, 255, 0) : rgb565(80, 160, 200);
+    fill_rect(x + i * bar_w, y + h - bh - 1, bar_w - 1, bh, color);
+  }
+}
+
+void draw_header() {
+  const uint16_t green = rgb565(157, 255, 0);
+  const uint16_t muted = rgb565(122, 138, 106);
+  const uint16_t panel = rgb565(16, 24, 14);
+  fill_rect(0, 0, kWidth, 28, panel);
+  fill_rect(0, 26, kWidth, 2, rgb565(118, 185, 0));
+  draw_text(8, 6, "ORCSDR", 2, green);
+  draw_text(120, 8, mode_name(g_mode), 2, green);
+  draw_text(220, 10, "TOUCH=MODE", 1, muted);
+}
+
+void draw_adsb_body() {
+  const uint16_t green = rgb565(157, 255, 0);
+  const uint16_t white = rgb565(232, 238, 228);
+  const uint16_t muted = rgb565(122, 138, 106);
+  const uint16_t red = rgb565(245, 120, 100);
+  char line[48];
+
+  draw_text(8, 36, "1090 MHZ  2.048 MS/S", 1, muted);
+  const bool ready = g_device_ready.load(std::memory_order_acquire);
+  const bool streaming = g_streaming.load(std::memory_order_acquire);
+  draw_text(8, 52, ready ? (streaming ? "STREAMING" : "READY") : "WAITING RTL", 2,
+            ready ? green : red);
+  draw_text(8, 74, g_status, 1, white);
+
+  snprintf(line, sizeof(line), "MSG %u  CRC %u  DROP %u",
+           total_messages.load(std::memory_order_relaxed),
+           total_crc_ok.load(std::memory_order_relaxed),
+           g_iq_drops.load(std::memory_order_relaxed));
+  draw_text(8, 92, line, 1, muted);
+
+  draw_text(8, 112, "ICAO   CALL  ALT", 1, muted);
+  fill_rect(8, 124, 304, 1, rgb565(46, 58, 46));
+
+  Track snapshot[6]{};
+  size_t count = 0;
+  portENTER_CRITICAL(&tracks_mux);
+  for (const auto& t : tracks) {
+    if (!t.used || count >= 6) continue;
+    snapshot[count++] = t;
+  }
+  portEXIT_CRITICAL(&tracks_mux);
+
+  if (count == 0) {
+    draw_text(8, 140, "NO AIRCRAFT YET", 2, muted);
+  } else {
+    for (size_t i = 0; i < count; ++i) {
+      const Track& t = snapshot[i];
+      char icao[8];
+      snprintf(icao, sizeof(icao), "%06X", t.icao);
+      char call[9];
+      strlcpy(call, t.has_callsign ? t.callsign : "------", sizeof(call));
+      char alt[12];
+      if (t.has_altitude)
+        snprintf(alt, sizeof(alt), "%5d", t.altitude_ft);
+      else
+        strlcpy(alt, "  ---", sizeof(alt));
+      snprintf(line, sizeof(line), "%s %s %s", icao, call, alt);
+      draw_text(8, 132 + static_cast<int>(i) * 16, line, 1, white);
+    }
+  }
+}
+
+void draw_radio_body() {
+  const uint16_t green = rgb565(157, 255, 0);
+  const uint16_t white = rgb565(232, 238, 228);
+  const uint16_t muted = rgb565(122, 138, 106);
+  const uint16_t red = rgb565(245, 120, 100);
+  char line[48];
+
+  const char* label = g_mode == Mode::Fm ? "FM BROADCAST" : "NOAA WX";
+  draw_text(8, 36, label, 1, muted);
+
+  if (g_mode == Mode::Fm) {
+    snprintf(line, sizeof(line), "%3u.%01u MHZ", g_freq_hz / 1000000,
+             (g_freq_hz / 100000) % 10);
+  } else {
+    snprintf(line, sizeof(line), "%u.%03u MHZ", g_freq_hz / 1000000,
+             (g_freq_hz / 1000) % 1000);
+  }
+  draw_text(8, 52, line, 3, white);
+
+  const bool ready = g_device_ready.load(std::memory_order_acquire);
+  const bool streaming = g_streaming.load(std::memory_order_acquire);
+  draw_text(8, 90, ready ? (streaming ? "STREAMING" : "READY") : "WAITING RTL", 2,
+            ready ? green : red);
+
+  const float dbfs = g_signal_dbfs.load(std::memory_order_relaxed);
+  snprintf(line, sizeof(line), "SIG %.1f DBFS  SPS %u", static_cast<double>(dbfs),
+           g_effective_sps.load(std::memory_order_relaxed));
+  draw_text(8, 114, line, 1, muted);
+  draw_text(8, 130, g_status, 1, white);
+
+  draw_spectrum(8, 150, 304, 72);
+  draw_text(8, 226, "SERIAL: MODE FREQ+/- STEP START STOP", 1, muted);
+}
+
+void draw_status_body() {
+  const uint16_t green = rgb565(157, 255, 0);
+  const uint16_t white = rgb565(232, 238, 228);
+  const uint16_t muted = rgb565(122, 138, 106);
+  char line[48];
+
+  draw_text(8, 40, "DEVICE", 2, green);
+  draw_text(8, 66, "WAVESHARE ESP32-P4", 1, white);
+  draw_text(8, 82, g_product, 1, muted);
+  snprintf(line, sizeof(line), "DRIVER %s", rtl_sdr_v4_esp_get_version_string());
+  draw_text(8, 98, line, 1, muted);
+  snprintf(line, sizeof(line), "HEAP %u KB", ESP.getFreeHeap() / 1024);
+  draw_text(8, 114, line, 1, muted);
+  snprintf(line, sizeof(line), "RTL %s",
+           g_device_ready.load() ? (g_streaming.load() ? "STREAM" : "READY") : "ABSENT");
+  draw_text(8, 130, line, 2, g_device_ready.load() ? green : rgb565(245, 120, 100));
+  draw_text(8, 156, "WEB UI", 1, muted);
+  snprintf(line, sizeof(line), "http://%s/", orcsdr::web::local_ip());
+  draw_text(8, 172, line, 1, orcsdr::web::http_ready() ? green : white);
+  draw_text(8, 192, "ETH", 1, muted);
+  draw_text(40, 192, orcsdr::web::ethernet_link_up() ? "LINK" : "DOWN", 1,
+            orcsdr::web::ethernet_link_up() ? green : rgb565(245, 120, 100));
+  draw_text(8, 212, "USB: LOWER-LEFT BY ETH", 1, muted);
+  draw_text(8, 226, "WEB /FM RADIO IN BROWSER", 1, muted);
+}
+
+void draw_dashboard(bool force) {
+  if (!display_ready) return;
+  const uint32_t rev = track_revision.load(std::memory_order_acquire);
+  const uint32_t now = millis();
+  if (!force && rev == last_ui_revision && (now - last_ui_ms) < 250) return;
+  last_ui_revision = rev;
+  last_ui_ms = now;
+
+  fill_rect(0, 0, kWidth, kHeight, rgb565(14, 14, 14));
+  draw_header();
+  switch (g_mode) {
+    case Mode::Adsb:
+      draw_adsb_body();
+      break;
+    case Mode::Fm:
+    case Mode::Wx:
+      draw_radio_body();
+      break;
+    case Mode::Status:
+    default:
+      draw_status_body();
+      break;
+  }
+  flush_framebuffer();
+}
+
+void on_adsb_frame(const orcsdr::adsb_rx::Frame& frame, void*) {
+  if (frame.icao == 0) return;
+  total_messages.fetch_add(1, std::memory_order_relaxed);
+  if (frame.bit_length > 0) total_crc_ok.fetch_add(1, std::memory_order_relaxed);
+
+  const uint32_t now = millis();
+  orcsdr::adsb_rx::Frame even_cpr{}, odd_cpr{};
+  bool try_cpr = false;
+  bool use_odd = false;
+
+  portENTER_CRITICAL(&tracks_mux);
+  Track* slot = nullptr;
+  Track* oldest = &tracks[0];
+  for (auto& candidate : tracks) {
+    if (candidate.used && candidate.icao == frame.icao) {
+      slot = &candidate;
+      break;
+    }
+    if (!candidate.used) {
+      if (!slot) slot = &candidate;
+    } else if (candidate.last_ms < oldest->last_ms) {
+      oldest = &candidate;
+    }
+  }
+  if (!slot) slot = oldest;
+  const bool added = !slot->used || slot->icao != frame.icao;
+  if (added) {
+    *slot = Track{};
+    slot->used = true;
+    slot->icao = frame.icao;
+  }
+  slot->last_ms = now;
+  slot->messages += 1;
+  if (frame.has_callsign) {
+    strlcpy(slot->callsign, frame.callsign, sizeof(slot->callsign));
+    slot->has_callsign = true;
+  }
+  if (frame.has_altitude) {
+    slot->altitude_ft = frame.altitude_ft;
+    slot->has_altitude = true;
+  }
+  if (frame.has_speed) {
+    slot->speed_kts = frame.speed_kts;
+    slot->has_speed = true;
+  }
+  if (frame.has_heading) {
+    slot->heading_deg = frame.heading_deg;
+    slot->has_heading = true;
+  }
+  if (frame.has_vertical_rate) {
+    slot->vertical_rate_fpm = frame.vertical_rate_fpm;
+    slot->has_vertical_rate = true;
+  }
+  if (frame.has_cpr) {
+    if (frame.cpr_odd) {
+      slot->odd_cpr = frame;
+      slot->has_odd_cpr = true;
+    } else {
+      slot->even_cpr = frame;
+      slot->has_even_cpr = true;
+    }
+    if (slot->has_even_cpr && slot->has_odd_cpr) {
+      even_cpr = slot->even_cpr;
+      odd_cpr = slot->odd_cpr;
+      use_odd = frame.cpr_odd;
+      try_cpr = true;
+    }
+  }
+  portEXIT_CRITICAL(&tracks_mux);
+
+  if (try_cpr) {
+    double lat = 0, lon = 0;
+    if (orcsdr::adsb_rx::decode_global_cpr(even_cpr, odd_cpr, use_odd, &lat, &lon)) {
+      portENTER_CRITICAL(&tracks_mux);
+      for (auto& t : tracks) {
+        if (t.used && t.icao == frame.icao) {
+          t.latitude = static_cast<float>(lat);
+          t.longitude = static_cast<float>(lon);
+          t.has_position = true;
+          break;
+        }
+      }
+      portEXIT_CRITICAL(&tracks_mux);
+    }
+  }
+
+  track_revision.fetch_add(1, std::memory_order_release);
+
+  Serial.printf("ADSB_FRAME icao=%06X call=%s alt=%d\n", frame.icao,
+                frame.has_callsign ? frame.callsign : "-",
+                frame.has_altitude ? frame.altitude_ft : -1);
+}
+
+void adsb_decoder_task(void*) {
+  uint8_t index = 0;
+  for (;;) {
+    if (xQueueReceive(iq_ready, &index, portMAX_DELAY) == pdTRUE) {
+      if (g_mode == Mode::Adsb) {
+        adsb_decoder.process_cu8(iq_blocks[index], iq_sizes[index], on_adsb_frame, nullptr);
+      }
+      (void)xQueueSend(iq_free, &index, portMAX_DELAY);
+    }
+  }
+}
+
+void expire_tracks(uint32_t now) {
+  bool changed = false;
+  portENTER_CRITICAL(&tracks_mux);
+  for (auto& t : tracks) {
+    if (t.used && (now - t.last_ms) > kTrackTtlMs) {
+      t = Track{};
+      changed = true;
+    }
+  }
+  portEXIT_CRITICAL(&tracks_mux);
+  if (changed) track_revision.fetch_add(1, std::memory_order_release);
+}
+
+bool stop_stream() {
+  if (!g_rtl) return true;
+  if (!g_streaming.load(std::memory_order_acquire)) return true;
+  const esp_err_t err = rtl_sdr_v4_esp_stop(g_rtl, 2000);
+  Serial.printf("RTL_STOP %s\n", rtl_sdr_v4_esp_err_to_name(err));
+  g_streaming.store(false, std::memory_order_release);
+  set_status(err == ESP_OK ? "stopped" : "stop err");
+  return err == ESP_OK;
+}
+
+bool start_stream() {
+  if (!g_rtl || !g_device_ready.load(std::memory_order_acquire)) {
+    set_status("no device");
+    return false;
+  }
+  if (g_mode == Mode::Status) {
+    set_status("status mode");
+    return false;
+  }
+  if (g_streaming.load(std::memory_order_acquire)) (void)stop_stream();
+
+  if (g_mode == Mode::Adsb) {
+    adsb_decoder.reset();
+    total_messages.store(0, std::memory_order_relaxed);
+    total_crc_ok.store(0, std::memory_order_relaxed);
+    portENTER_CRITICAL(&tracks_mux);
+    for (auto& t : tracks) t = Track{};
+    portEXIT_CRITICAL(&tracks_mux);
+  }
+  if (g_mode == Mode::Fm || g_mode == Mode::Wx) {
+    orcsdr::fm::reset();
+  }
+  g_iq_drops.store(0, std::memory_order_relaxed);
+  g_iq_blocks.store(0, std::memory_order_relaxed);
+  g_iq_bytes.store(0, std::memory_order_relaxed);
+  track_revision.fetch_add(1, std::memory_order_release);
+
+  rtl_sdr_v4_esp_stream_config_t st;
+  rtl_sdr_v4_esp_stream_config_default(&st);
+  st.preset = RTL_SDR_V4_ESP_PRESET_CUSTOM_HZ;
+  st.frequency_hz = g_freq_hz;
+  st.sample_rate_sps = stream_rate_for_mode(g_mode);
+  const esp_err_t err = rtl_sdr_v4_esp_start(g_rtl, &st);
+  Serial.printf("RTL_START %s mode=%s rate=%u frequency_hz=%u\n",
+                rtl_sdr_v4_esp_err_to_name(err), mode_name(g_mode), st.sample_rate_sps,
+                st.frequency_hz);
+  if (err != ESP_OK) {
+    set_status("start failed");
+    g_streaming.store(false, std::memory_order_release);
+    return false;
+  }
+  g_streaming.store(true, std::memory_order_release);
+  char buf[32];
+  snprintf(buf, sizeof(buf), "%s live", mode_name(g_mode));
+  set_status(buf);
+  return true;
+}
+
+void request_mode(Mode mode) {
+  if (mode == g_mode) {
+    /* Web UI may re-select FM while idle — restart stream. */
+    if (mode != Mode::Status && !g_streaming.load(std::memory_order_acquire) &&
+        g_device_ready.load(std::memory_order_acquire)) {
+      start_pending = true;
+      Serial.printf("MODE %s restart_stream frequency_hz=%u\n", mode_name(g_mode), g_freq_hz);
+    }
+    return;
+  }
+  g_mode = mode;
+  if (mode != Mode::Status) {
+    g_freq_hz = default_freq_for_mode(mode);
+  }
+  mode_change_pending = true;
+  track_revision.fetch_add(1, std::memory_order_release);
+  Serial.printf("MODE %s frequency_hz=%u\n", mode_name(g_mode), g_freq_hz);
+}
+
+void step_frequency(int direction) {
+  if (g_mode == Mode::Fm) {
+    const int64_t next = static_cast<int64_t>(g_freq_hz) + direction * static_cast<int64_t>(kFmStepHz);
+    g_freq_hz = static_cast<uint32_t>(constrain(next, static_cast<int64_t>(kFmMinHz),
+                                                static_cast<int64_t>(kFmMaxHz)));
+  } else if (g_mode == Mode::Wx) {
+    const int64_t next = static_cast<int64_t>(g_freq_hz) + direction * static_cast<int64_t>(kWxStepHz);
+    g_freq_hz = static_cast<uint32_t>(constrain(next, static_cast<int64_t>(kWxMinHz),
+                                                static_cast<int64_t>(kWxMaxHz)));
+  } else {
+    return;
+  }
+  Serial.printf("FREQ %u\n", g_freq_hz);
+  if (g_streaming.load(std::memory_order_acquire) && g_rtl) {
+    const esp_err_t err = rtl_sdr_v4_esp_retune_hz(g_rtl, g_freq_hz);
+    Serial.printf("RTL_RETUNE %s frequency_hz=%u\n", rtl_sdr_v4_esp_err_to_name(err),
+                  g_freq_hz);
+  }
+  track_revision.fetch_add(1, std::memory_order_release);
+}
+
+void print_help() {
+  Serial.println("ORCSDR_WAVESHARE commands:");
+  Serial.println("  MODE ADSB|FM|WX|STATUS");
+  Serial.println("  FREQ <hz>");
+  Serial.println("  +  /  -     step FM 200kHz or WX 25kHz");
+  Serial.println("  START / STOP");
+  Serial.println("  HELP");
+  Serial.println("Touch cycles modes. USB host: lower-left Type-A by Ethernet.");
+}
+
+void process_command(char* command) {
+  if (strcmp(command, "HELP") == 0 || strcmp(command, "?") == 0) {
+    print_help();
+    return;
+  }
+  if (strcmp(command, "START") == 0) {
+    start_pending = true;
+    return;
+  }
+  if (strcmp(command, "STOP") == 0) {
+    stop_pending = true;
+    return;
+  }
+  if (strcmp(command, "+") == 0) {
+    step_frequency(+1);
+    return;
+  }
+  if (strcmp(command, "-") == 0) {
+    step_frequency(-1);
+    return;
+  }
+  if (strncmp(command, "MODE ", 5) == 0) {
+    const char* name = command + 5;
+    if (strcmp(name, "ADSB") == 0) request_mode(Mode::Adsb);
+    else if (strcmp(name, "FM") == 0) request_mode(Mode::Fm);
+    else if (strcmp(name, "WX") == 0) request_mode(Mode::Wx);
+    else if (strcmp(name, "STATUS") == 0) request_mode(Mode::Status);
+    else Serial.println("MODE_INVALID");
+    return;
+  }
+  if (strncmp(command, "FREQ ", 5) == 0) {
+    const uint32_t hz = static_cast<uint32_t>(strtoul(command + 5, nullptr, 10));
+    if (hz < RTL_SDR_V4_ESP_FREQ_MIN_HZ || hz > RTL_SDR_V4_ESP_FREQ_MAX_HZ) {
+      Serial.println("FREQ_INVALID");
+      return;
+    }
+    g_freq_hz = hz;
+    Serial.printf("FREQ %u\n", g_freq_hz);
+    if (g_streaming.load(std::memory_order_acquire) && g_rtl) {
+      const esp_err_t err = rtl_sdr_v4_esp_retune_hz(g_rtl, g_freq_hz);
+      Serial.printf("RTL_RETUNE %s frequency_hz=%u\n", rtl_sdr_v4_esp_err_to_name(err),
+                    g_freq_hz);
+    }
+    track_revision.fetch_add(1, std::memory_order_release);
+    return;
+  }
+  Serial.println("CMD_UNKNOWN use HELP");
+}
+
+void poll_serial() {
+  while (Serial.available() > 0) {
+    const char c = static_cast<char>(Serial.read());
+    if (c == '\r') continue;
+    if (c == '\n') {
+      serial_line[serial_len] = '\0';
+      if (serial_len > 0) process_command(serial_line);
+      serial_len = 0;
+      continue;
+    }
+    if (serial_len + 1 < sizeof(serial_line)) serial_line[serial_len++] = c;
+    else serial_len = 0;
+  }
+}
+
+void on_rtl_event(rtl_sdr_v4_esp_event_t event, const void* payload, void*) {
+  switch (event) {
+    case RTL_SDR_V4_ESP_EVT_READY:
+    case RTL_SDR_V4_ESP_EVT_ENUMERATED: {
+      g_device_ready.store(true, std::memory_order_release);
+      const auto* info = static_cast<const rtl_sdr_v4_esp_device_info_t*>(payload);
+      if (info) {
+        strlcpy(g_product, info->product[0] ? info->product : "Blog V4", sizeof(g_product));
+        Serial.printf("RTL_SDR_PROBE_OK v4=true vid=%04x pid=%04x hs=%d product=%s\n",
+                      info->vid, info->pid, info->high_speed ? 1 : 0, g_product);
+      } else {
+        Serial.println("RTL_SDR_PROBE_OK v4=true");
+      }
+      set_status("V4 ready");
+      if (g_mode != Mode::Status) start_pending = true;
+      track_revision.fetch_add(1, std::memory_order_release);
+      break;
+    }
+    case RTL_SDR_V4_ESP_EVT_DISCONNECTED:
+      g_device_ready.store(false, std::memory_order_release);
+      g_streaming.store(false, std::memory_order_release);
+      set_status("disconnected");
+      Serial.println("RTL_SDR_DISCONNECTED");
+      track_revision.fetch_add(1, std::memory_order_release);
+      break;
+    case RTL_SDR_V4_ESP_EVT_IQ_BLOCK: {
+      const auto* iq = static_cast<const rtl_sdr_v4_esp_iq_block_t*>(payload);
+      if (!iq || !iq->data || iq->bytes == 0) break;
+      const size_t n = iq->bytes <= kIqBlockBytes ? iq->bytes : kIqBlockBytes;
+      if (g_mode == Mode::Fm || g_mode == Mode::Wx) {
+        update_signal_from_iq(iq->data, n);
+        orcsdr::fm::process_cu8(iq->data, n, g_mode == Mode::Fm);
+      }
+      if (g_mode == Mode::Adsb) {
+        update_signal_from_iq(iq->data, n);
+        if (iq_free && iq_ready) {
+          uint8_t index = 0;
+          if (xQueueReceive(iq_free, &index, 0) == pdTRUE) {
+            std::memcpy(iq_blocks[index], iq->data, n);
+            iq_sizes[index] = n;
+            (void)xQueueSend(iq_ready, &index, 0);
+            g_iq_blocks.fetch_add(1, std::memory_order_relaxed);
+            g_iq_bytes.fetch_add(n, std::memory_order_relaxed);
+          } else {
+            g_iq_drops.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+      } else {
+        g_iq_blocks.fetch_add(1, std::memory_order_relaxed);
+        g_iq_bytes.fetch_add(n, std::memory_order_relaxed);
+      }
+      (void)rtl_sdr_v4_esp_release_iq_block(g_rtl, iq);
+      break;
+    }
+    case RTL_SDR_V4_ESP_EVT_STREAM_STARTED:
+      g_streaming.store(true, std::memory_order_release);
+      break;
+    case RTL_SDR_V4_ESP_EVT_STOPPED:
+      g_streaming.store(false, std::memory_order_release);
+      break;
+    case RTL_SDR_V4_ESP_EVT_ERROR: {
+      const auto* err = static_cast<const rtl_sdr_v4_esp_error_info_t*>(payload);
+      Serial.printf("RTL_ERROR %s\n", err ? err->message : "unknown");
+      set_status("rtl error");
+      break;
+    }
+    case RTL_SDR_V4_ESP_EVT_RETUNED:
+      if (payload) {
+        g_freq_hz = *static_cast<const uint32_t*>(payload);
+        track_revision.fetch_add(1, std::memory_order_release);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+void publish_web_snapshot() {
+  orcsdr::web::Snapshot snap{};
+  strlcpy(snap.mode, mode_name(g_mode), sizeof(snap.mode));
+  strlcpy(snap.product, g_product, sizeof(snap.product));
+  strlcpy(snap.status, g_status, sizeof(snap.status));
+  strlcpy(snap.ip, orcsdr::web::local_ip(), sizeof(snap.ip));
+  snap.eth_link = orcsdr::web::ethernet_link_up();
+  snap.rtl_ready = g_device_ready.load(std::memory_order_acquire);
+  snap.streaming = g_streaming.load(std::memory_order_acquire);
+  snap.frequency_hz = g_freq_hz;
+  snap.sample_rate_sps = stream_rate_for_mode(g_mode);
+  snap.effective_sps = g_effective_sps.load(std::memory_order_relaxed);
+  snap.iq_drops = g_iq_drops.load(std::memory_order_relaxed);
+  snap.free_heap = ESP.getFreeHeap();
+  snap.total_messages = total_messages.load(std::memory_order_relaxed);
+  snap.total_crc_ok = total_crc_ok.load(std::memory_order_relaxed);
+  {
+    const auto& st = adsb_decoder.stats();
+    snap.adsb_preambles = st.preambles;
+    snap.adsb_frames = st.frames;
+    snap.adsb_df17 = st.df17;
+    snap.adsb_mag_min = st.magnitude_min;
+    snap.adsb_mag_max = st.magnitude_max;
+  }
+  snap.revision = track_revision.load(std::memory_order_relaxed);
+  snap.live = snap.streaming && g_mode == Mode::Adsb && snap.total_crc_ok > 0;
+  snap.strongest_signal_dbfs = g_signal_dbfs.load(std::memory_order_relaxed);
+
+  static uint32_t rate_window_start_ms = 0;
+  static uint32_t rate_window_msgs = 0;
+  static float last_message_rate = 0.0f;
+  const uint32_t now = millis();
+  if (rate_window_start_ms == 0) {
+    rate_window_start_ms = now;
+    rate_window_msgs = snap.total_messages;
+  } else if (now - rate_window_start_ms >= 2000) {
+    const uint32_t delta = snap.total_messages - rate_window_msgs;
+    last_message_rate =
+        delta * 1000.0f / static_cast<float>(now - rate_window_start_ms);
+    rate_window_start_ms = now;
+    rate_window_msgs = snap.total_messages;
+  }
+  snap.message_rate = last_message_rate;
+
+  orcsdr::web::get_receiver_location(&snap.location_configured, &snap.latitude,
+                                     &snap.longitude, &snap.radar_range_nm);
+
+  uint8_t count = 0;
+  portENTER_CRITICAL(&tracks_mux);
+  for (const auto& t : tracks) {
+    if (!t.used || count >= orcsdr::web::kMaxAircraft) continue;
+    auto& out = snap.aircraft[count++];
+    out.icao = t.icao;
+    strlcpy(out.callsign, t.callsign, sizeof(out.callsign));
+    out.has_callsign = t.has_callsign;
+    out.altitude_ft = t.altitude_ft;
+    out.has_altitude = t.has_altitude;
+    out.speed_kts = t.speed_kts;
+    out.has_speed = t.has_speed;
+    out.heading_deg = t.heading_deg;
+    out.has_heading = t.has_heading;
+    out.vertical_rate_fpm = t.vertical_rate_fpm;
+    out.has_vertical_rate = t.has_vertical_rate;
+    out.latitude = t.latitude;
+    out.longitude = t.longitude;
+    out.has_position = t.has_position;
+    out.messages = t.messages;
+    out.age_ms = now - t.last_ms;
+  }
+  portEXIT_CRITICAL(&tracks_mux);
+  snap.aircraft_count = count;
+
+  snap.fm_signal_dbfs = orcsdr::fm::signal_dbfs();
+  snap.fm_spectrum_bins = orcsdr::fm::kSpectrumBins;
+  orcsdr::fm::copy_spectrum(snap.fm_spectrum, orcsdr::fm::kSpectrumBins);
+  snap.pcm_underruns = orcsdr::fm::underruns();
+  snap.pcm_overruns = orcsdr::fm::overruns();
+  snap.pcm_available = static_cast<uint32_t>(orcsdr::fm::pcm_available());
+  snap.pcm_sequence = orcsdr::fm::pcm_sequence();
+  if (g_mode == Mode::Fm || g_mode == Mode::Wx) {
+    snap.strongest_signal_dbfs = snap.fm_signal_dbfs;
+  }
+
+  orcsdr::web::publish_snapshot(snap);
+}
+
+bool initialize_rtl() {
+  iq_free = xQueueCreate(kIqBlockCount, sizeof(uint8_t));
+  iq_ready = xQueueCreate(kIqBlockCount, sizeof(uint8_t));
+  if (!iq_free || !iq_ready) {
+    set_status("iq queue fail");
+    return false;
+  }
+  for (uint8_t i = 0; i < kIqBlockCount; ++i) {
+    iq_blocks[i] = static_cast<uint8_t*>(
+        heap_caps_malloc(kIqBlockBytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    if (!iq_blocks[i]) {
+      iq_blocks[i] = static_cast<uint8_t*>(
+          heap_caps_malloc(kIqBlockBytes, MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT));
+    }
+    if (!iq_blocks[i]) {
+      set_status("iq alloc fail");
+      return false;
+    }
+    (void)xQueueSend(iq_free, &i, 0);
+  }
+
+  if (xTaskCreatePinnedToCore(adsb_decoder_task, "adsb_decode", 6144, nullptr, 4, nullptr,
+                              1) != pdPASS) {
+    set_status("decode task fail");
+    return false;
+  }
+
+  rtl_sdr_v4_esp_config_t cfg;
+  rtl_sdr_v4_esp_config_default(&cfg);
+  cfg.event_cb = on_rtl_event;
+  cfg.transfer_bytes = 32768;
+  cfg.transfer_count = 3;
+  cfg.usb_task_core_id = 0;
+  esp_err_t err = rtl_sdr_v4_esp_config_validate(&cfg);
+  if (err != ESP_OK) {
+    set_status("cfg invalid");
+    return false;
+  }
+  err = rtl_sdr_v4_esp_install(&cfg, &g_rtl);
+  if (err != ESP_OK) {
+    Serial.printf("RTL_INSTALL %s\n", rtl_sdr_v4_esp_err_to_name(err));
+    set_status("install failed");
+    return false;
+  }
+  Serial.printf("RTL_INSTALL ok v%s caps=0x%08x\n", rtl_sdr_v4_esp_get_version_string(),
+                static_cast<unsigned>(rtl_sdr_v4_esp_get_capabilities()));
+  set_status("host waiting");
+  return true;
+}
+
+}  // namespace
+
+void setup() {
+  Serial.begin(115200);
+  delay(400);
+  Serial.println();
+  Serial.println("ORCSDR_WAVESHARE boot branch=codex/ads-b-dashboard multi-mode");
+  print_help();
+
+  if (!orcsdr::adsb_rx::Decoder::self_check()) {
+    Serial.println("RTL_ADSB_SELF_CHECK_FAIL");
+  } else {
+    Serial.println("RTL_ADSB_SELF_CHECK_OK");
+  }
+
+  const esp_err_t display_result = initialize_display();
+  Serial.printf("DISPLAY_INIT result=%s\n", esp_err_to_name(display_result));
+  if (display_result == ESP_OK) {
+    set_status("display ready");
+    const esp_err_t touch_result = initialize_touch();
+    Serial.printf("TOUCH_INIT result=%s irq=%d cs=%d\n", esp_err_to_name(touch_result),
+                  kTouchIrq, kTouchCs);
+    draw_dashboard(true);
+  } else {
+    set_status("display failed");
+  }
+
+  if (!orcsdr::web::begin_network_and_http()) {
+    Serial.println("ETH_INIT failed — web UI unavailable until link");
+  }
+  if (!orcsdr::fm::begin()) {
+    Serial.println("FM_PCM_INIT failed");
+  } else {
+    Serial.println("FM_PCM_INIT ok rate=48000 ring=1s");
+  }
+
+  if (!initialize_rtl()) {
+    draw_dashboard(true);
+    return;
+  }
+  draw_dashboard(true);
+  Serial.println("ORCSDR_WAVESHARE ready usb_host=lower_left_type_a_by_eth web=/");
+}
+
+void loop() {
+  poll_serial();
+  orcsdr::web::poll_network_and_http();
+
+  const uint8_t web_mode = orcsdr::web::take_mode_request();
+  if (web_mode == 1) request_mode(Mode::Adsb);
+  else if (web_mode == 2) request_mode(Mode::Fm);
+  else if (web_mode == 3) request_mode(Mode::Wx);
+
+  const uint32_t web_freq = orcsdr::web::take_freq_request();
+  if (web_freq != 0) {
+    g_freq_hz = web_freq;
+    if (g_mode != Mode::Fm && g_mode != Mode::Wx) {
+      /* Tuning from FM UI implies radio mode. */
+      request_mode(Mode::Fm);
+      g_freq_hz = web_freq;
+    } else if (g_streaming.load(std::memory_order_acquire) && g_rtl) {
+      const esp_err_t err = rtl_sdr_v4_esp_retune_hz(g_rtl, g_freq_hz);
+      Serial.printf("RTL_RETUNE %s frequency_hz=%u\n", rtl_sdr_v4_esp_err_to_name(err),
+                    g_freq_hz);
+      orcsdr::fm::reset();
+    } else if (!g_streaming.load(std::memory_order_acquire)) {
+      start_pending = true;
+    }
+    track_revision.fetch_add(1, std::memory_order_release);
+  }
+
+  const uint8_t stream_req = orcsdr::web::take_stream_request();
+  if (stream_req == 1) start_pending = true;
+  else if (stream_req == 2) stop_pending = true;
+
+  static bool touch_was_down = false;
+  uint16_t raw_x = 0;
+  uint16_t raw_y = 0;
+  const bool touch_down = read_touch(&raw_x, &raw_y);
+  if (touch_down && !touch_was_down) {
+    Serial.printf("TOUCH raw_x=%u raw_y=%u\n", raw_x, raw_y);
+    const int next = (static_cast<int>(g_mode) + 1) % static_cast<int>(Mode::Count);
+    request_mode(static_cast<Mode>(next));
+  }
+  touch_was_down = touch_down;
+
+  if (stop_pending) {
+    stop_pending = false;
+    (void)stop_stream();
+  }
+  if (mode_change_pending) {
+    mode_change_pending = false;
+    (void)stop_stream();
+    if (g_mode != Mode::Status && g_device_ready.load(std::memory_order_acquire)) {
+      delay(100);
+      (void)start_stream();
+    }
+    draw_dashboard(true);
+  }
+  if (start_pending) {
+    start_pending = false;
+    delay(100);
+    (void)start_stream();
+    draw_dashboard(true);
+  }
+
+  static uint32_t last_metrics_ms = 0;
+  static uint32_t last_web_ms = 0;
+  const uint32_t now = millis();
+  if (now - last_web_ms >= 500) {
+    last_web_ms = now;
+    publish_web_snapshot();
+  }
+  if (now - last_metrics_ms >= 2000) {
+    last_metrics_ms = now;
+    expire_tracks(now);
+    if (g_rtl && g_streaming.load(std::memory_order_acquire)) {
+      rtl_sdr_v4_esp_metrics_t m{};
+      if (rtl_sdr_v4_esp_get_metrics(g_rtl, &m) == ESP_OK) {
+        g_effective_sps.store(m.effective_sps, std::memory_order_relaxed);
+        const auto& st = adsb_decoder.stats();
+        Serial.printf(
+            "ORC_METRICS mode=%s sps=%u bytes=%llu drops=%u sig=%.1f msg=%u "
+            "preambles=%u frames=%u df17=%u crc=%u mag=%u..%u heap=%u ip=%s\n",
+            mode_name(g_mode), m.effective_sps,
+            static_cast<unsigned long long>(g_iq_bytes.load()),
+            g_iq_drops.load(), static_cast<double>(g_signal_dbfs.load()),
+            total_messages.load(), st.preambles, st.frames, st.df17, st.crc_ok,
+            st.magnitude_min == 0xffff ? 0 : st.magnitude_min, st.magnitude_max,
+            ESP.getFreeHeap(), orcsdr::web::local_ip());
+      }
+      track_revision.fetch_add(1, std::memory_order_relaxed);
+    } else if (!g_device_ready.load(std::memory_order_acquire)) {
+      Serial.println("ORC_WAIT rtl_sdr_not_attached use_lower_left_usb_by_eth");
+    }
+  }
+
+  draw_dashboard(false);
+  delay(5);
+}

--- a/apps/orcsdr-waveshare/src/web_api.cpp
+++ b/apps/orcsdr-waveshare/src/web_api.cpp
@@ -1,0 +1,54 @@
+#include "web_api.hpp"
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+#include <cstring>
+
+namespace orcsdr::web {
+namespace {
+
+Snapshot g_snapshot{};
+portMUX_TYPE g_mux = portMUX_INITIALIZER_UNLOCKED;
+
+bool g_loc_configured = false;
+double g_lat = 0;
+double g_lon = 0;
+uint16_t g_range_nm = 25;
+
+}  // namespace
+
+void publish_snapshot(const Snapshot& snapshot) {
+  portENTER_CRITICAL(&g_mux);
+  g_snapshot = snapshot;
+  portEXIT_CRITICAL(&g_mux);
+}
+
+void copy_snapshot(Snapshot* out) {
+  if (!out) return;
+  portENTER_CRITICAL(&g_mux);
+  *out = g_snapshot;
+  portEXIT_CRITICAL(&g_mux);
+}
+
+void set_receiver_location(bool configured, double latitude, double longitude,
+                           uint16_t radar_range_nm) {
+  portENTER_CRITICAL(&g_mux);
+  g_loc_configured = configured;
+  g_lat = latitude;
+  g_lon = longitude;
+  g_range_nm = radar_range_nm == 0 ? 25 : radar_range_nm;
+  portEXIT_CRITICAL(&g_mux);
+}
+
+void get_receiver_location(bool* configured, double* latitude, double* longitude,
+                           uint16_t* radar_range_nm) {
+  portENTER_CRITICAL(&g_mux);
+  if (configured) *configured = g_loc_configured;
+  if (latitude) *latitude = g_lat;
+  if (longitude) *longitude = g_lon;
+  if (radar_range_nm) *radar_range_nm = g_range_nm;
+  portEXIT_CRITICAL(&g_mux);
+}
+
+}  // namespace orcsdr::web

--- a/apps/orcsdr-waveshare/src/web_api.hpp
+++ b/apps/orcsdr-waveshare/src/web_api.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+/** Live snapshot shared between RF core and HTTP handlers. */
+namespace orcsdr::web {
+
+constexpr size_t kMaxAircraft = 16;
+
+struct Aircraft {
+  uint32_t icao = 0;
+  char callsign[9]{};
+  char registration[9]{};
+  char type[49]{};
+  char owner[51]{};
+  int altitude_ft = 0;
+  int speed_kts = 0;
+  int heading_deg = 0;
+  int vertical_rate_fpm = 0;
+  float latitude = 0;
+  float longitude = 0;
+  float signal_dbfs = 0;
+  bool has_callsign = false;
+  bool has_altitude = false;
+  bool has_speed = false;
+  bool has_heading = false;
+  bool has_vertical_rate = false;
+  bool has_position = false;
+  uint32_t messages = 0;
+  uint32_t age_ms = 0;
+};
+
+struct Snapshot {
+  Aircraft aircraft[kMaxAircraft]{};
+  uint8_t aircraft_count = 0;
+  uint32_t revision = 0;
+  uint32_t total_messages = 0;
+  uint32_t total_crc_ok = 0;
+  uint32_t adsb_preambles = 0;
+  uint32_t adsb_frames = 0;
+  uint32_t adsb_df17 = 0;
+  uint16_t adsb_mag_min = 0xffff;
+  uint16_t adsb_mag_max = 0;
+  float message_rate = 0;
+  float strongest_signal_dbfs = -90.0f;
+  bool live = false;
+  bool rtl_ready = false;
+  bool streaming = false;
+  char mode[12] = "ADSB";
+  char product[48] = "-";
+  char status[48] = "-";
+  uint32_t frequency_hz = 0;
+  uint32_t sample_rate_sps = 0;
+  uint32_t effective_sps = 0;
+  uint32_t iq_drops = 0;
+  uint32_t free_heap = 0;
+  char ip[16] = "0.0.0.0";
+  bool eth_link = false;
+  uint16_t radar_range_nm = 25;
+  bool location_configured = false;
+  double latitude = 0;
+  double longitude = 0;
+  /* FM / WX browser radio path */
+  float fm_signal_dbfs = -90.0f;
+  float fm_spectrum[64]{};
+  uint8_t fm_spectrum_bins = 64;
+  uint32_t pcm_underruns = 0;
+  uint32_t pcm_overruns = 0;
+  uint32_t pcm_available = 0;
+  uint32_t pcm_sequence = 0;
+};
+
+/** Thread-safe publish from RF loop; HTTP handlers take a copy. */
+void publish_snapshot(const Snapshot& snapshot);
+void copy_snapshot(Snapshot* out);
+
+/** Optional receiver location for radar geometry (e7 degrees). */
+void set_receiver_location(bool configured, double latitude, double longitude,
+                           uint16_t radar_range_nm);
+void get_receiver_location(bool* configured, double* latitude, double* longitude,
+                           uint16_t* radar_range_nm);
+
+}  // namespace orcsdr::web

--- a/apps/orcsdr-waveshare/src/web_server.cpp
+++ b/apps/orcsdr-waveshare/src/web_server.cpp
@@ -1,0 +1,429 @@
+#include "web_server.hpp"
+
+#include "web_api.hpp"
+#include "web_ui_page.h"
+#include "web_ui_fm.h"
+#include "fm_pcm.hpp"
+#include "rtl_sdr_v4_esp.h"
+
+#include <Arduino.h>
+#include <ETH.h>
+#include <Network.h>
+#include <WebServer.h>
+
+#include <cstdio>
+#include <cstring>
+#include <cstdlib>
+
+namespace orcsdr::web {
+namespace {
+
+/* Waveshare ESP32-P4-Module-DEV-KIT Ethernet (same as OrcLink waveshare-p4). */
+constexpr int kEthernetPhyAddress = 1;
+constexpr int kEthernetMdc = 31;
+constexpr int kEthernetMdio = 52;
+constexpr int kEthernetReset = 51;
+
+WebServer server(80);
+bool eth_started = false;
+bool eth_link = false;
+bool eth_has_ip = false;
+bool http_started = false;
+char ip_text[16] = "0.0.0.0";
+
+volatile bool evt_link = false;
+volatile bool evt_ip = false;
+volatile bool evt_lost = false;
+
+void on_network_event(arduino_event_id_t event) {
+  switch (event) {
+    case ARDUINO_EVENT_ETH_CONNECTED:
+      evt_link = true;
+      break;
+    case ARDUINO_EVENT_ETH_GOT_IP:
+      evt_ip = true;
+      break;
+    case ARDUINO_EVENT_ETH_LOST_IP:
+    case ARDUINO_EVENT_ETH_DISCONNECTED:
+    case ARDUINO_EVENT_ETH_STOP:
+      evt_lost = true;
+      break;
+    default:
+      break;
+  }
+}
+
+void json_escape(const char* in, char* out, size_t out_size) {
+  size_t o = 0;
+  for (size_t i = 0; in[i] != '\0' && o + 2 < out_size; ++i) {
+    const char c = in[i];
+    if (c == '"' || c == '\\') {
+      if (o + 3 >= out_size) break;
+      out[o++] = '\\';
+      out[o++] = c;
+    } else if (static_cast<unsigned char>(c) < 0x20) {
+      continue;
+    } else {
+      out[o++] = c;
+    }
+  }
+  out[o] = '\0';
+}
+
+void handle_root() {
+  server.sendHeader("Cache-Control", "no-store");
+  server.send(200, "text/html", kWebUiIndexHtml);
+}
+
+void handle_state() {
+  Snapshot snap{};
+  copy_snapshot(&snap);
+
+  /* Build JSON in a heap buffer — aircraft + FM spectrum. */
+  constexpr size_t kCap = 12288;
+  char* json = static_cast<char*>(malloc(kCap));
+  if (!json) {
+    server.send(500, "text/plain", "oom");
+    return;
+  }
+
+  char esc_product[64]{};
+  char esc_status[64]{};
+  char esc_mode[24]{};
+  json_escape(snap.product, esc_product, sizeof(esc_product));
+  json_escape(snap.status, esc_status, sizeof(esc_status));
+  json_escape(snap.mode, esc_mode, sizeof(esc_mode));
+
+  int n = snprintf(
+      json, kCap,
+      "{"
+      "\"mode\":\"%s\","
+      "\"status\":\"%s\","
+      "\"product\":\"%s\","
+      "\"ip\":\"%s\","
+      "\"eth_link\":%s,"
+      "\"rtl_ready\":%s,"
+      "\"streaming\":%s,"
+      "\"frequency_hz\":%u,"
+      "\"sample_rate_sps\":%u,"
+      "\"effective_sps\":%u,"
+      "\"iq_drops\":%u,"
+      "\"free_heap\":%u,"
+      "\"adsb\":{"
+      "\"live\":%s,"
+      "\"total_messages\":%u,"
+      "\"total_crc_ok\":%u,"
+      "\"preambles\":%u,"
+      "\"candidate_frames\":%u,"
+      "\"df17\":%u,"
+      "\"mag_min\":%u,"
+      "\"mag_max\":%u,"
+      "\"message_rate\":%.2f,"
+      "\"strongest_signal_dbfs\":%.1f,"
+      "\"aircraft_count\":%u,"
+      "\"revision\":%u,"
+      "\"aircraft\":[",
+      esc_mode, esc_status, esc_product, snap.ip,
+      snap.eth_link ? "true" : "false", snap.rtl_ready ? "true" : "false",
+      snap.streaming ? "true" : "false", snap.frequency_hz, snap.sample_rate_sps,
+      snap.effective_sps, snap.iq_drops, snap.free_heap,
+      snap.live ? "true" : "false", snap.total_messages, snap.total_crc_ok,
+      snap.adsb_preambles, snap.adsb_frames, snap.adsb_df17, snap.adsb_mag_min,
+      snap.adsb_mag_max, static_cast<double>(snap.message_rate),
+      static_cast<double>(snap.strongest_signal_dbfs), snap.aircraft_count,
+      snap.revision);
+
+  for (uint8_t i = 0; i < snap.aircraft_count && n > 0 && static_cast<size_t>(n) + 400 < kCap;
+       ++i) {
+    const Aircraft& a = snap.aircraft[i];
+    char call[16]{};
+    char reg[16]{};
+    char type[64]{};
+    char owner[64]{};
+    json_escape(a.callsign, call, sizeof(call));
+    json_escape(a.registration, reg, sizeof(reg));
+    json_escape(a.type, type, sizeof(type));
+    json_escape(a.owner, owner, sizeof(owner));
+    n += snprintf(
+        json + n, kCap - static_cast<size_t>(n),
+        "%s{"
+        "\"icao\":%u,"
+        "\"callsign\":\"%s\","
+        "\"registration\":\"%s\","
+        "\"type\":\"%s\","
+        "\"owner\":\"%s\","
+        "\"altitude_ft\":%d,"
+        "\"speed_kts\":%d,"
+        "\"heading_deg\":%d,"
+        "\"vertical_rate_fpm\":%d,"
+        "\"latitude\":%.5f,"
+        "\"longitude\":%.5f,"
+        "\"signal_dbfs\":%.1f,"
+        "\"has_callsign\":%s,"
+        "\"has_altitude\":%s,"
+        "\"has_speed\":%s,"
+        "\"has_heading\":%s,"
+        "\"has_vertical_rate\":%s,"
+        "\"has_position\":%s,"
+        "\"messages\":%u,"
+        "\"age_ms\":%u"
+        "}",
+        i ? "," : "", a.icao, call, reg, type, owner, a.altitude_ft, a.speed_kts,
+        a.heading_deg, a.vertical_rate_fpm, static_cast<double>(a.latitude),
+        static_cast<double>(a.longitude), static_cast<double>(a.signal_dbfs),
+        a.has_callsign ? "true" : "false", a.has_altitude ? "true" : "false",
+        a.has_speed ? "true" : "false", a.has_heading ? "true" : "false",
+        a.has_vertical_rate ? "true" : "false", a.has_position ? "true" : "false",
+        a.messages, a.age_ms);
+  }
+
+  if (n > 0 && static_cast<size_t>(n) + 32 < kCap) {
+    n += snprintf(json + n, kCap - static_cast<size_t>(n),
+                  "]},"
+                  "\"fm\":{"
+                  "\"signal_dbfs\":%.1f,"
+                  "\"pcm_underruns\":%u,"
+                  "\"pcm_overruns\":%u,"
+                  "\"pcm_available\":%u,"
+                  "\"pcm_sequence\":%u,"
+                  "\"pcm_rate_hz\":%u,"
+                  "\"spectrum\":[",
+                  static_cast<double>(snap.fm_signal_dbfs), snap.pcm_underruns,
+                  snap.pcm_overruns, snap.pcm_available, snap.pcm_sequence,
+                  static_cast<unsigned>(orcsdr::fm::kPcmRateHz));
+  }
+  const uint8_t bins = snap.fm_spectrum_bins ? snap.fm_spectrum_bins : 64;
+  for (uint8_t i = 0; i < bins && n > 0 && static_cast<size_t>(n) + 24 < kCap; ++i) {
+    n += snprintf(json + n, kCap - static_cast<size_t>(n), "%s%.4f", i ? "," : "",
+                  static_cast<double>(snap.fm_spectrum[i]));
+  }
+  if (n > 0 && static_cast<size_t>(n) + 8 < kCap) {
+    n += snprintf(json + n, kCap - static_cast<size_t>(n), "]}}");
+  }
+
+  server.sendHeader("Cache-Control", "no-store");
+  server.sendHeader("Access-Control-Allow-Origin", "*");
+  server.send(200, "application/json", json);
+  free(json);
+}
+
+void handle_fm_page() {
+  server.sendHeader("Cache-Control", "no-store");
+  server.send(200, "text/html", kWebUiFmHtml);
+}
+
+void handle_audio() {
+  size_t max_samples = 4096;
+  if (server.hasArg("max")) {
+    max_samples = static_cast<size_t>(constrain(server.arg("max").toInt(), 256, 8192));
+  }
+  int16_t* pcm = static_cast<int16_t*>(malloc(max_samples * sizeof(int16_t)));
+  if (!pcm) {
+    server.send(500, "text/plain", "oom");
+    return;
+  }
+  const size_t count = orcsdr::fm::pull_pcm(pcm, max_samples);
+  const size_t bytes = 16 + count * sizeof(int16_t);
+  uint8_t* packet = static_cast<uint8_t*>(malloc(bytes));
+  if (!packet) {
+    free(pcm);
+    server.send(500, "text/plain", "oom");
+    return;
+  }
+  packet[0] = 'P';
+  packet[1] = 'C';
+  packet[2] = 'M';
+  packet[3] = '1';
+  auto put_u32 = [](uint8_t* p, uint32_t v) {
+    p[0] = static_cast<uint8_t>(v & 0xff);
+    p[1] = static_cast<uint8_t>((v >> 8) & 0xff);
+    p[2] = static_cast<uint8_t>((v >> 16) & 0xff);
+    p[3] = static_cast<uint8_t>((v >> 24) & 0xff);
+  };
+  put_u32(packet + 4, orcsdr::fm::kPcmRateHz);
+  put_u32(packet + 8, orcsdr::fm::pcm_sequence());
+  put_u32(packet + 12, static_cast<uint32_t>(count));
+  if (count) std::memcpy(packet + 16, pcm, count * sizeof(int16_t));
+  free(pcm);
+
+  server.sendHeader("Cache-Control", "no-store");
+  server.sendHeader("Access-Control-Allow-Origin", "*");
+  server.setContentLength(bytes);
+  server.send(200, "application/octet-stream", "");
+  server.sendContent(reinterpret_cast<const char*>(packet), bytes);
+  free(packet);
+}
+
+void handle_location() {
+  if (server.method() != HTTP_POST) {
+    server.send(405, "text/plain", "POST only");
+    return;
+  }
+  const String body = server.arg("plain");
+  /* Minimal parse: "latitude":1.2, "longitude":-3.4, "radar_range_nm":25 */
+  double lat = 0, lon = 0;
+  int range = 25;
+  const char* s = body.c_str();
+  const char* p = strstr(s, "\"latitude\"");
+  if (p) lat = strtod(strchr(p, ':') + 1, nullptr);
+  p = strstr(s, "\"longitude\"");
+  if (p) lon = strtod(strchr(p, ':') + 1, nullptr);
+  p = strstr(s, "\"radar_range_nm\"");
+  if (p) range = atoi(strchr(p, ':') + 1);
+  const bool ok = lat >= -90.0 && lat <= 90.0 && lon >= -180.0 && lon <= 180.0 && range >= 5 &&
+                  range <= 250;
+  if (!ok) {
+    server.send(400, "application/json", "{\"ok\":false}");
+    return;
+  }
+  set_receiver_location(true, lat, lon, static_cast<uint16_t>(range));
+  Serial.printf("WEB_LOCATION lat=%.7f lon=%.7f range_nm=%d\n", lat, lon, range);
+  server.send(200, "application/json", "{\"ok\":true}");
+}
+
+/* Mode changes are requested via a one-slot flag read by main. */
+volatile uint8_t g_mode_request = 0;  // 0=none, 1=ADSB, 2=FM, 3=WX
+volatile uint32_t g_freq_request_hz = 0;
+
+void handle_mode() {
+  if (server.method() != HTTP_POST) {
+    server.send(405, "text/plain", "POST only");
+    return;
+  }
+  const String body = server.arg("plain");
+  if (body.indexOf("ADSB") >= 0) g_mode_request = 1;
+  else if (body.indexOf("\"FM\"") >= 0 || body.indexOf(":\"FM") >= 0) g_mode_request = 2;
+  else if (body.indexOf("WX") >= 0) g_mode_request = 3;
+  else {
+    server.send(400, "application/json", "{\"ok\":false}");
+    return;
+  }
+  Serial.printf("WEB_MODE_REQUEST id=%u\n", g_mode_request);
+  server.send(200, "application/json", "{\"ok\":true}");
+}
+
+void handle_freq() {
+  if (server.method() != HTTP_POST) {
+    server.send(405, "text/plain", "POST only");
+    return;
+  }
+  const String body = server.arg("plain");
+  const char* p = strstr(body.c_str(), "frequency_hz");
+  if (!p) {
+    server.send(400, "application/json", "{\"ok\":false}");
+    return;
+  }
+  const char* colon = strchr(p, ':');
+  if (!colon) {
+    server.send(400, "application/json", "{\"ok\":false}");
+    return;
+  }
+  const uint32_t hz = static_cast<uint32_t>(strtoul(colon + 1, nullptr, 10));
+  if (hz < RTL_SDR_V4_ESP_FREQ_MIN_HZ || hz > RTL_SDR_V4_ESP_FREQ_MAX_HZ) {
+    server.send(400, "application/json", "{\"ok\":false}");
+    return;
+  }
+  g_freq_request_hz = hz;
+  Serial.printf("WEB_FREQ_REQUEST frequency_hz=%u\n", hz);
+  server.send(200, "application/json", "{\"ok\":true}");
+}
+
+/* 1=start, 2=stop */
+volatile uint8_t g_stream_request = 0;
+
+void handle_stream_control() {
+  if (server.method() != HTTP_POST) {
+    server.send(405, "text/plain", "POST only");
+    return;
+  }
+  const String body = server.arg("plain");
+  if (body.indexOf("start") >= 0 || body.indexOf("START") >= 0) g_stream_request = 1;
+  else if (body.indexOf("stop") >= 0 || body.indexOf("STOP") >= 0) g_stream_request = 2;
+  else {
+    server.send(400, "application/json", "{\"ok\":false}");
+    return;
+  }
+  Serial.printf("WEB_STREAM_REQUEST id=%u\n", g_stream_request);
+  server.send(200, "application/json", "{\"ok\":true}");
+}
+
+void handle_not_found() { server.send(404, "text/plain", "not found"); }
+
+void start_http_if_needed() {
+  if (http_started) return;
+  server.on("/", HTTP_GET, handle_root);
+  server.on("/index.html", HTTP_GET, handle_root);
+  server.on("/fm", HTTP_GET, handle_fm_page);
+  server.on("/fm.html", HTTP_GET, handle_fm_page);
+  server.on("/api/state", HTTP_GET, handle_state);
+  server.on("/api/audio", HTTP_GET, handle_audio);
+  server.on("/api/location", HTTP_POST, handle_location);
+  server.on("/api/mode", HTTP_POST, handle_mode);
+  server.on("/api/freq", HTTP_POST, handle_freq);
+  server.on("/api/stream", HTTP_POST, handle_stream_control);
+  server.onNotFound(handle_not_found);
+  server.begin();
+  http_started = true;
+  Serial.println("HTTP_SERVER started port=80 paths=/ /fm /api/state /api/audio /api/stream");
+}
+
+}  // namespace
+
+uint8_t take_mode_request() {
+  const uint8_t v = g_mode_request;
+  g_mode_request = 0;
+  return v;
+}
+
+uint32_t take_freq_request() {
+  const uint32_t v = g_freq_request_hz;
+  g_freq_request_hz = 0;
+  return v;
+}
+
+uint8_t take_stream_request() {
+  const uint8_t v = g_stream_request;
+  g_stream_request = 0;
+  return v;
+}
+
+bool begin_network_and_http() {
+  Network.onEvent(on_network_event);
+  eth_started = ETH.begin(ETH_PHY_IP101, kEthernetPhyAddress, kEthernetMdc, kEthernetMdio,
+                          kEthernetReset, EMAC_CLK_EXT_IN);
+  Serial.printf("ETH_INIT started=%s phy=IP101 mdc=%d mdio=%d reset=%d\n",
+                eth_started ? "true" : "false", kEthernetMdc, kEthernetMdio, kEthernetReset);
+  return eth_started;
+}
+
+void poll_network_and_http() {
+  if (evt_lost) {
+    evt_lost = false;
+    eth_link = false;
+    eth_has_ip = false;
+    strlcpy(ip_text, "0.0.0.0", sizeof(ip_text));
+    Serial.println("ETH_STATUS link=false");
+  }
+  if (evt_link) {
+    evt_link = false;
+    eth_link = true;
+    Serial.println("ETH_STATUS link=true dhcp=pending");
+  }
+  if (evt_ip) {
+    evt_ip = false;
+    eth_link = true;
+    eth_has_ip = true;
+    const IPAddress ip = ETH.localIP();
+    snprintf(ip_text, sizeof(ip_text), "%u.%u.%u.%u", ip[0], ip[1], ip[2], ip[3]);
+    Serial.printf("ETH_STATUS link=true ip=%s speed_mbps=%u\n", ip_text, ETH.linkSpeed());
+    start_http_if_needed();
+  }
+
+  if (http_started) server.handleClient();
+}
+
+const char* local_ip() { return ip_text; }
+bool ethernet_link_up() { return eth_link; }
+bool http_ready() { return http_started && eth_has_ip; }
+
+}  // namespace orcsdr::web

--- a/apps/orcsdr-waveshare/src/web_server.hpp
+++ b/apps/orcsdr-waveshare/src/web_server.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+
+namespace orcsdr::web {
+
+/** Start Ethernet (Waveshare IP101 defaults) and HTTP server on port 80. */
+bool begin_network_and_http();
+
+/** Poll DHCP/events and HTTP clients — call from loop(). */
+void poll_network_and_http();
+
+/** Current DHCP address or "0.0.0.0". */
+const char* local_ip();
+
+bool ethernet_link_up();
+bool http_ready();
+
+/** Non-zero once: 1=ADSB, 2=FM, 3=WX. Cleared on read. */
+uint8_t take_mode_request();
+
+/** Non-zero frequency request in Hz; 0 if none. Cleared on read. */
+uint32_t take_freq_request();
+
+/** Non-zero once: 1=start stream, 2=stop stream. Cleared on read. */
+uint8_t take_stream_request();
+
+}  // namespace orcsdr::web

--- a/apps/orcsdr-waveshare/src/web_ui_fm.h
+++ b/apps/orcsdr-waveshare/src/web_ui_fm.h
@@ -1,0 +1,546 @@
+#pragma once
+
+/* FM radio station UI: PCM audio + live scope + RF waterfall. */
+static const char kWebUiFmHtml[] = R"HTML(<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>OrcSDR FM Radio</title>
+<style>
+:root{
+  --bg:#07090c; --panel:#101820; --panel2:#0c141c; --line:#243040;
+  --cyan:#3de0ff; --amber:#ffb020; --lime:#8cff2e;
+  --text:#e8eef6; --muted:#8b97a8; --danger:#ff4d6a;
+}
+*{box-sizing:border-box}
+body{margin:0;min-height:100vh;background:
+  radial-gradient(1200px 600px at 10% -10%,#123 0%,transparent 50%),
+  radial-gradient(900px 500px at 100% 0%,#1a1020 0%,transparent 45%),
+  var(--bg);color:var(--text);
+  font-family:"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif}
+a{color:var(--cyan);text-decoration:none}
+.shell{max-width:1200px;margin:0 auto;padding:18px 18px 40px}
+.top{display:flex;flex-wrap:wrap;gap:12px 20px;align-items:center;margin-bottom:16px}
+.brand{font-size:28px;font-weight:800;letter-spacing:.04em}
+.brand span{color:var(--cyan)}
+.pill{border:1px solid var(--line);background:var(--panel);border-radius:999px;
+  padding:6px 12px;color:var(--muted);font-size:13px}
+.pill.on{color:var(--lime);border-color:#3a6}
+.grid{display:grid;grid-template-columns:1.35fr .85fr;gap:16px}
+@media(max-width:960px){.grid{grid-template-columns:1fr}}
+.card{background:linear-gradient(180deg,var(--panel),var(--panel2));
+  border:1px solid var(--line);border-radius:18px;padding:18px}
+h2{margin:0 0 10px;font-size:12px;letter-spacing:.14em;color:var(--muted);font-weight:700}
+.freq{font-size:clamp(42px,8vw,72px);font-weight:800;line-height:1;
+  font-variant-numeric:tabular-nums;text-shadow:0 0 30px rgba(61,224,255,.35)}
+.freq small{font-size:.4em;color:var(--cyan);margin-left:8px}
+.meta{display:flex;flex-wrap:wrap;gap:10px 18px;margin:10px 0 14px;color:var(--muted)}
+.meta b{color:var(--text);font-weight:600}
+.dial-row{display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+button,input[type=range]{accent-color:var(--cyan)}
+button{border:1px solid var(--line);background:#15202b;color:var(--text);
+  border-radius:12px;padding:10px 14px;font:inherit;cursor:pointer}
+button.primary{background:linear-gradient(135deg,#1b6,#0a4);border-color:#5d5}
+button.danger{background:linear-gradient(135deg,#622,#300);border-color:var(--danger)}
+button:disabled{opacity:.5;cursor:wait}
+input[type=number]{background:#0b121a;border:1px solid var(--line);color:var(--text);
+  border-radius:10px;padding:10px 12px;width:140px;font-size:16px}
+.stations{display:grid;grid-template-columns:repeat(auto-fill,minmax(140px,1fr));gap:8px;max-height:360px;overflow:auto}
+.station{text-align:left;padding:12px;border-radius:12px;background:#0d1620;border:1px solid var(--line)}
+.station.active{border-color:var(--cyan);box-shadow:inset 0 0 0 1px var(--cyan)}
+.station .mhz{font-size:18px;font-weight:700;color:var(--cyan)}
+.station .name{font-size:12px;color:var(--muted);margin-top:4px}
+.viz{display:grid;gap:10px;margin-top:8px}
+canvas{width:100%;display:block;background:#060a10;border-radius:12px;border:1px solid var(--line)}
+#scope{height:110px}
+#waterfall{height:180px}
+.eq{display:grid;gap:10px}
+.eq label{display:flex;justify-content:space-between;font-size:13px;color:var(--muted)}
+.eq input{width:100%}
+.vu{height:14px;background:#0a1018;border-radius:8px;overflow:hidden;border:1px solid var(--line)}
+.vu>i{display:block;height:100%;width:0;background:linear-gradient(90deg,var(--lime),var(--amber),var(--danger));transition:width .08s linear}
+.row{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+.foot{margin-top:14px;color:var(--muted);font-size:12px}
+#statusMsg{min-height:1.2em;color:var(--amber);font-size:13px;margin-top:8px}
+</style>
+</head>
+<body>
+<div class="shell">
+  <div class="top">
+    <div class="brand">OrcSDR <span>FM</span></div>
+    <div id="livePill" class="pill">STREAM OFF</div>
+    <div id="ipPill" class="pill">IP -</div>
+    <div id="audioPill" class="pill">AUDIO OFF</div>
+    <a class="pill" href="/">ADS-B DASHBOARD</a>
+  </div>
+
+  <div class="grid">
+    <section class="card">
+      <h2>ON AIR</h2>
+      <div class="freq"><span id="freq">96.1</span><small>MHz</small></div>
+      <div class="meta">
+        <div>Station <b id="stationName">—</b></div>
+        <div>Signal <b id="sig">-90.0</b> dBFS</div>
+        <div>SPS <b id="sps">0</b></div>
+        <div>PCM queue <b id="pcmQ">0</b></div>
+        <div>Chunk <b id="buf">0</b> ms</div>
+      </div>
+
+      <div class="viz">
+        <div>
+          <h2>SCOPE (audio / RF level)</h2>
+          <canvas id="scope"></canvas>
+          <div class="vu" style="margin-top:8px"><i id="vuBar"></i></div>
+        </div>
+        <div>
+          <h2>WATERFALL (RF spectrum history)</h2>
+          <canvas id="waterfall"></canvas>
+        </div>
+      </div>
+
+      <div class="dial-row" style="margin-top:16px">
+        <button id="btnDown">− 0.2</button>
+        <input id="freqIn" type="number" min="88" max="108" step="0.1" value="96.1"/>
+        <button id="btnUp">+ 0.2</button>
+        <button id="btnTune" class="primary">TUNE</button>
+        <button id="btnPlay" class="primary">▶ PLAY</button>
+        <button id="btnStop" class="danger">■ STOP</button>
+      </div>
+      <div id="statusMsg"></div>
+      <div class="foot">Device demodulates FM to 48 kHz PCM over Ethernet. Browser plays audio and draws scope + waterfall.
+      Click <b>PLAY</b> once (browsers require a user gesture for sound).</div>
+    </section>
+
+    <section class="card">
+      <h2>STATIONS</h2>
+      <div class="stations" id="stations"></div>
+      <div class="row" style="margin-top:12px">
+        <input id="newName" placeholder="Label" style="flex:1;min-width:100px;background:#0b121a;border:1px solid var(--line);color:var(--text);border-radius:10px;padding:10px"/>
+        <button id="btnAdd">ADD CURRENT</button>
+      </div>
+    </section>
+  </div>
+
+  <section class="card" style="margin-top:16px">
+    <h2>BROWSER DSP RACK</h2>
+    <div class="grid" style="grid-template-columns:repeat(auto-fit,minmax(220px,1fr))">
+      <div class="eq">
+        <label>Volume <span id="volLbl">0.90</span></label>
+        <input id="vol" type="range" min="0" max="1.5" step="0.01" value="0.9"/>
+        <label>Bass <span id="bassLbl">2 dB</span></label>
+        <input id="bass" type="range" min="-12" max="12" step="0.5" value="2"/>
+        <label>Mid <span id="midLbl">0 dB</span></label>
+        <input id="mid" type="range" min="-12" max="12" step="0.5" value="0"/>
+        <label>Treble <span id="trebleLbl">1 dB</span></label>
+        <input id="treble" type="range" min="-12" max="12" step="0.5" value="1"/>
+      </div>
+      <div class="eq">
+        <label>Compressor threshold <span id="thrLbl">-24 dB</span></label>
+        <input id="thr" type="range" min="-60" max="0" step="1" value="-24"/>
+        <label>Presence (2.8 kHz) <span id="presLbl">3 dB</span></label>
+        <input id="pres" type="range" min="-12" max="12" step="0.5" value="3"/>
+        <label>Stereo width <span id="widthLbl">0.30</span></label>
+        <input id="width" type="range" min="0" max="1" step="0.01" value="0.3"/>
+        <label>Noise gate <span id="gateLbl">-55 dB</span></label>
+        <input id="gate" type="range" min="-80" max="-20" step="1" value="-55"/>
+      </div>
+    </div>
+  </section>
+</div>
+
+<script>
+const DEFAULT_STATIONS = [
+  {name:'Preset A', mhz:88.5},{name:'Preset B', mhz:91.7},
+  {name:'Preset C', mhz:94.9},{name:'KZEL-ish', mhz:96.1},
+  {name:'Preset D', mhz:98.5},{name:'Preset E', mhz:101.3},
+  {name:'Preset F', mhz:104.7},{name:'Preset G', mhz:107.7},
+];
+
+const state = {
+  playing: false,
+  streaming: false,
+  freqHz: 96100000,
+  stations: JSON.parse(localStorage.getItem('orcsdr_fm_stations')||'null') || DEFAULT_STATIONS,
+  audioCtx: null,
+  nodes: null,
+  nextTime: 0,
+  audioTimer: null,
+  uiTimer: null,
+  lastSpectrum: new Array(64).fill(0),
+  waterfall: null, // ImageData rows
+  lastPcm: null,
+};
+
+const $ = id => document.getElementById(id);
+const mhzOf = hz => (hz/1e6).toFixed(1);
+const saveStations = () => localStorage.setItem('orcsdr_fm_stations', JSON.stringify(state.stations));
+const setMsg = t => { $('statusMsg').textContent = t || ''; };
+
+async function postJson(url, obj){
+  const r = await fetch(url, {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
+    body: JSON.stringify(obj)
+  });
+  if(!r.ok) throw new Error(url+' '+r.status);
+  return r.json().catch(()=>({}));
+}
+
+function renderStations(){
+  const root = $('stations');
+  root.innerHTML = '';
+  state.stations.forEach(s=>{
+    const b = document.createElement('button');
+    b.className = 'station' + (Math.abs(s.mhz*1e6 - state.freqHz)<1000 ? ' active':'');
+    b.innerHTML = `<div class="mhz">${s.mhz.toFixed(1)}</div><div class="name">${s.name}</div>`;
+    b.onclick = ()=> tuneTo(Math.round(s.mhz*1e6), s.name);
+    root.appendChild(b);
+  });
+}
+
+function ensureAudio(){
+  if (state.audioCtx) return state.audioCtx;
+  const AC = window.AudioContext || window.webkitAudioContext;
+  const ctx = new AC({sampleRate:48000});
+  const input = ctx.createGain();
+  const bass = ctx.createBiquadFilter(); bass.type='lowshelf'; bass.frequency.value=120;
+  const mid = ctx.createBiquadFilter(); mid.type='peaking'; mid.frequency.value=1000; mid.Q.value=0.9;
+  const presence = ctx.createBiquadFilter(); presence.type='peaking'; presence.frequency.value=2800; presence.Q.value=1.1;
+  const treble = ctx.createBiquadFilter(); treble.type='highshelf'; treble.frequency.value=6500;
+  const comp = ctx.createDynamicsCompressor();
+  comp.threshold.value=-24; comp.knee.value=18; comp.ratio.value=3.5;
+  comp.attack.value=0.008; comp.release.value=0.18;
+  const delay = ctx.createDelay(0.03); delay.delayTime.value=0.012;
+  const width = ctx.createGain(); width.gain.value=0.3;
+  const dry = ctx.createGain(); dry.gain.value=1;
+  const master = ctx.createGain(); master.gain.value=0.9;
+  const analyser = ctx.createAnalyser(); analyser.fftSize=2048;
+
+  input.connect(bass); bass.connect(mid); mid.connect(presence); presence.connect(treble);
+  treble.connect(comp); comp.connect(dry); dry.connect(master);
+  treble.connect(delay); delay.connect(width); width.connect(master);
+  master.connect(analyser); analyser.connect(ctx.destination);
+
+  state.audioCtx = ctx;
+  state.nodes = {input,bass,mid,presence,treble,comp,width,master,analyser,delay};
+  applyEq();
+  return ctx;
+}
+
+function applyEq(){
+  if(!state.nodes) return;
+  const n = state.nodes;
+  n.master.gain.value = +$('vol').value;
+  n.bass.gain.value = +$('bass').value;
+  n.mid.gain.value = +$('mid').value;
+  n.presence.gain.value = +$('pres').value;
+  n.treble.gain.value = +$('treble').value;
+  n.comp.threshold.value = +$('thr').value;
+  n.width.gain.value = +$('width').value;
+  $('volLbl').textContent = (+$('vol').value).toFixed(2);
+  $('bassLbl').textContent = $('bass').value+' dB';
+  $('midLbl').textContent = $('mid').value+' dB';
+  $('trebleLbl').textContent = $('treble').value+' dB';
+  $('presLbl').textContent = $('pres').value+' dB';
+  $('thrLbl').textContent = $('thr').value+' dB';
+  $('widthLbl').textContent = (+$('width').value).toFixed(2);
+  $('gateLbl').textContent = $('gate').value+' dB';
+}
+
+function sizeCanvas(c, cssH){
+  const dpr = devicePixelRatio || 1;
+  const w = Math.max(100, c.clientWidth|0);
+  const h = cssH || c.clientHeight || 110;
+  if (c.width !== (w*dpr|0) || c.height !== (h*dpr|0)) {
+    c.width = w*dpr|0;
+    c.height = h*dpr|0;
+  }
+  const g = c.getContext('2d');
+  g.setTransform(dpr,0,0,dpr,0,0);
+  return {g, w, h};
+}
+
+function drawScopeFromPcm(int16){
+  const {g,w,h} = sizeCanvas($('scope'), 110);
+  g.fillStyle = '#060a10'; g.fillRect(0,0,w,h);
+  g.strokeStyle = '#1b2a3a';
+  for(let i=0;i<3;i++){ g.beginPath(); g.moveTo(0,h*(i+1)/4); g.lineTo(w,h*(i+1)/4); g.stroke(); }
+  if(!int16 || !int16.length){
+    g.fillStyle='#8b97a8'; g.font='12px sans-serif';
+    g.fillText(state.streaming ? 'waiting for PCM…' : 'RF stream off — press PLAY', 12, 20);
+    return;
+  }
+  g.strokeStyle = '#3de0ff'; g.lineWidth=2; g.beginPath();
+  const step = Math.max(1, (int16.length / w)|0);
+  for(let x=0,i=0; x<w; x++, i+=step){
+    const v = int16[Math.min(i,int16.length-1)] / 32768;
+    const y = h*0.5 - v*h*0.42;
+    if(x===0) g.moveTo(x,y); else g.lineTo(x,y);
+  }
+  g.stroke();
+  let peak=0; for(let i=0;i<int16.length;i++) peak=Math.max(peak, Math.abs(int16[i]));
+  $('vuBar').style.width = Math.min(100, peak/32768*130)+'%';
+}
+
+function drawScopeFromSpectrum(bins){
+  const {g,w,h} = sizeCanvas($('scope'), 110);
+  g.fillStyle = '#060a10'; g.fillRect(0,0,w,h);
+  if(!bins || !bins.length){
+    g.fillStyle='#8b97a8'; g.font='12px sans-serif';
+    g.fillText('no spectrum yet', 12, 20);
+    return;
+  }
+  let peak = 1e-9; for(const v of bins) peak=Math.max(peak,v);
+  const bw = w/bins.length;
+  for(let i=0;i<bins.length;i++){
+    const bh = (bins[i]/peak)*(h-6);
+    g.fillStyle = i%2 ? '#3de0ff' : '#1faa66';
+    g.fillRect(i*bw, h-bh, Math.max(1,bw-1), bh);
+  }
+  // if not playing, VU from spectrum energy
+  if(!state.playing){
+    const e = bins.reduce((a,b)=>a+b,0)/bins.length;
+    $('vuBar').style.width = Math.min(100, Math.sqrt(e)*80)+'%';
+  }
+}
+
+function colorMap(t){
+  // t 0..1 -> blue/cyan/green/yellow/red
+  const x = Math.max(0, Math.min(1, t));
+  const r = Math.min(255, Math.floor(x*3*255));
+  const g = Math.min(255, Math.floor((x>0.3? (x-0.3)*2.2 : 0)*255));
+  const b = Math.min(255, Math.floor((1-x)*220 + 40));
+  return [r,g,b,255];
+}
+
+function pushWaterfall(bins){
+  const c = $('waterfall');
+  const dpr = devicePixelRatio || 1;
+  const w = Math.max(100, c.clientWidth|0);
+  const h = 180;
+  if (c.width !== (w*dpr|0) || c.height !== (h*dpr|0)) {
+    c.width = w*dpr|0; c.height = h*dpr|0;
+    state.waterfall = null;
+  }
+  const g = c.getContext('2d');
+  // scroll up by 1 CSS pixel
+  g.setTransform(dpr,0,0,dpr,0,0);
+  g.drawImage(c, 0, dpr, c.width, c.height-dpr, 0, 0, w, h-1);
+
+  if(!bins || !bins.length){
+    g.fillStyle = '#060a10';
+    g.fillRect(0, h-1, w, 1);
+    return;
+  }
+  let peak = 1e-9; for(const v of bins) peak=Math.max(peak,v);
+  // log-ish scale
+  const row = g.createImageData(w, 1);
+  for(let x=0;x<w;x++){
+    const i = Math.min(bins.length-1, (x * bins.length / w)|0);
+    const lin = bins[i] / peak;
+    const t = Math.min(1, Math.log10(1 + lin*9));
+    const [r,gv,b,a] = colorMap(t);
+    const o = x*4;
+    row.data[o]=r; row.data[o+1]=gv; row.data[o+2]=b; row.data[o+3]=a;
+  }
+  // putImageData ignores current transform — write in device pixels at bottom
+  const bottom = c.height - dpr;
+  // scale row to device width
+  const big = g.createImageData(c.width, dpr);
+  for(let y=0;y<dpr;y++){
+    for(let x=0;x<c.width;x++){
+      const src = ((x/dpr)|0)*4;
+      const dst = (y*c.width + x)*4;
+      big.data[dst]=row.data[src];
+      big.data[dst+1]=row.data[src+1];
+      big.data[dst+2]=row.data[src+2];
+      big.data[dst+3]=255;
+    }
+  }
+  g.setTransform(1,0,0,1,0,0);
+  g.putImageData(big, 0, bottom);
+}
+
+async function ensureFmStream(){
+  setMsg('Starting FM stream…');
+  await postJson('/api/mode', {mode:'FM'});
+  await postJson('/api/freq', {frequency_hz: state.freqHz});
+  await postJson('/api/stream', {action:'start'});
+  // wait until streaming + pcm
+  for(let i=0;i<20;i++){
+    await new Promise(r=>setTimeout(r,200));
+    const j = await (await fetch('/api/state',{cache:'no-store'})).json();
+    if(j.mode==='FM' && j.streaming){
+      setMsg('FM stream live');
+      return true;
+    }
+  }
+  setMsg('FM stream did not start — check RTL USB (lower-left by Ethernet)');
+  return false;
+}
+
+async function tuneTo(hz, name){
+  hz = Math.max(88e6, Math.min(108e6, hz));
+  state.freqHz = hz;
+  $('freq').textContent = mhzOf(hz);
+  $('freqIn').value = mhzOf(hz);
+  if(name) $('stationName').textContent = name;
+  else {
+    const hit = state.stations.find(s => Math.abs(s.mhz*1e6 - hz)<1000);
+    $('stationName').textContent = hit ? hit.name : 'Manual';
+  }
+  renderStations();
+  try{
+    await postJson('/api/mode', {mode:'FM'});
+    await postJson('/api/freq', {frequency_hz: hz});
+    if(!state.streaming) await postJson('/api/stream', {action:'start'});
+    setMsg('Tuned '+mhzOf(hz)+' MHz');
+  }catch(e){ setMsg('Tune failed: '+e.message); }
+}
+
+function schedulePcm(int16, rate){
+  const ctx = ensureAudio();
+  if(ctx.state === 'suspended') ctx.resume();
+  const gateDb = +$('gate').value;
+  const gateLin = Math.pow(10, gateDb/20);
+  const f32 = new Float32Array(int16.length);
+  for(let i=0;i<int16.length;i++){
+    let v = int16[i]/32768;
+    if (Math.abs(v) < gateLin) v *= 0.12;
+    f32[i]=v;
+  }
+  const audioBuf = ctx.createBuffer(1, f32.length, rate||48000);
+  audioBuf.copyToChannel(f32, 0);
+  const src = ctx.createBufferSource();
+  src.buffer = audioBuf;
+  src.connect(state.nodes.input);
+  const now = ctx.currentTime;
+  // keep ~80–250 ms jitter buffer
+  if(state.nextTime < now + 0.06) state.nextTime = now + 0.12;
+  if(state.nextTime > now + 0.45){
+    // too far ahead — drop this chunk
+    return;
+  }
+  src.start(state.nextTime);
+  state.nextTime += audioBuf.duration;
+}
+
+async function pullAudio(){
+  if(!state.playing) return;
+  try{
+    const r = await fetch('/api/audio?max=4800', {cache:'no-store'});
+    if(!r.ok){ setMsg('audio HTTP '+r.status); return; }
+    const buf = await r.arrayBuffer();
+    if(buf.byteLength < 16) return;
+    const view = new DataView(buf);
+    const magic = String.fromCharCode(view.getUint8(0),view.getUint8(1),view.getUint8(2),view.getUint8(3));
+    if(magic !== 'PCM1'){ setMsg('bad audio magic'); return; }
+    const rate = view.getUint32(4, true);
+    const count = view.getUint32(12, true);
+    if(count <= 0){
+      $('buf').textContent = '0';
+      return;
+    }
+    const samples = new Int16Array(buf, 16, count);
+    state.lastPcm = samples;
+    $('buf').textContent = Math.round(count/rate*1000);
+    schedulePcm(samples, rate);
+    drawScopeFromPcm(samples);
+  }catch(e){
+    setMsg('audio pull: '+e.message);
+  }
+}
+
+async function pollState(){
+  try{
+    const r = await fetch('/api/state',{cache:'no-store'});
+    const j = await r.json();
+    $('ipPill').textContent = 'IP '+(j.ip||'-');
+    $('sps').textContent = j.effective_sps||0;
+    state.streaming = !!(j.streaming && j.mode==='FM');
+    $('livePill').textContent = state.streaming ? 'FM LIVE' : ((j.mode||'IDLE')+' / RF OFF');
+    $('livePill').classList.toggle('on', state.streaming);
+    if(j.frequency_hz){
+      state.freqHz = j.frequency_hz;
+      $('freq').textContent = mhzOf(j.frequency_hz);
+    }
+    const fm = j.fm || {};
+    $('sig').textContent = (fm.signal_dbfs!=null ? fm.signal_dbfs : -90).toFixed(1);
+    $('pcmQ').textContent = fm.pcm_available||0;
+    if(Array.isArray(fm.spectrum) && fm.spectrum.length){
+      state.lastSpectrum = fm.spectrum;
+      pushWaterfall(fm.spectrum);
+      if(!state.playing) drawScopeFromSpectrum(fm.spectrum);
+    }
+  }catch(e){
+    setMsg('state: '+e.message);
+  }
+}
+
+async function startPlay(){
+  $('btnPlay').disabled = true;
+  try{
+    ensureAudio();
+    await state.audioCtx.resume();
+    const ok = await ensureFmStream();
+    if(!ok) return;
+    state.playing = true;
+    state.nextTime = 0;
+    $('audioPill').textContent = 'AUDIO ON';
+    $('audioPill').classList.add('on');
+    $('btnPlay').textContent = '● PLAYING';
+    if(state.audioTimer) clearInterval(state.audioTimer);
+    state.audioTimer = setInterval(pullAudio, 35);
+    setMsg('Playing — use volume if silent');
+  }catch(e){
+    setMsg('Play failed: '+e.message);
+  }finally{
+    $('btnPlay').disabled = false;
+  }
+}
+
+function stopPlay(){
+  state.playing = false;
+  if(state.audioTimer){ clearInterval(state.audioTimer); state.audioTimer=null; }
+  $('btnPlay').textContent = '▶ PLAY';
+  $('audioPill').textContent = 'AUDIO OFF';
+  $('audioPill').classList.remove('on');
+  if(state.audioCtx) state.audioCtx.suspend();
+  setMsg('Audio stopped (RF may still stream)');
+}
+
+$('btnPlay').onclick = startPlay;
+$('btnStop').onclick = stopPlay;
+$('btnTune').onclick = ()=> tuneTo(Math.round(parseFloat($('freqIn').value)*1e6));
+$('btnUp').onclick = ()=> tuneTo(state.freqHz + 200000);
+$('btnDown').onclick = ()=> tuneTo(state.freqHz - 200000);
+$('btnAdd').onclick = ()=>{
+  const name = $('newName').value.trim() || 'Preset';
+  state.stations.push({name, mhz: state.freqHz/1e6});
+  saveStations(); renderStations();
+};
+['vol','bass','mid','treble','pres','thr','width','gate'].forEach(id=>{
+  $(id).oninput = applyEq;
+});
+window.addEventListener('resize', ()=>{
+  if(state.lastPcm && state.playing) drawScopeFromPcm(state.lastPcm);
+  else drawScopeFromSpectrum(state.lastSpectrum);
+});
+
+renderStations();
+// boot: enter FM + start RF (no audio until PLAY)
+(async ()=>{
+  try{
+    await postJson('/api/mode', {mode:'FM'});
+    await postJson('/api/freq', {frequency_hz: state.freqHz});
+    await postJson('/api/stream', {action:'start'});
+    setMsg('RF starting — press PLAY for browser audio');
+  }catch(e){ setMsg(e.message); }
+  pollState();
+  state.uiTimer = setInterval(pollState, 200);
+})();
+</script>
+</body>
+</html>
+)HTML";

--- a/apps/orcsdr-waveshare/src/web_ui_page.h
+++ b/apps/orcsdr-waveshare/src/web_ui_page.h
@@ -1,0 +1,492 @@
+#pragma once
+
+/* Tab5 ADS-B dashboard look-alike served by OrcSDR Waveshare HTTP backend. */
+static const char kWebUiIndexHtml[] = R"HTML(<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>OrcSDR ADS-B</title>
+<style>
+:root{
+  --bg:#000000;
+  --panel:#0b1420;
+  --border:#2a3545;
+  --blue:#00a0ff;
+  --green:#6fe820;
+  --muted:#9ca3af;
+  --text:#f3f4f6;
+  --navy:#0b1f3a;
+  --maroon:#5a1020;
+  --card-radius:12px;
+}
+*{box-sizing:border-box}
+html,body{margin:0;padding:0;background:var(--bg);color:var(--text);
+  font-family:Inter,Segoe UI,Roboto,Helvetica,Arial,sans-serif;min-height:100%}
+body{display:flex;flex-direction:column;min-height:100vh}
+button{font:inherit;cursor:pointer;border:1px solid #9ca3af;border-radius:8px;
+  background:#1f2937;color:#fff;padding:8px 14px}
+button.active,button.primary{background:#14532d;border-color:#6fe820}
+button.danger{background:var(--maroon)}
+button.nav{background:transparent;border:none;color:#d1d5db;min-width:100px;padding:18px 12px}
+button.nav.active{background:#0b1f3a;color:var(--blue)}
+.header{display:flex;align-items:center;gap:18px;padding:14px 20px;
+  border-bottom:1px solid var(--border);flex-wrap:wrap}
+.header h1{margin:0;font-size:28px;font-weight:700;letter-spacing:.02em}
+.badge-live{display:inline-flex;align-items:center;gap:8px}
+.dot{width:12px;height:12px;border-radius:50%;background:var(--green);box-shadow:0 0 8px var(--green)}
+.dot.off{background:#6b7280;box-shadow:none}
+.muted{color:var(--muted)}
+.blue{color:var(--blue)}
+.green{color:var(--green)}
+.main{flex:1;padding:16px 18px 88px;display:grid;gap:16px}
+.tabs{position:fixed;left:0;right:0;bottom:0;display:grid;grid-template-columns:repeat(5,1fr);
+  background:#000;border-top:1px solid var(--border);z-index:20}
+.card{background:var(--panel);border:1px solid var(--border);border-radius:var(--card-radius);padding:16px}
+.layout-radar{display:grid;grid-template-columns:minmax(280px,1.2fr) minmax(260px,.9fr);gap:16px}
+.layout-list{display:grid;grid-template-columns:minmax(320px,1.4fr) minmax(240px,.8fr);gap:16px}
+.layout-stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}
+.layout-target,.layout-settings{display:grid;gap:16px}
+@media (max-width:900px){
+  .layout-radar,.layout-list{grid-template-columns:1fr}
+  .header h1{font-size:22px}
+}
+#radar{width:100%;height:min(62vh,560px);background:#071018;border-radius:10px;display:block}
+.summary h2{margin:0 0 8px;color:var(--green);font-size:28px}
+.summary .id{color:var(--muted);margin-bottom:12px}
+.kv{display:grid;grid-template-columns:1fr 1fr;gap:10px 16px;margin-top:12px}
+.kv label{display:block;color:var(--blue);font-size:12px;letter-spacing:.04em}
+.kv span{font-size:20px}
+.row{display:flex;align-items:center;gap:12px;padding:12px;border-radius:8px;cursor:pointer}
+.row:hover{background:#0f1a28}
+.row.selected{background:var(--navy)}
+.row .call{color:var(--green);font-weight:700}
+.plane-ico{width:18px;height:18px;color:var(--green)}
+.metric-big{font-size:34px;margin:8px 0 0}
+.bars{display:flex;align-items:flex-end;gap:6px;height:80px;margin-top:14px}
+.bars i{display:block;width:18px;background:var(--green);border-radius:2px 2px 0 0}
+.form-row{display:flex;flex-wrap:wrap;gap:10px;align-items:center;margin:10px 0}
+input{background:#0b1f3a;border:1px solid var(--border);color:#fff;border-radius:8px;
+  padding:10px 12px;min-width:160px}
+.hidden{display:none !important}
+.foot-note{color:var(--muted);font-size:13px;margin-top:8px}
+</style>
+</head>
+<body>
+<header class="header">
+  <h1>OrcSDR</h1>
+  <div class="blue" style="font-size:22px;font-weight:600">ADS-B 1090</div>
+  <div class="badge-live"><span id="liveDot" class="dot off"></span>
+    <button id="liveBtn" class="danger">DEMO</button></div>
+  <div><span id="acCount" style="font-size:18px">0 AIRCRAFT</span></div>
+  <div class="muted">MSG RATE <span id="msgRate" class="green">0.0/s</span></div>
+  <div class="muted">SPS <span id="sps">0</span></div>
+  <div class="muted">IP <span id="ip">-</span></div>
+  <div class="muted" id="statusLine">booting</div>
+  <a href="/fm" style="color:var(--green);margin-left:auto">FM RADIO →</a>
+</header>
+
+<main class="main">
+  <section id="view-radar" class="layout-radar">
+    <div class="card">
+      <canvas id="radar"></canvas>
+      <div class="foot-note" id="radarHint">Set receiver location in SETTINGS for range/bearing.</div>
+    </div>
+    <div class="card summary" id="radarSummary"></div>
+  </section>
+
+  <section id="view-list" class="layout-list hidden">
+    <div class="card" id="listBody"></div>
+    <div class="card summary" id="listSummary"></div>
+  </section>
+
+  <section id="view-target" class="layout-target hidden">
+    <div class="card summary" id="targetBody"></div>
+  </section>
+
+  <section id="view-stats" class="layout-stats hidden">
+    <div class="card"><div class="blue">SIGNAL STRENGTH</div>
+      <div class="metric-big" id="statSig">-90.0 dBFS</div>
+      <div class="bars" id="sigBars"></div></div>
+    <div class="card"><div class="blue">MESSAGE RATE</div>
+      <div class="metric-big green" id="statRate">0.0 msg/sec</div></div>
+    <div class="card"><div class="blue">MODE-S ACTIVITY</div>
+      <div class="metric-big" id="statMsg">0</div>
+      <div class="muted">total CRC-OK frames</div></div>
+    <div class="card"><div class="blue">AIRCRAFT</div>
+      <div class="metric-big" id="statAc">0</div></div>
+    <div class="card"><div class="blue">STREAM</div>
+      <div class="metric-big" id="statSps">0</div>
+      <div class="muted">effective SPS · drops <span id="statDrops">0</span></div></div>
+  </section>
+
+  <section id="view-settings" class="layout-settings hidden">
+    <div class="card">
+      <h2 class="blue" style="margin-top:0">ADS-B SETTINGS</h2>
+      <div class="form-row"><label class="muted">Receiver latitude</label>
+        <input id="lat" type="number" step="0.0000001" placeholder="e.g. 37.7749"/></div>
+      <div class="form-row"><label class="muted">Receiver longitude</label>
+        <input id="lon" type="number" step="0.0000001" placeholder="e.g. -122.4194"/></div>
+      <div class="form-row"><label class="muted">Radar range (NM)</label>
+        <input id="rangeNm" type="number" min="5" max="200" value="25"/>
+        <button class="primary" id="saveLoc">SAVE LOCATION</button></div>
+      <p class="foot-note">Location is stored in browser localStorage and sent to the device for radar geometry.
+      RF gain remains automatic (read-only), matching Tab5 ADS-B.</p>
+      <div class="form-row">
+        <button id="modeAdsb" class="primary">MODE ADSB</button>
+        <button id="modeFm">MODE FM</button>
+        <button id="modeWx">MODE WX</button>
+      </div>
+    </div>
+    <div class="card">
+      <div id="settingsSide" class="green" style="font-size:28px">LIVE RECEIVER</div>
+      <p class="muted" id="settingsDetail">1090 MHz Mode-S capture</p>
+      <p class="muted">USB host: lower-left Type-A next to Ethernet on Waveshare P4.</p>
+    </div>
+  </section>
+</main>
+
+<nav class="tabs">
+  <button class="nav active" data-view="radar">RADAR</button>
+  <button class="nav" data-view="list">LIST</button>
+  <button class="nav" data-view="target">TARGET</button>
+  <button class="nav" data-view="stats">STATS</button>
+  <button class="nav" data-view="settings">SETTINGS</button>
+</nav>
+
+<script>
+const state = {
+  view: 'radar',
+  selected: 0,
+  lockedIcao: 0,
+  data: null,
+};
+
+const views = ['radar','list','target','stats','settings'];
+const deg2rad = d => d * Math.PI / 180;
+
+function $(id){ return document.getElementById(id); }
+
+function loadLoc(){
+  try {
+    const j = JSON.parse(localStorage.getItem('orcsdr_rx')||'{}');
+    if (j.lat!=null) $('lat').value = j.lat;
+    if (j.lon!=null) $('lon').value = j.lon;
+    if (j.range!=null) $('rangeNm').value = j.range;
+  } catch(e){}
+}
+
+function haversineNm(lat1, lon1, lat2, lon2){
+  const R = 3440.065;
+  const dlat = deg2rad(lat2-lat1), dlon = deg2rad(lon2-lon1);
+  const a = Math.sin(dlat/2)**2 + Math.cos(deg2rad(lat1))*Math.cos(deg2rad(lat2))*Math.sin(dlon/2)**2;
+  return 2*R*Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+}
+function bearingDeg(lat1, lon1, lat2, lon2){
+  const y = Math.sin(deg2rad(lon2-lon1))*Math.cos(deg2rad(lat2));
+  const x = Math.cos(deg2rad(lat1))*Math.sin(deg2rad(lat2)) -
+            Math.sin(deg2rad(lat1))*Math.cos(deg2rad(lat2))*Math.cos(deg2rad(lon2-lon1));
+  return (Math.atan2(y,x)*180/Math.PI + 360) % 360;
+}
+
+function enrich(ac){
+  const lat = parseFloat($('lat').value);
+  const lon = parseFloat($('lon').value);
+  const rangeNm = parseFloat($('rangeNm').value)||25;
+  const locOk = Number.isFinite(lat) && Number.isFinite(lon);
+  if (ac.has_position && locOk){
+    ac.range_nm = haversineNm(lat, lon, ac.latitude, ac.longitude);
+    ac.bearing_deg = Math.round(bearingDeg(lat, lon, ac.latitude, ac.longitude));
+    ac.geometry = true;
+  } else {
+    ac.range_nm = null;
+    ac.bearing_deg = null;
+    ac.geometry = false;
+  }
+  ac.radar_range_nm = rangeNm;
+  return ac;
+}
+
+function aircraftList(){
+  const d = state.data;
+  if (!d || !d.aircraft) return [];
+  return d.aircraft.map(enrich);
+}
+
+function selectedAircraft(){
+  const list = aircraftList();
+  if (!list.length) return null;
+  if (state.lockedIcao){
+    const hit = list.find(a => a.icao === state.lockedIcao);
+    if (hit) return hit;
+  }
+  state.selected = Math.min(state.selected, list.length-1);
+  return list[state.selected];
+}
+
+function fmtIcao(v){ return (v>>>0).toString(16).toUpperCase().padStart(6,'0'); }
+function callOf(a){
+  if (a.has_callsign && a.callsign) return a.callsign;
+  if (a.registration) return a.registration;
+  return fmtIcao(a.icao);
+}
+
+function summaryHtml(a){
+  if (!a){
+    return `<h2 class="blue">SEARCHING</h2><p class="muted">No aircraft in the last 60 seconds</p>`;
+  }
+  const locked = state.lockedIcao === a.icao;
+  return `
+    <h2>${callOf(a)}</h2>
+    <div class="id">${a.registration||'--'} | ${fmtIcao(a.icao)}</div>
+    <div class="muted">${a.type||'--'}</div>
+    <div class="muted">${a.owner||''}</div>
+    <div style="margin:12px 0">
+      <button id="lockBtn" class="${locked?'primary':''}">${locked?'LOCKED':'LOCK'}</button>
+    </div>
+    <div class="kv">
+      <div><label>ALTITUDE</label><span>${a.has_altitude? a.altitude_ft+' ft':'--'}</span></div>
+      <div><label>SPEED</label><span>${a.has_speed? a.speed_kts+' kts':'--'}</span></div>
+      <div><label>RANGE / BEARING</label><span>${a.geometry? a.range_nm.toFixed(0)+' NM  '+String(a.bearing_deg).padStart(3,'0')+' deg':'--'}</span></div>
+      <div><label>HEADING</label><span>${a.has_heading? String(a.heading_deg).padStart(3,'0')+' deg':'--'}</span></div>
+      <div><label>VERT RATE</label><span>${a.has_vertical_rate? ((a.vertical_rate_fpm>=0?'+':'')+a.vertical_rate_fpm+' ft/min'):'--'}</span></div>
+      <div><label>SIGNAL</label><span>${a.signal_dbfs!=null? a.signal_dbfs.toFixed(1)+' dBFS':'--'}</span></div>
+    </div>`;
+}
+
+function drawRadar(){
+  const canvas = $('radar');
+  const rect = canvas.getBoundingClientRect();
+  const dpr = window.devicePixelRatio||1;
+  canvas.width = Math.floor(rect.width*dpr);
+  canvas.height = Math.floor(rect.height*dpr);
+  const ctx = canvas.getContext('2d');
+  ctx.setTransform(dpr,0,0,dpr,0,0);
+  const w = rect.width, h = rect.height;
+  const cx = w/2, cy = h/2, radius = Math.min(w,h)*0.42;
+  ctx.clearRect(0,0,w,h);
+  ctx.fillStyle = '#071018';
+  ctx.fillRect(0,0,w,h);
+  ctx.strokeStyle = '#1f4d3a';
+  ctx.lineWidth = 1;
+  for (let r=1;r<=4;r++){
+    ctx.beginPath();
+    ctx.arc(cx,cy,radius*r/4,0,Math.PI*2);
+    ctx.stroke();
+  }
+  ctx.beginPath(); ctx.moveTo(cx-radius,cy); ctx.lineTo(cx+radius,cy); ctx.stroke();
+  ctx.beginPath(); ctx.moveTo(cx,cy-radius); ctx.lineTo(cx,cy+radius); ctx.stroke();
+  ctx.fillStyle = '#fff';
+  ctx.font = '14px sans-serif';
+  ctx.textAlign='center'; ctx.fillText('N', cx, cy-radius-8);
+  ctx.fillText('S', cx, cy+radius+16);
+  ctx.fillText('W', cx-radius-14, cy+4);
+  ctx.fillText('E', cx+radius+14, cy+4);
+
+  // home
+  drawPlane(ctx, cx, cy, 16, '#00a0ff');
+
+  const list = aircraftList();
+  const rangeNm = parseFloat($('rangeNm').value)||25;
+  list.forEach((a,i)=>{
+    if (!a.geometry) return;
+    const dist = Math.min(a.range_nm / rangeNm, 1);
+    const ang = deg2rad(a.bearing_deg - 90);
+    const px = cx + Math.cos(ang) * dist * (radius-12);
+    const py = cy + Math.sin(ang) * dist * (radius-12);
+    const sel = (selectedAircraft() && selectedAircraft().icao===a.icao);
+    drawPlane(ctx, px, py, sel?14:11, sel?'#00a0ff':'#6fe820');
+    if (sel){
+      ctx.strokeStyle = '#6fe820';
+      ctx.strokeRect(px-18, py-18, 36, 36);
+    }
+    ctx.fillStyle = '#9ca3af';
+    ctx.font = '12px sans-serif';
+    ctx.fillText(callOf(a), px, py+24);
+  });
+
+  const locOk = Number.isFinite(parseFloat($('lat').value)) && Number.isFinite(parseFloat($('lon').value));
+  $('radarHint').textContent = locOk
+    ? `Radar range ${rangeNm} NM · ${list.filter(a=>a.geometry).length} positioned`
+    : 'Set receiver location in SETTINGS for range / bearing.';
+}
+
+function drawPlane(ctx,x,y,s,color){
+  ctx.save();
+  ctx.translate(x,y);
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  ctx.moveTo(0,-s);
+  ctx.lineTo(s*0.35,-s*0.2);
+  ctx.lineTo(s*0.15,-s*0.2);
+  ctx.lineTo(s,s*0.35);
+  ctx.lineTo(s*0.2,s*0.15);
+  ctx.lineTo(0,s*0.55);
+  ctx.lineTo(-s*0.2,s*0.15);
+  ctx.lineTo(-s,s*0.35);
+  ctx.lineTo(-s*0.15,-s*0.2);
+  ctx.lineTo(-s*0.35,-s*0.2);
+  ctx.closePath();
+  ctx.fill();
+  ctx.restore();
+}
+
+function renderList(){
+  const list = aircraftList();
+  let html = `<div class="blue" style="margin-bottom:10px">AIRCRAFT · ALTITUDE · SPEED · RANGE</div>`;
+  if (!list.length) html += `<p class="muted">SEARCHING…</p>`;
+  list.forEach((a,i)=>{
+    const sel = selectedAircraft() && selectedAircraft().icao===a.icao;
+    html += `<div class="row ${sel?'selected':''}" data-i="${i}">
+      <span class="call">${callOf(a)}</span>
+      <span class="muted">${fmtIcao(a.icao)}</span>
+      <span>${a.has_altitude? a.altitude_ft+' ft':'--'}</span>
+      <span>${a.has_speed? a.speed_kts+' kts':'--'}</span>
+      <span>${a.geometry? a.range_nm.toFixed(0)+' NM':'--'}</span>
+    </div>`;
+  });
+  $('listBody').innerHTML = html;
+  $('listBody').querySelectorAll('.row').forEach(el=>{
+    el.onclick = ()=>{ state.selected = +el.dataset.i; state.lockedIcao = 0; render(); };
+  });
+}
+
+function renderTarget(){
+  const a = selectedAircraft();
+  if (!a){
+    $('targetBody').innerHTML = `<h2 class="blue">SEARCHING FOR AIRCRAFT</h2>`;
+    return;
+  }
+  $('targetBody').innerHTML = summaryHtml(a) + `
+    <div class="kv" style="margin-top:20px">
+      <div><label>LATITUDE</label><span>${a.has_position? a.latitude.toFixed(4):'--'}</span></div>
+      <div><label>LONGITUDE</label><span>${a.has_position? a.longitude.toFixed(4):'--'}</span></div>
+    </div>`;
+  bindLock();
+}
+
+function renderStats(){
+  const d = state.data || {};
+  const adsb = d.adsb || {};
+  $('statSig').textContent = (adsb.strongest_signal_dbfs??-90).toFixed(1)+' dBFS';
+  $('statRate').textContent = (adsb.message_rate??0).toFixed(1)+' msg/sec';
+  $('statMsg').textContent = adsb.total_crc_ok??0;
+  $('statAc').textContent = adsb.aircraft_count??0;
+  $('statSps').textContent = d.effective_sps??0;
+  $('statDrops').textContent = d.iq_drops??0;
+  const bars = $('sigBars');
+  bars.innerHTML = '';
+  const level = Math.max(0, Math.min(10, Math.round(((adsb.strongest_signal_dbfs??-90)+90)/6)));
+  for (let i=0;i<10;i++){
+    const el = document.createElement('i');
+    el.style.height = (18+i*6)+'px';
+    el.style.opacity = i<level? '1':'0.25';
+    bars.appendChild(el);
+  }
+}
+
+function bindLock(){
+  const btn = $('lockBtn');
+  if (!btn) return;
+  btn.onclick = ()=>{
+    const a = selectedAircraft();
+    if (!a) return;
+    state.lockedIcao = state.lockedIcao===a.icao ? 0 : a.icao;
+    render();
+  };
+}
+
+function render(){
+  const d = state.data;
+  const adsb = d?.adsb || {};
+  const live = !!(adsb.live && d?.streaming);
+  $('liveDot').classList.toggle('off', !live);
+  $('liveBtn').textContent = live ? 'LIVE' : 'DEMO';
+  $('liveBtn').className = live ? 'primary' : 'danger';
+  $('acCount').textContent = (adsb.aircraft_count??0)+' AIRCRAFT';
+  $('msgRate').textContent = (adsb.message_rate??0).toFixed(1)+'/s';
+  $('sps').textContent = d?.effective_sps??0;
+  $('ip').textContent = d?.ip || '-';
+  $('statusLine').textContent = `${d?.mode||'-'} · ${d?.status||'-'} · ${d?.product||''}`;
+  $('settingsSide').textContent = live ? 'LIVE RECEIVER' : 'WAITING FOR LIVE FRAME';
+  $('settingsSide').className = live ? 'green' : '';
+  $('settingsDetail').textContent = live
+    ? '1090 MHz Mode-S capture active'
+    : 'Waiting for CRC-valid frames · demo chrome until live';
+
+  const sum = summaryHtml(selectedAircraft());
+  $('radarSummary').innerHTML = sum;
+  $('listSummary').innerHTML = sum;
+  bindLock();
+  if (state.view==='radar') drawRadar();
+  if (state.view==='list') renderList();
+  if (state.view==='target') renderTarget();
+  if (state.view==='stats') renderStats();
+}
+
+function setView(name){
+  state.view = name;
+  views.forEach(v=>{
+    $('view-'+v).classList.toggle('hidden', v!==name);
+  });
+  document.querySelectorAll('.nav').forEach(b=>{
+    b.classList.toggle('active', b.dataset.view===name);
+  });
+  render();
+}
+
+async function poll(){
+  try{
+    const r = await fetch('/api/state', {cache:'no-store'});
+    if (!r.ok) throw new Error('http '+r.status);
+    state.data = await r.json();
+    // rebuild aircraft array convenience
+    state.data.aircraft = (state.data.adsb && state.data.adsb.aircraft) || [];
+    render();
+  }catch(e){
+    $('statusLine').textContent = 'API offline: '+e.message;
+  }
+}
+
+async function saveLocation(){
+  const lat = parseFloat($('lat').value);
+  const lon = parseFloat($('lon').value);
+  const range = parseInt($('rangeNm').value,10)||25;
+  localStorage.setItem('orcsdr_rx', JSON.stringify({lat,lon,range}));
+  try{
+    await fetch('/api/location', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({latitude:lat, longitude:lon, radar_range_nm:range})
+    });
+  }catch(e){}
+  render();
+}
+
+async function setMode(mode){
+  try{
+    await fetch('/api/mode', {
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body: JSON.stringify({mode})
+    });
+  }catch(e){}
+}
+
+document.querySelectorAll('.nav').forEach(b=>{
+  b.onclick = ()=> setView(b.dataset.view);
+});
+$('saveLoc').onclick = saveLocation;
+$('modeAdsb').onclick = ()=>setMode('ADSB');
+$('modeFm').onclick = ()=>setMode('FM');
+$('modeWx').onclick = ()=>setMode('WX');
+window.addEventListener('resize', ()=>{ if(state.view==='radar') drawRadar(); });
+
+loadLoc();
+setView('radar');
+poll();
+setInterval(poll, 1000);
+</script>
+</body>
+</html>
+)HTML";

--- a/components/rtl_sdr_v4_esp/README.md
+++ b/components/rtl_sdr_v4_esp/README.md
@@ -9,7 +9,8 @@ Standalone **ESP-IDF component**: USB Host client for the official
 | **Component id** | `rtl_sdr_v4_esp` |
 | **Header** | `rtl_sdr_v4_esp.h` |
 | **API version** | **0.4.1** (multi-URB streaming + safe hot retune) |
-| **Primary silicon** | ESP32-P4 High-Speed USB host (measured) |
+| **Primary silicon** | ESP32-P4 High-Speed USB host (**measured**) |
+| **Measured boards** | M5Stack Tab5 · Waveshare ESP32-P4-Module-DEV-KIT |
 | **Provenance** | Clean-room observed transfers — not a librtlsdr port |
 
 ## What this is
@@ -84,8 +85,13 @@ if (err != ESP_OK) {
 | Dual-core IQ ring | **Core0 USB / Core1 delivery** |
 
 Measured Tab5 radio behavior (960 kS/s, KZEL/NOAA, continuous listen) remains
-the regression reference. See [`PROJECT_STATUS.md`](../../PROJECT_STATUS.md)
-for the outstanding soak, hot-plug, and second-board gates.
+the primary regression reference. **Second-board RF** is hardware-verified on
+Waveshare ESP32-P4 with **this component unmodified** (ADS-B 2.048 MS/s + FM
+960 kS/s) — see
+[`docs/WAVESHARE_P4_VALIDATION.md`](../../docs/WAVESHARE_P4_VALIDATION.md).
+
+Outstanding: formal five-minute soak artifact, hot-plug recovery.
+See [`PROJECT_STATUS.md`](../../PROJECT_STATUS.md).
 
 ## Identity filter
 

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -3,14 +3,16 @@
 ## Goals
 
 1. **Standalone driver** (`components/rtl_sdr_v4_esp`) usable without OrcSDR UI.
-2. **OrcSDR app** (`apps/orcsdr-tab5`) consumes the component for radio UX.
+2. **OrcSDR apps** consume the component for radio UX (Tab5 native UI; Waveshare
+   web/LCD shell).
 3. **OrcLink** remains the control-plane project; it does not own this driver.
 
 ## Target matrix
 
 | Target | USB host | Status |
 |---|---|---|
-| ESP32-P4 (Tab5, Waveshare P4 kits) | High-Speed | **Measured** reference |
+| ESP32-P4 **M5Stack Tab5** | High-Speed | **Measured** product reference |
+| ESP32-P4 **Waveshare Module-DEV-KIT** | High-Speed | **Measured** second board (driver unmodified) |
 | ESP32-S3 | Full-Speed OTG | Build-only until measured |
 | ESP32-S2 | Full-Speed OTG | Build-only until measured |
 | Classic ESP32 | No native HS host | **Out of scope** |
@@ -48,17 +50,38 @@ least 95% effective sample rate, zero fatal USB errors, and bounded drop counts.
 - [x] Retune drains bulk before EP0
 - [ ] Unplug/replug recovery without reboot on Tab5 and a second P4 board
 
-### Gate 4 — Second board (**not started**)
+### Gate 4 — Second board (**complete for core RF: Waveshare P4**)
 
-Repeat Gate 2 on Waveshare ESP32-P4 (or other measured P4) with board BSP for VBUS only.
+Repeat Gate 2 RF path on a second measured ESP32-P4. **Driver source was not
+modified.** Application BSP only (USB port choice, display, Ethernet UI).
+
+| Item | Evidence |
+|---|---|
+| Board | Waveshare ESP32-P4-Module-DEV-KIT, P4 rev 1.3, MAC `80:f1:b2:d1:e0:d5` |
+| App | `apps/orcsdr-waveshare` |
+| Driver | `rtl_sdr_v4_esp` **v0.4.1 unchanged** |
+| Enumerate | Blog V4 HS `0bda:2838` |
+| ADS-B | 1090 MHz @ 2.048 MS/s; live CRC-valid Mode-S / aircraft |
+| FM | 960 kS/s stream; on-device demod + browser PCM |
+| USB host port | **Lower-left Type-A next to Ethernet** (measured) |
+| Report | [`WAVESHARE_P4_VALIDATION.md`](WAVESHARE_P4_VALIDATION.md) |
+
+No Tab5 `M5.Power` VBUS toggle on Waveshare — host USB-A is used as-is.
+OTG jumper must be **HOST**.
+
+**Still open after Gate 4:** formal five-minute soak artifact, hot-plug recovery
+on both boards, S2/S3 measurement.
 
 ## Board BSP boundary
 
 The driver must **not** hard-code M5 Tab5 power rails. Apps provide:
 
-- VBUS enable (e.g. `M5.Power.setExtOutput`)
+- VBUS enable when required (e.g. `M5.Power.setExtOutput` on Tab5)
 - Optional status LEDs
 - USB Host install if shared with other class drivers
+- Board-specific display / network / audio codec wiring
+
+Waveshare proof: same install/start/retune/stop API as Tab5; zero driver edits.
 
 ## Clean-room rules
 
@@ -71,5 +94,6 @@ tunes must stay labeled.
 | Lives in OrcLink | Lives in OrcSDR |
 |---|---|
 | Daemon, policy, adapters (Windows host rtl-sdr, etc.) | RTL-SDRv4-ESP component |
-| Firmware-test workflow for OrcLink node identity | Tab5 radio app / examples |
+| Firmware-test workflow for OrcLink node identity | Tab5 radio app / Waveshare shell / examples |
 | Control Room, orclinkctl | Optional future OrcLink adapter *calling* OrcSDR |
+| Waveshare display pin map (ILI9341) used as reference | Ported into `apps/orcsdr-waveshare` only |

--- a/docs/WAVESHARE_P4_VALIDATION.md
+++ b/docs/WAVESHARE_P4_VALIDATION.md
@@ -1,0 +1,137 @@
+# Waveshare ESP32-P4 second-board validation
+
+**Status:** Hardware-verified (driver portability + application shell)  
+**Date:** 2026-08-11  
+**Branch baseline:** `codex/ads-b-dashboard`  
+**Driver:** `rtl_sdr_v4_esp` **v0.4.1 — unmodified for this port**
+
+## Why this matters
+
+OrcSDR’s Tab5 app and the RTL-SDRv4-ESP driver were developed and measured on
+**M5Stack Tab5**. Gate 4 in `PORTING.md` required repeating the RF path on a
+**second ESP32-P4 board** without baking Tab5 BSP into the driver.
+
+This report records that the **USB host driver worked out of the box** on a
+Waveshare ESP32-P4-Module-DEV-KIT. Board-specific work was limited to display,
+USB port selection, Ethernet web UI, and app shell — **not** transfer tables,
+identity filter, or bulk pipeline.
+
+## Device under test
+
+| Field | Value |
+|---|---|
+| Board | Waveshare **ESP32-P4-Module-DEV-KIT** |
+| Chip | ESP32-P4 revision **v1.3** |
+| Flash / PSRAM | 16 MB flash; PSRAM present |
+| MAC (measured) | `80:f1:b2:d1:e0:d5` |
+| Console | Type-C CH343 **COM3**, 115200 |
+| RTL-SDR | Official **Blog V4** `0bda:2838`, high-speed |
+| App | `apps/orcsdr-waveshare` |
+
+## Driver changes required
+
+| Item | Result |
+|---|---|
+| Patch `rtl_sdr_v4_esp` source | **None** |
+| New EP0 / bulk tables | **None** |
+| New VID/PID filter | **None** |
+| Tab5 `M5.Power.setExtOutput` | **Not used** (not required on this board) |
+| App link | PlatformIO `lib_extra_dirs` + `lib_deps = rtl_sdr_v4_esp` |
+
+```text
+RTL_INSTALL ok v0.4.1 caps=0x0000001f
+RTL_SDR_PROBE_OK v4=true vid=0bda pid=2838 hs=1 product=Blog V4
+```
+
+## Board BSP (application only)
+
+### USB host port (hardware-verified)
+
+The kit exposes **four Type-A ports**. Only one path enumerates the Blog V4
+under the ESP USB host stack used here:
+
+| Port | Result |
+|---|---|
+| **Lower-left Type-A, next to Ethernet RJ45** | **Works** |
+| Other three Type-A ports | Do not use for RTL-SDR on this target |
+
+Also set the **USB OTG jumper to HOST**.
+
+### Display / touch (not driver)
+
+MPI2418-style 2.4" **ILI9341** SPI panel on the 26-pin header. Pin map and
+init sequence taken from the measured OrcLink `firmware/waveshare-p4` target
+(GPIO SCLK=0, MOSI=3, MISO=2, DC=6, RST=20, CS=36; touch CS=32, IRQ=21).
+
+### Ethernet web UI (not driver)
+
+Onboard IP101 RMII (MDC=31, MDIO=52, RESET=51) serves a browser dashboard so
+the small panel is not required for full ADS-B / FM chrome.
+
+## RF measurements (observed)
+
+### ADS-B 1090 MHz @ 2.048 MS/s
+
+| Metric | Observed |
+|---|---|
+| Commanded rate | `RTL_SDR_V4_ESP_RATE_2048K` |
+| Effective SPS | ~2.03–2.05 MS/s while streaming |
+| IQ drops | Single-digit over multi-minute runs after start |
+| LO | 1 090 000 000 Hz |
+| Decoder | Tab5 `adsb_decoder` reused without fork |
+| Live aircraft | CRC-valid Mode-S frames; ICAOs published to web UI |
+
+Example serial shape:
+
+```text
+RTL_START ESP_OK mode=ADSB rate=2048000 frequency_hz=1090000000
+ORC_METRICS mode=ADSB sps=204xxxx ... preambles=... crc=... mag=0..2xx
+```
+
+### FM broadcast @ 960 kS/s
+
+| Metric | Observed |
+|---|---|
+| Commanded rate | `RTL_SDR_V4_ESP_RATE_960K` |
+| Effective SPS | ~0.94–0.96 MS/s while streaming |
+| LO example | 96.1 MHz |
+| App demod | On-device WBFM → 48 kHz mono PCM ring |
+| Browser | `/fm` pulls `/api/audio` PCM1 frames for Web Audio |
+
+```text
+RTL_START ESP_OK mode=FM rate=960000 frequency_hz=96100000
+```
+
+## What this does *not* claim
+
+- Five-minute formal soak log attached as a permanent artifact (still open P1)
+- Unplug/replug recovery without reboot (still open Gate 3)
+- Full Tab5 1280×720 UI on the Waveshare LCD
+- ES8311 speaker path on Waveshare (browser audio is the current FM listen path)
+- ESP32-S2/S3 Full-Speed support (still out of measured scope)
+
+## How to reproduce
+
+```powershell
+cd apps/orcsdr-waveshare
+pio run -e waveshare_p4_adsb -t upload --upload-port COM3
+pio device monitor -e waveshare_p4_adsb
+```
+
+1. OTG jumper **HOST**  
+2. Blog V4 in **lower-left USB-A by Ethernet**  
+3. Ethernet cable for web UI; note `ETH_STATUS ... ip=`  
+4. Open `http://<ip>/` (ADS-B) or `http://<ip>/fm` (FM radio)
+
+Full operator notes: [`apps/orcsdr-waveshare/README.md`](../apps/orcsdr-waveshare/README.md).
+
+## Conclusion
+
+| Question | Answer |
+|---|---|
+| Did the driver need Waveshare-specific changes? | **No** |
+| Did Blog V4 enumerate and stream on a second P4? | **Yes** |
+| Is Gate 4 (second board) closed for core RF? | **Yes — hardware-verified** |
+
+Tab5 remains the product reference UI. Waveshare proves **RTL-SDRv4-ESP
+portability** and hosts a network-first second-board shell.


### PR DESCRIPTION
## Summary
- Add `apps/orcsdr-waveshare`: second-board OrcSDR shell for Waveshare ESP32-P4-Module-DEV-KIT (ILI9341 status LCD, Ethernet web ADS-B + FM UI, multi-mode RF).
- **`rtl_sdr_v4_esp` is unchanged** — Blog V4 HS enumerate/stream worked out of the box on a second P4 host.
- Document Gate 4 evidence in `docs/WAVESHARE_P4_VALIDATION.md` and update `PORTING.md`, `PROJECT_STATUS.md`, root README, and component README.

## Hardware-verified (measured kit)
- Board: Waveshare P4 rev 1.3, MAC `80:f1:b2:d1:e0:d5`, console COM3 (CH343)
- USB host: **lower-left Type-A next to Ethernet**, OTG jumper HOST
- ADS-B: 1090 MHz @ 2.048 MS/s, live CRC-valid Mode-S / aircraft on web UI
- FM: 960 kS/s stream; on-device 48 kHz PCM + browser `/fm` audio path

## Note vs Codex Tab5 settings work
This branch is **only** the Waveshare second-board path. It does **not** include the in-progress Tab5 global-settings / settings-tab fixes under active Codex testing. Safe to review in parallel.

## Test plan
- [x] Build/flash `apps/orcsdr-waveshare` env `waveshare_p4_adsb`
- [x] `RTL_INSTALL` / `RTL_SDR_PROBE_OK` Blog V4 HS
- [x] ADS-B stream + live ICAO on `http://<eth-ip>/`
- [x] FM stream + `/api/audio` PCM frames
- [ ] Formal five-minute soak log (still open P1)
- [ ] Hot-plug recovery (still open Gate 3)