### PR TITLE
chore: configure manual CodeRabbit reviews [skip review]

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,6 @@
+# Preserve the free review allowance: reviewers opt in only when a PR is ready.
+reviews:
+  auto_review:
+    enabled: false
+    drafts: false
+    auto_incremental_review: false


### PR DESCRIPTION
Disables automatic and incremental CodeRabbit reviews. Use @coderabbitai review only on ready, substantive PRs to preserve the free-tier allowance.