### PR TITLE
Tab5: add RF Lab dashboard and stabilize RTL processing

### DIFF
--- a/apps/orcsdr-tab5/main/CMakeLists.txt
+++ b/apps/orcsdr-tab5/main/CMakeLists.txt
@@ -24,6 +24,7 @@ idf_component_register(
         "../ui/p25_config.cpp"
         "../ui/p25_decoder.cpp"
         "../ui/radio_ui_service.cpp"
+        "../ui/rf_analysis.cpp"
         "../ui/rf_visualizer.cpp"
         "../ui/rf_visualizer_controls.cpp"
         "../ui/settings_app.cpp"

--- a/apps/orcsdr-tab5/main/CMakeLists.txt
+++ b/apps/orcsdr-tab5/main/CMakeLists.txt
@@ -25,6 +25,7 @@ idf_component_register(
         "../ui/p25_decoder.cpp"
         "../ui/radio_ui_service.cpp"
         "../ui/rf_analysis.cpp"
+        "../ui/rf_lab.cpp"
         "../ui/rf_visualizer.cpp"
         "../ui/rf_visualizer_controls.cpp"
         "../ui/settings_app.cpp"

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -436,6 +436,12 @@ try {
       [void](Open-Ui 'SETTINGS' $targets[-1].Band)
       Watch-Responsive $DwellSeconds 'SETTINGS' $targets[-1].Band
       [void](Open-Ui 'HOME' $targets[-1].Band)
+      [void](Open-Ui 'RF_LAB' $targets[-1].Band)
+      [void](Send-And-Wait 'RTL_LAB SELF_CHECK' '^RTL_LAB_SELF_CHECK pass=1$')
+      [void](Send-And-Wait 'RTL_LAB PAGE CONTROLS' '^RTL_LAB_OK page=CONTROLS$')
+      Watch-Responsive $DwellSeconds 'RF_LAB' $targets[-1].Band
+      [void](Send-And-Wait 'RTL_LAB CLOSE' '^RTL_LAB_OK close=queued$')
+      [void](Wait-UiState 'HOME' $targets[-1].Band)
       [void](Open-Ui 'FM' 'FM')
       Assert-FmAudioProgress
       if ($cycle -eq 1 -or $cycle % 5 -eq 0) { Assert-SoundCycle }

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -188,6 +188,15 @@ function Get-AudioStatus {
 }
 
 function Assert-FmAudioProgress {
+  $streamDeadline = [DateTime]::UtcNow.AddSeconds(30)
+  do {
+    $driver = Get-DriverStatus
+    if ($driver.State -eq 'STREAMING' -and $driver.Bytes -gt 0) { break }
+    Start-Sleep -Milliseconds 500
+  } while ([DateTime]::UtcNow -lt $streamDeadline)
+  if ($driver.State -ne 'STREAMING' -or $driver.Bytes -eq 0) {
+    throw "FM IQ did not start: state=$($driver.State) bytes=$($driver.Bytes)"
+  }
   $first = Get-AudioStatus
   $deadline = [DateTime]::UtcNow.AddSeconds([Math]::Max(5, $TimeoutSeconds))
   do {
@@ -300,8 +309,11 @@ if (@($Run, $Soak, $Driver079).Where({ $_ }).Count -gt 1) {
 }
 
 function Get-DriverStatus {
-  $line = Send-And-Wait 'RTL_DRIVER STATUS' '^RTL_DRIVER_STATUS '
   $pattern = 'version=(\S+) state=(\S+).*gain_auto_cap=([01]) rtl_agc_cap=([01]) gain_cap=([01]) bias_cap=([01]) mode=(AUTO|MANUAL) gain_tenth_db=(\d+) rtl_agc=([01]) bias=([01]) bytes=(\d+) blocks=(\d+) effective_sps=(\d+) overruns=(\d+) drops=(\d+) shadow_ok=([01]) metrics_ok=([01])'
+  for ($attempt = 0; $attempt -lt 3; $attempt++) {
+    $line = Send-And-Wait 'RTL_DRIVER STATUS' '^RTL_DRIVER_STATUS '
+    if ($line -match $pattern) { break }
+  }
   if ($line -notmatch $pattern) { throw "Malformed driver status: $line" }
   [pscustomobject]@{
     Version = $Matches[1]; State = $Matches[2]; GainAutoCap = [int]$Matches[3]
@@ -404,8 +416,14 @@ try {
   }
 
   Wait-DeviceReady
-  [void](Send-And-Wait 'RTL_STATUS' '^RTL_SDR_STATUS ' 20)
   Connect-Authenticated
+  $rtlDeadline = [DateTime]::UtcNow.AddSeconds(30)
+  do {
+    $rtlStatus = Send-And-Wait 'RTL_STATUS' '^RTL_SDR_STATUS ' 20
+    if ($rtlStatus -match 'connected=true ') { break }
+    Start-Sleep -Milliseconds 500
+  } while ([DateTime]::UtcNow -lt $rtlDeadline)
+  if ($rtlStatus -notmatch 'connected=true ') { throw "RTL-SDR did not enumerate: $rtlStatus" }
   $initial = Get-UiState
   $initialVerbosity = $null
   $soundWasEnabled = $null

--- a/apps/orcsdr-tab5/ui/dashboard_registry.cpp
+++ b/apps/orcsdr-tab5/ui/dashboard_registry.cpp
@@ -17,6 +17,7 @@ constexpr Descriptor kEntries[] = {
     {Id::airband, "AIRBAND", "VHF aviation voice", Category::aviation, true},
     {Id::marine, "MARINE", "VHF marine receiver", Category::audio, true},
     {Id::satellite, "SATELLITE", "Satellite receive workspace", Category::digital, true},
+    {Id::rf_lab, "RF LAB", "Live measurements and driver tests", Category::utility, true},
     {Id::settings, "SETTINGS", "Global device settings", Category::system, true},
 };
 
@@ -53,8 +54,8 @@ void load_recent(const uint8_t* ids, size_t count_value) {
     }
   }
   if (g_recent_count == 0) {
-    constexpr Id defaults[] = {Id::fm, Id::p25, Id::adsb, Id::shortwave,
-                               Id::lora, Id::cb, Id::weather};
+    constexpr Id defaults[] = {Id::rf_lab, Id::fm, Id::p25, Id::adsb,
+                               Id::shortwave, Id::lora, Id::cb, Id::weather};
     std::copy(std::begin(defaults), std::end(defaults), g_recent.begin());
     g_recent_count = std::size(defaults);
   }
@@ -98,7 +99,7 @@ bool self_check() {
                      g_recent[1] == Id::fm && !record_open(Id::p25);
   g_recent = saved;
   g_recent_count = saved_count;
-  return loaded && moved && std::size(kEntries) == 11;
+  return loaded && moved && std::size(kEntries) == 12 && find(Id::rf_lab) != nullptr;
 }
 
 }  // namespace orcsdr::dashboards

--- a/apps/orcsdr-tab5/ui/dashboard_registry.hpp
+++ b/apps/orcsdr-tab5/ui/dashboard_registry.hpp
@@ -19,6 +19,7 @@ enum class Id : uint8_t {
   satellite,
   utilities,
   settings,
+  rf_lab,
   count,
 };
 

--- a/apps/orcsdr-tab5/ui/lora_native_decoder.cpp
+++ b/apps/orcsdr-tab5/ui/lora_native_decoder.cpp
@@ -1,5 +1,7 @@
 #include "lora_native_decoder.hpp"
 
+#include "rf_analysis.hpp"
+
 #include <dsps_fft2r.h>
 #include <esp_heap_caps.h>
 #include <esp_timer.h>
@@ -686,13 +688,13 @@ bool decode_mesh(const uint8_t* data, size_t size, const Config& config, Packet*
 
 bool initialize() {
   if (g_scratch.fft != nullptr && g_scratch.downchirp != nullptr)
-    return dsps_fft2r_init_fc32(nullptr, static_cast<int>(kMaxFft)) == ESP_OK;
+    return rf_analysis::initialize_fft();
   g_scratch.fft = static_cast<float*>(heap_caps_malloc(sizeof(float) * kMaxFft * 2,
                                                          MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
   g_scratch.downchirp = static_cast<float*>(heap_caps_malloc(sizeof(float) * kMaxFft * 2,
                                                                MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
   if (g_scratch.fft == nullptr || g_scratch.downchirp == nullptr) return false;
-  return dsps_fft2r_init_fc32(nullptr, static_cast<int>(kMaxFft)) == ESP_OK;
+  return rf_analysis::initialize_fft();
 }
 
 static size_t decode_capture_pass(const uint8_t* cu8, size_t bytes, uint32_t sample_rate_sps,

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -489,6 +489,7 @@ constexpr size_t kRtlSpectrumWelchWindows = 2;
 constexpr uint32_t kRtlSpectrumIntervalMs = 100;
 constexpr uint32_t kRtlSpectrumStressedIntervalMs = 220;
 constexpr size_t kRtlRingDepth = 3;
+constexpr UBaseType_t kRtlDspTaskPrio = 6;
 constexpr uint32_t kRtlAudioPrimeMs = 450;
 constexpr uint32_t kRtlSignalMeterIntervalMs = 200;
 /* Tab5 microSD (M5 docs): SPI pins for optional WAV export. */
@@ -877,11 +878,16 @@ struct RtlIqBlock {
   uint8_t* data;
   size_t bytes;
   uint32_t sequence;
-  bool end_marker;
+  uint8_t slot;
+  RtlBand band;
+  float audio_scale;
+  bool lab_custom_rate;
 };
 static uint8_t* rtl_ring_slots[kRtlRingDepth]{};
 static QueueHandle_t rtl_free_q = nullptr;
 static QueueHandle_t rtl_filled_q = nullptr;
+static std::atomic<uint32_t> rtl_iq_pipeline_drops{0};
+static std::atomic<uint32_t> rtl_iq_sequence{0};
 /* Scratch IQ buffer for demod/spectrum (size >= max bulk transfer). */
 static uint8_t rtl_iq_processing[32768 + 512];
 /* Relative RF level from IQ power (dBFS-ish, 0 = full-scale CU8). */
@@ -2433,13 +2439,13 @@ bool restart_rtl_speaker_i2s(uint8_t volume) {
   if (speaker_backoff_active(now)) return false;
   const uint32_t dma_largest =
       heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA);
-  /* 4×512 stereo ≈ 8 KiB. After Wi-Fi/USB the leftover slab can be ~5 KiB;
-   * retrying begin/end every second fragments that slab and stalls IQ. */
-  if (dma_largest < 4096u) {
+  /* Keep two small DMA buffers available after the USB driver claims its
+   * descriptors. 256 stereo frames × 2 buffers is 2 KiB plus descriptors. */
+  if (dma_largest < 3072u) {
     speaker_note_fail(now);
     if (!g_speaker_fail_logged) {
       g_speaker_fail_logged = true;
-      Serial.printf("RTL_SPEAKER_BEGIN_FAIL dma_largest=%lu need=4096\n",
+      Serial.printf("RTL_SPEAKER_BEGIN_FAIL dma_largest=%lu need=3072\n",
                     static_cast<unsigned long>(dma_largest));
       log_dram_budget("speaker_begin_fail");
     }
@@ -2453,15 +2459,10 @@ bool restart_rtl_speaker_i2s(uint8_t volume) {
   speaker_config.stereo = true;
   speaker_config.task_priority = 6;
   speaker_config.task_pinned_core = 1;
-  if (dma_largest >= 8192u) {
-    speaker_config.dma_buf_len = 512;
-    speaker_config.dma_buf_count = 4;
-  } else {
-    speaker_config.dma_buf_len = 512;
-    speaker_config.dma_buf_count = 2;
-    Serial.printf("RTL_SPEAKER_DMA fallback count=2 largest=%lu\n",
-                  static_cast<unsigned long>(dma_largest));
-  }
+  speaker_config.dma_buf_len = 256;
+  speaker_config.dma_buf_count = 2;
+  Serial.printf("RTL_SPEAKER_DMA len=256 count=2 largest=%lu\n",
+                static_cast<unsigned long>(dma_largest));
   M5.Speaker.config(speaker_config);
   if (M5.Speaker.isRunning()) M5.Speaker.end();
   apply_speaker_volume(volume);
@@ -5061,7 +5062,16 @@ orcsdr::rf_lab::Runtime rf_lab_runtime() {
   return runtime;
 }
 
+void stop_p25_automation() {
+  p25_survey_active.store(false, std::memory_order_release);
+  p25_entry_probe_at_ms = 0;
+  p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+  p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
+  p25_voice_frequency_hz = 0;
+}
+
 void open_rf_lab() {
+  stop_p25_automation();
   const auto origin = orcsdr::screens::status().active;
   orcsdr::rf_lab::set_runtime(rf_lab_runtime());
   orcsdr::screens::begin_transition(orcsdr::screens::Id::rf_lab, millis());
@@ -5128,7 +5138,10 @@ void service_rf_lab() {
       if (!esp_rtl_sdr_is_rate_supported(rate)) result = ESP_ERR_INVALID_ARG;
       else {
         rtl_lab_rate_override_sps.store(rate, std::memory_order_release);
-        queue_local_rtl_listen(rtl_ui_band, rtl_ui_frequency_hz, false);
+        uint32_t current_rate = 0;
+        if (esp_rtl_sdr_get_sample_rate(g_rtl, &current_rate) != ESP_OK ||
+            current_rate != rate)
+          queue_local_rtl_listen(rtl_ui_band, rtl_ui_frequency_hz, false);
       }
     } else if (action.kind == Kind::ppm) {
       result = esp_rtl_sdr_set_freq_correction(g_rtl, action.value);
@@ -5586,11 +5599,12 @@ void draw_spectrum(const uint8_t* iq, size_t bytes) {
                                   (static_cast<uint64_t>(dsp_us) * 100u) /
                                   (static_cast<uint64_t>(window_ms) * 1000u));
     if (serial_verbosity_at(SerialVerbosity::trace)) {
-      Serial.printf("RTL_SPECTRUM_FPS fps=%u bins=%u welch=%u tool=%s audio_dropped=%u "
-                    "audio_chunks=%u audio_peak=%d dsp_load_pct=%u dsp_blocks=%u "
+      Serial.printf("RTL_SPECTRUM_FPS fps=%u bins=%u welch=%u tool=%s iq_dropped=%u "
+                    "audio_dropped=%u audio_chunks=%u audio_peak=%d dsp_load_pct=%u dsp_blocks=%u "
                     "dsp_block_us_max=%u\n",
                     rtl_spectrum_fps, static_cast<unsigned>(kRtlSpectrumBins),
                     static_cast<unsigned>(windows), orc_tool_name(tool),
+                    rtl_iq_pipeline_drops.load(std::memory_order_relaxed),
                     rtl_audio.dropped_chunks, rtl_audio.queued_chunks, rtl_audio.peak,
                     dsp_load_pct, dsp_blocks, dsp_max_us);
     }
@@ -6691,9 +6705,9 @@ void initialize_rtl_sdr_host() {
 /*
  * Core split (working path):
  *   Core 0 — driver USB (host + client)
- *   Core 1 — driver delivery posts EVT_IQ_BLOCK → demod+speaker here;
- *            rtl_app does touch / retune / spectrum (lower rate)
- * The extra audio-job queue broke both audio and graphics; keep demod inline.
+ *   Core 1 — driver delivery copies borrowed IQ into a bounded ring;
+ *            rtl_dsp owns demod/decoder/audio work and rtl_app owns controls.
+ * The callback must return promptly so the driver and idle watchdog can run.
  */
 static void on_rtl_driver_event(esp_rtl_sdr_event_t event, const void *payload, void *ctx) {
   (void)ctx;
@@ -6721,63 +6735,29 @@ static void on_rtl_driver_event(esp_rtl_sdr_event_t event, const void *payload, 
       Serial.println("RTL_SDR_DISCONNECTED");
       break;
     case ESP_RTL_SDR_EVT_IQ_BLOCK: {
-      const uint32_t dsp_started_us = micros();
       const auto *iq = static_cast<const esp_rtl_sdr_iq_block_t *>(payload);
       if (iq == nullptr || iq->data == nullptr || iq->bytes == 0) break;
       const size_t n =
           iq->bytes <= sizeof(rtl_iq_processing) ? iq->bytes : sizeof(rtl_iq_processing);
-      const bool lab_active = orcsdr::rf_lab::active();
+      rtl_capture_bytes += n;
+      uint8_t slot = 0;
+      if (!rtl_free_q || !rtl_filled_q || xQueueReceive(rtl_free_q, &slot, 0) != pdTRUE) {
+        rtl_iq_pipeline_drops.fetch_add(1, std::memory_order_relaxed);
+        break;
+      }
+      std::memcpy(rtl_ring_slots[slot], iq->data, n);
       const uint32_t lab_rate = rtl_lab_rate_override_sps.load(std::memory_order_relaxed);
       const uint32_t decoder_rate = g_stream_band == RtlBand::adsb
                                         ? ESP_RTL_SDR_RATE_2048K
                                         : ESP_RTL_SDR_RATE_960K;
-      const bool lab_custom_rate = lab_active && lab_rate && lab_rate != decoder_rate;
-      if (!lab_custom_rate && g_stream_band == RtlBand::adsb && adsb_iq_free && adsb_iq_ready) {
-        uint8_t index = 0;
-        if (xQueueReceive(adsb_iq_free, &index, 0) == pdTRUE) {
-          std::memcpy(adsb_iq_blocks[index], iq->data, n);
-          adsb_iq_sizes[index] = n;
-          (void)xQueueSend(adsb_iq_ready, &index, 0);
-        } else {
-          adsb_iq_drops.fetch_add(1, std::memory_order_relaxed);
-        }
-      }
-      update_signal_level_from_iq(iq->data, n);
-      if (!lab_custom_rate && g_stream_band == RtlBand::p25)
-        orcsdr::p25decoder::process_cu8(iq->data, n);
-      /* ADS-B needs the full callback budget; it has no spectrum or audio path. */
-      if (g_stream_band != RtlBand::adsb || orcsdr::home::active() ||
-          orcsdr::visualizer::active() || lab_active)
-        spectrum_offer_iq_snapshot(iq->data, n);
-      if (!lab_custom_rate && g_stream_band == RtlBand::lora) lora_iq_offer(iq->data, n);
-      if (!lab_custom_rate && !orcsdr::visualizer::channel_audio_active() &&
-          g_stream_band != RtlBand::lora && g_stream_band != RtlBand::p25 &&
-          (rtl_audio_enabled.load(std::memory_order_relaxed) ||
-           g_audio_rec_active.load(std::memory_order_relaxed)) &&
-          !rtl_audio_test_tone.load(std::memory_order_relaxed)) {
-        if (g_stream_band == RtlBand::cb) {
-          if (cb_audio_gate_open()) {
-            const CbMode mode = cb_mode.load(std::memory_order_relaxed);
-            if (mode == CbMode::am) demodulate_am(iq->data, n, g_stream_audio_scale);
-            else demodulate_ssb(iq->data, n, g_stream_audio_scale, mode);
-          } else {
-            rtl_audio_play_count = 0;
-          }
-        } else if (g_stream_band == RtlBand::am) {
-          demodulate_am(iq->data, n, g_stream_audio_scale);
-        } else {
-          demodulate_fm(iq->data, n, g_stream_audio_scale,
-                        g_stream_band == RtlBand::fm);
-        }
-      }
-      rtl_capture_bytes += n;
-      const uint32_t dsp_elapsed_us = micros() - dsp_started_us;
-      rtl_dsp_window_us.fetch_add(dsp_elapsed_us, std::memory_order_relaxed);
-      rtl_dsp_window_blocks.fetch_add(1, std::memory_order_relaxed);
-      uint32_t previous_max = rtl_dsp_block_us_max.load(std::memory_order_relaxed);
-      while (dsp_elapsed_us > previous_max &&
-             !rtl_dsp_block_us_max.compare_exchange_weak(
-                 previous_max, dsp_elapsed_us, std::memory_order_relaxed)) {
+      const RtlIqBlock block{
+          rtl_ring_slots[slot], n,
+          rtl_iq_sequence.fetch_add(1, std::memory_order_relaxed), slot, g_stream_band,
+          g_stream_audio_scale,
+          orcsdr::rf_lab::active() && lab_rate && lab_rate != decoder_rate};
+      if (xQueueSend(rtl_filled_q, &block, 0) != pdTRUE) {
+        rtl_iq_pipeline_drops.fetch_add(1, std::memory_order_relaxed);
+        (void)xQueueSend(rtl_free_q, &slot, 0);
       }
       break;
     }
@@ -6802,6 +6782,63 @@ static void on_rtl_driver_event(esp_rtl_sdr_event_t event, const void *payload, 
     }
     default:
       break;
+  }
+}
+
+static void rtl_dsp_task(void *) {
+  RtlIqBlock block{};
+  while (true) {
+    if (xQueueReceive(rtl_filled_q, &block, portMAX_DELAY) != pdTRUE) continue;
+    const uint32_t dsp_started_us = micros();
+    const bool lab_active = orcsdr::rf_lab::active();
+    if (!block.lab_custom_rate && block.band == RtlBand::adsb && adsb_iq_free &&
+        adsb_iq_ready) {
+      uint8_t index = 0;
+      if (xQueueReceive(adsb_iq_free, &index, 0) == pdTRUE) {
+        std::memcpy(adsb_iq_blocks[index], block.data, block.bytes);
+        adsb_iq_sizes[index] = block.bytes;
+        (void)xQueueSend(adsb_iq_ready, &index, 0);
+      } else {
+        adsb_iq_drops.fetch_add(1, std::memory_order_relaxed);
+      }
+    }
+    update_signal_level_from_iq(block.data, block.bytes);
+    if (!block.lab_custom_rate && block.band == RtlBand::p25)
+      orcsdr::p25decoder::process_cu8(block.data, block.bytes);
+    if (block.band != RtlBand::adsb || orcsdr::home::active() ||
+        orcsdr::visualizer::active() || lab_active)
+      spectrum_offer_iq_snapshot(block.data, block.bytes);
+    if (!block.lab_custom_rate && block.band == RtlBand::lora)
+      lora_iq_offer(block.data, block.bytes);
+    if (!block.lab_custom_rate && !orcsdr::visualizer::channel_audio_active() &&
+        block.band != RtlBand::lora && block.band != RtlBand::p25 &&
+        (rtl_audio_enabled.load(std::memory_order_relaxed) ||
+         g_audio_rec_active.load(std::memory_order_relaxed)) &&
+        !rtl_audio_test_tone.load(std::memory_order_relaxed)) {
+      if (block.band == RtlBand::cb) {
+        if (cb_audio_gate_open()) {
+          const CbMode mode = cb_mode.load(std::memory_order_relaxed);
+          if (mode == CbMode::am) demodulate_am(block.data, block.bytes, block.audio_scale);
+          else demodulate_ssb(block.data, block.bytes, block.audio_scale, mode);
+        } else {
+          rtl_audio_play_count = 0;
+        }
+      } else if (block.band == RtlBand::am) {
+        demodulate_am(block.data, block.bytes, block.audio_scale);
+      } else if (block.band != RtlBand::adsb) {
+        demodulate_fm(block.data, block.bytes, block.audio_scale, block.band == RtlBand::fm);
+      }
+    }
+    const uint32_t dsp_elapsed_us = micros() - dsp_started_us;
+    rtl_dsp_window_us.fetch_add(dsp_elapsed_us, std::memory_order_relaxed);
+    rtl_dsp_window_blocks.fetch_add(1, std::memory_order_relaxed);
+    uint32_t previous_max = rtl_dsp_block_us_max.load(std::memory_order_relaxed);
+    while (dsp_elapsed_us > previous_max &&
+           !rtl_dsp_block_us_max.compare_exchange_weak(
+               previous_max, dsp_elapsed_us, std::memory_order_relaxed)) {
+    }
+    (void)xQueueSend(rtl_free_q, &block.slot, portMAX_DELAY);
+    vTaskDelay(1);
   }
 }
 
@@ -6831,6 +6868,7 @@ static void rtl_driver_app_task(void *) {
       rtl_dsp_window_us.store(0, std::memory_order_relaxed);
       rtl_dsp_window_blocks.store(0, std::memory_order_relaxed);
       rtl_dsp_block_us_max.store(0, std::memory_order_relaxed);
+      rtl_iq_pipeline_drops.store(0, std::memory_order_relaxed);
       rtl_audio_play_count = 0;
       rtl_audio_play_block_index = 0;
       memset(rtl_audio_play_block_ready_ms, 0, sizeof(rtl_audio_play_block_ready_ms));
@@ -7264,6 +7302,34 @@ static void rtl_driver_app_task(void *) {
 }
 
 void initialize_rtl_sdr_host() {
+  rtl_free_q = xQueueCreateWithCaps(kRtlRingDepth, sizeof(uint8_t),
+                                      MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  rtl_filled_q = xQueueCreateWithCaps(kRtlRingDepth, sizeof(RtlIqBlock),
+                                        MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+  if (!rtl_free_q || !rtl_filled_q) {
+    set_rtl_sdr_status("RTL-SDR: IQ queue allocation failed");
+    return;
+  }
+  for (uint8_t i = 0; i < kRtlRingDepth; ++i) {
+    rtl_ring_slots[i] = static_cast<uint8_t*>(
+        heap_caps_malloc(sizeof(rtl_iq_processing), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+    if (!rtl_ring_slots[i]) {
+      set_rtl_sdr_status("RTL-SDR: IQ ring allocation failed");
+      return;
+    }
+    (void)xQueueSend(rtl_free_q, &i, 0);
+  }
+  if (xTaskCreatePinnedToCoreWithCaps(rtl_dsp_task, "rtl_dsp", 8192, nullptr,
+                                      kRtlDspTaskPrio, &rtl_dsp_task_handle, 1,
+                                      MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) != pdPASS) {
+    set_rtl_sdr_status("RTL-SDR: DSP task failed");
+    return;
+  }
+  Serial.printf("RTL_IQ_PIPELINE ready slots=%u bytes=%u core=1 priority=%u\n",
+                static_cast<unsigned>(kRtlRingDepth),
+                static_cast<unsigned>(sizeof(rtl_iq_processing)),
+                static_cast<unsigned>(kRtlDspTaskPrio));
+
   adsb_iq_free = xQueueCreate(kAdsbIqBlockCount, sizeof(uint8_t));
   adsb_iq_ready = xQueueCreate(kAdsbIqBlockCount, sizeof(uint8_t));
   if (!adsb_iq_free || !adsb_iq_ready) {
@@ -7327,7 +7393,7 @@ void initialize_rtl_sdr_host() {
                               nullptr, 1) != pdPASS) {
     set_rtl_sdr_status("RTL-SDR: app task failed");
   }
-  Serial.println("RTL_CORE_SPLIT usb=core0 dsp_audio_ui_hosted=core1 (inline demod)");
+  Serial.println("RTL_CORE_SPLIT usb=core0 callback=enqueue dsp_audio_ui_hosted=core1");
 }
 #endif /* RTL_USE_LEGACY_USB */
 
@@ -8259,7 +8325,7 @@ void service_p25_survey(uint32_t now) {
 }
 
 void service_p25_follow(uint32_t now) {
-  if (g_stream_band != RtlBand::p25 ||
+  if (orcsdr::rf_lab::active() || g_stream_band != RtlBand::p25 ||
       p25_survey_active.load(std::memory_order_relaxed)) return;
   const auto decoded = orcsdr::p25decoder::snapshot();
   if (p25_follow_state.load(std::memory_order_acquire) == P25FollowState::voice) {
@@ -9309,6 +9375,9 @@ bool point_in_button(int32_t x, int32_t y) {
 
 void queue_local_rtl_listen(RtlBand band, uint32_t frequency_hz,
                             bool persist_navigation) {
+  if (band != RtlBand::p25) {
+    stop_p25_automation();
+  }
   if (!rtl_band_has_audio(band)) sync_rtl_audio_for_band(band);
   if (band == RtlBand::adsb) {
     frequency_hz = kAdsbDefaultHz;
@@ -12076,6 +12145,10 @@ void service_boot_device_staging() {
   switch (boot_init_stage) {
     case BootInitStage::usb_power_settle:
       if (elapsed_ms < 350) return;
+      /* Reserve the small I2S DMA ring while contiguous internal RAM still
+       * exists. Starting it after USB enumeration cannot allocate reliably. */
+      allow_boot_speaker();
+      log_dram_budget("speaker_before_usb");
       set_rtl_sdr_status("Boot: starting RTL-SDR host");
       initialize_rtl_sdr_host();
       log_dram_budget("after_usb");

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -67,6 +67,7 @@ extern "C" {
 #include "p25_config.hpp"
 #include "p25_decoder.hpp"
 #include "radio_ui_service.hpp"
+#include "rf_lab.hpp"
 #include "rf_visualizer.hpp"
 #include "settings_app.hpp"
 #include "ui_capture.hpp"
@@ -1210,6 +1211,7 @@ static float rtl_session_audio_scale = 5500.0f;
 static bool rtl_session_continuous = true;
 static uint32_t rtl_session_started_ms = 0;
 static std::atomic<uint32_t> rtl_session_frequency_hz{kRtlFmDefaultHz};
+static std::atomic<uint32_t> rtl_lab_rate_override_sps{0};
 // M5GFX framebuffer writes are single-task only.  The RTL worker requests a
 // repaint; loop() owns the actual draw.
 static std::atomic<bool> rtl_stream_ui_refresh_pending{false};
@@ -1866,6 +1868,7 @@ void handle_global_settings_touch(int32_t x, int32_t y);
 void update_global_settings();
 void redraw_global_settings();
 void draw_global_settings_gear();
+void draw_global_bias_warning();
 orcsdr::fm::Snapshot fm_dashboard_snapshot();
 void handle_fm_dashboard_action(const orcsdr::fm::Action& action);
 orcsdr::p25::Snapshot p25_dashboard_snapshot();
@@ -4778,6 +4781,19 @@ void draw_global_settings_gear() {
   orcsdr::audio_header::draw_settings_button();
   orcsdr::audio_header::draw_mute_button(
       rtl_audio_user_enabled.load(std::memory_order_acquire));
+  draw_global_bias_warning();
+}
+
+void draw_global_bias_warning() {
+  bool enabled = false;
+  if (g_rtl == nullptr || esp_rtl_sdr_get_bias_tee(g_rtl, &enabled) != ESP_OK || !enabled)
+    return;
+  M5.Display.fillRoundRect(1016, 72, 240, 32, 6, TFT_RED);
+  M5.Display.setFont(nullptr);
+  M5.Display.setTextDatum(middle_center);
+  M5.Display.setTextColor(TFT_WHITE, TFT_RED);
+  M5.Display.setTextSize(2);
+  M5.Display.drawString("BIAS ON", 1136, 88);
 }
 
 void draw_cb_dashboard(bool static_panel) {
@@ -4987,6 +5003,152 @@ void service_visualizer() {
       request_hot_retune(action.value);
     else if (action.kind == orcsdr::visualizer::ActionKind::span_hz)
       rtl_scope_span_hz.store(action.value, std::memory_order_relaxed);
+  }
+}
+
+orcsdr::rf_lab::Runtime rf_lab_runtime() {
+  orcsdr::rf_lab::Runtime runtime{};
+  runtime.frequency_hz = rtl_ui_frequency_hz;
+  runtime.sample_rate_sps = rtl_lab_rate_override_sps.load(std::memory_order_relaxed);
+  runtime.source_available =
+      rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running;
+  runtime.sound_enabled = rtl_audio_user_enabled.load(std::memory_order_acquire);
+  runtime.volume = rtl_live_volume.load(std::memory_order_acquire);
+  runtime.sd_writable = g_sd_fs != nullptr;
+  strlcpy(runtime.driver_version, esp_rtl_sdr_get_version_string(),
+          sizeof(runtime.driver_version));
+  if (g_rtl == nullptr) {
+    strlcpy(runtime.device, "No RTL-SDR", sizeof(runtime.device));
+    strlcpy(runtime.health, "not installed", sizeof(runtime.health));
+    return runtime;
+  }
+  runtime.capabilities = esp_rtl_sdr_get_capabilities();
+  esp_rtl_sdr_metrics_t metrics{};
+  if (esp_rtl_sdr_get_metrics(g_rtl, &metrics) == ESP_OK) {
+    runtime.usb_overruns = metrics.overruns;
+    runtime.consumer_drops = metrics.consumer_drops;
+    runtime.effective_sps = metrics.effective_sps;
+    if (!runtime.sample_rate_sps) runtime.sample_rate_sps = metrics.sample_rate_sps;
+  }
+  if (!runtime.sample_rate_sps)
+    (void)esp_rtl_sdr_get_sample_rate(g_rtl, &runtime.sample_rate_sps);
+  (void)esp_rtl_sdr_get_freq_correction(g_rtl, &runtime.ppm);
+  (void)esp_rtl_sdr_get_tuner_gain(g_rtl, &runtime.gain_tenth_db);
+  size_t gain_count = 0;
+  if (esp_rtl_sdr_get_tuner_gains(g_rtl, runtime.gain_ladder,
+                                  std::size(runtime.gain_ladder), &gain_count) == ESP_OK)
+    runtime.gain_count = static_cast<uint8_t>(
+        std::min(gain_count, std::size(runtime.gain_ladder)));
+  esp_rtl_sdr_gain_mode_t mode = ESP_RTL_SDR_GAIN_MODE_AUTO;
+  if (esp_rtl_sdr_get_tuner_gain_mode(g_rtl, &mode) == ESP_OK)
+    runtime.gain_mode = mode == ESP_RTL_SDR_GAIN_MODE_AUTO
+                            ? orcsdr::rf_lab::GainMode::automatic
+                            : orcsdr::rf_lab::GainMode::manual;
+  (void)esp_rtl_sdr_get_rtl_agc(g_rtl, &runtime.rtl_agc);
+  (void)esp_rtl_sdr_get_bias_tee(g_rtl, &runtime.bias_tee);
+  esp_rtl_sdr_device_info_t device{};
+  if (esp_rtl_sdr_get_device_info(g_rtl, &device) == ESP_OK && device.present)
+    snprintf(runtime.device, sizeof(runtime.device), "%.30s %.12s", device.product,
+             device.serial);
+  else
+    strlcpy(runtime.device, "RTL-SDR unavailable", sizeof(runtime.device));
+  esp_rtl_sdr_health_info_t health{};
+  if (esp_rtl_sdr_get_health(g_rtl, &health) == ESP_OK)
+    strlcpy(runtime.health, health.advice[0] ? health.advice : "OK",
+            sizeof(runtime.health));
+  else
+    strlcpy(runtime.health, "unknown", sizeof(runtime.health));
+  return runtime;
+}
+
+void open_rf_lab() {
+  const auto origin = orcsdr::screens::status().active;
+  orcsdr::rf_lab::set_runtime(rf_lab_runtime());
+  orcsdr::screens::begin_transition(orcsdr::screens::Id::rf_lab, millis());
+  if (!orcsdr::rf_lab::enter(static_cast<uint8_t>(origin), active_dashboard_tab(origin))) {
+    orcsdr::screens::begin_transition(origin, millis());
+    orcsdr::screens::finish_transition();
+    return;
+  }
+  orcsdr::home::leave();
+  orcsdr::screens::finish_transition();
+}
+
+void close_rf_lab() {
+  const auto origin = static_cast<orcsdr::screens::Id>(orcsdr::rf_lab::origin_screen());
+  orcsdr::rf_lab::leave();
+  orcsdr::screens::begin_transition(origin, millis());
+  orcsdr::screens::finish_transition();
+  switch (origin) {
+    case orcsdr::screens::Id::home: show_home(); break;
+    case orcsdr::screens::Id::fm: orcsdr::fm::draw(); break;
+    case orcsdr::screens::Id::p25: orcsdr::p25::draw(); break;
+    case orcsdr::screens::Id::adsb: orcsdr::adsb::draw(); break;
+    case orcsdr::screens::Id::lora: orcsdr::lora::draw(); break;
+    case orcsdr::screens::Id::radio:
+      draw_sdr_screen(rtl_ui_band, rtl_ui_frequency_hz,
+                      rtl_live_volume.load(std::memory_order_acquire));
+      break;
+    default: show_home(); break;
+  }
+  draw_global_bias_warning();
+}
+
+void service_rf_lab() {
+  static uint32_t last_runtime_ms = 0;
+  const uint32_t now = millis();
+  if (!orcsdr::rf_lab::active()) return;
+  if (now - last_runtime_ms >= 200) {
+    last_runtime_ms = now;
+    orcsdr::rf_lab::set_runtime(rf_lab_runtime());
+  }
+  const auto touch = M5.Touch.getDetail(0);
+  orcsdr::rf_lab::handle_touch(touch.x, touch.y,
+                               touch.isPressed() || touch.wasPressed(), now);
+  orcsdr::rf_lab::service_ui(now);
+  orcsdr::rf_lab::Action action{};
+  while (orcsdr::rf_lab::take_action(&action)) {
+    esp_err_t result = ESP_OK;
+    using Kind = orcsdr::rf_lab::ActionKind;
+    if (action.kind == Kind::close) {
+      close_rf_lab();
+      continue;
+    }
+    if (g_rtl == nullptr) {
+      Serial.println("RTL_LAB_ACTION result=not_installed");
+      continue;
+    }
+    if (action.kind == Kind::tune_hz) {
+      if (rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running)
+        request_hot_retune(static_cast<uint32_t>(action.value));
+      else
+        queue_local_rtl_listen(RtlBand::browse, static_cast<uint32_t>(action.value), false);
+    } else if (action.kind == Kind::sample_rate_sps) {
+      const uint32_t rate = static_cast<uint32_t>(action.value);
+      if (!esp_rtl_sdr_is_rate_supported(rate)) result = ESP_ERR_INVALID_ARG;
+      else {
+        rtl_lab_rate_override_sps.store(rate, std::memory_order_release);
+        queue_local_rtl_listen(rtl_ui_band, rtl_ui_frequency_hz, false);
+      }
+    } else if (action.kind == Kind::ppm) {
+      result = esp_rtl_sdr_set_freq_correction(g_rtl, action.value);
+      if (result == ESP_OK && rtl_capture_state.load(std::memory_order_acquire) ==
+                                  RtlCaptureState::running)
+        request_hot_retune(rtl_ui_frequency_hz);
+    } else if (action.kind == Kind::gain_mode) {
+      result = esp_rtl_sdr_set_tuner_gain_mode(
+          g_rtl, action.value ? ESP_RTL_SDR_GAIN_MODE_MANUAL
+                              : ESP_RTL_SDR_GAIN_MODE_AUTO);
+    } else if (action.kind == Kind::gain_tenth_db) {
+      result = esp_rtl_sdr_set_tuner_gain(g_rtl, action.value);
+    } else if (action.kind == Kind::rtl_agc) {
+      result = esp_rtl_sdr_set_rtl_agc(g_rtl, action.value != 0);
+    } else if (action.kind == Kind::bias_tee) {
+      result = esp_rtl_sdr_set_bias_tee(g_rtl, action.value != 0);
+    }
+    Serial.printf("RTL_LAB_ACTION kind=%u value=%ld accepted=%d result=%s\n",
+                  static_cast<unsigned>(action.kind), static_cast<long>(action.value),
+                  result == ESP_OK, esp_rtl_sdr_err_to_name(result));
   }
 }
 
@@ -6564,7 +6726,13 @@ static void on_rtl_driver_event(esp_rtl_sdr_event_t event, const void *payload, 
       if (iq == nullptr || iq->data == nullptr || iq->bytes == 0) break;
       const size_t n =
           iq->bytes <= sizeof(rtl_iq_processing) ? iq->bytes : sizeof(rtl_iq_processing);
-      if (g_stream_band == RtlBand::adsb && adsb_iq_free && adsb_iq_ready) {
+      const bool lab_active = orcsdr::rf_lab::active();
+      const uint32_t lab_rate = rtl_lab_rate_override_sps.load(std::memory_order_relaxed);
+      const uint32_t decoder_rate = g_stream_band == RtlBand::adsb
+                                        ? ESP_RTL_SDR_RATE_2048K
+                                        : ESP_RTL_SDR_RATE_960K;
+      const bool lab_custom_rate = lab_active && lab_rate && lab_rate != decoder_rate;
+      if (!lab_custom_rate && g_stream_band == RtlBand::adsb && adsb_iq_free && adsb_iq_ready) {
         uint8_t index = 0;
         if (xQueueReceive(adsb_iq_free, &index, 0) == pdTRUE) {
           std::memcpy(adsb_iq_blocks[index], iq->data, n);
@@ -6575,13 +6743,14 @@ static void on_rtl_driver_event(esp_rtl_sdr_event_t event, const void *payload, 
         }
       }
       update_signal_level_from_iq(iq->data, n);
-      if (g_stream_band == RtlBand::p25) orcsdr::p25decoder::process_cu8(iq->data, n);
+      if (!lab_custom_rate && g_stream_band == RtlBand::p25)
+        orcsdr::p25decoder::process_cu8(iq->data, n);
       /* ADS-B needs the full callback budget; it has no spectrum or audio path. */
       if (g_stream_band != RtlBand::adsb || orcsdr::home::active() ||
-          orcsdr::visualizer::active())
+          orcsdr::visualizer::active() || lab_active)
         spectrum_offer_iq_snapshot(iq->data, n);
-      if (g_stream_band == RtlBand::lora) lora_iq_offer(iq->data, n);
-      if (!orcsdr::visualizer::channel_audio_active() &&
+      if (!lab_custom_rate && g_stream_band == RtlBand::lora) lora_iq_offer(iq->data, n);
+      if (!lab_custom_rate && !orcsdr::visualizer::channel_audio_active() &&
           g_stream_band != RtlBand::lora && g_stream_band != RtlBand::p25 &&
           (rtl_audio_enabled.load(std::memory_order_relaxed) ||
            g_audio_rec_active.load(std::memory_order_relaxed)) &&
@@ -6705,8 +6874,10 @@ static void rtl_driver_app_task(void *) {
       st.preset = ESP_RTL_SDR_PRESET_CUSTOM_HZ;
       st.frequency_hz =
           band == RtlBand::fm ? rtl_fm_command_lo_hz(frequency_hz) : frequency_hz;
-      st.sample_rate_sps = band == RtlBand::adsb ? ESP_RTL_SDR_RATE_2048K
-                                                  : ESP_RTL_SDR_RATE_960K;
+      const uint32_t lab_rate = rtl_lab_rate_override_sps.load(std::memory_order_acquire);
+      st.sample_rate_sps = lab_rate ? lab_rate
+                                    : band == RtlBand::adsb ? ESP_RTL_SDR_RATE_2048K
+                                                            : ESP_RTL_SDR_RATE_960K;
       esp_err_t err = esp_rtl_sdr_start(g_rtl, &st);
       Serial.printf("RTL_START %s rate=%u display_hz=%u lo_hz=%u\n",
                     esp_rtl_sdr_err_to_name(err), st.sample_rate_sps, frequency_hz,
@@ -8390,6 +8561,7 @@ void show_home(bool demo) {
 
 void draw_home_dashboard() {
   orcsdr::navigation::draw_home();
+  draw_global_bias_warning();
 }
 
 orcsdr::dashboards::Id dashboard_for_band(RtlBand band, uint32_t frequency_hz) {
@@ -8420,6 +8592,12 @@ void persist_dashboard_open(orcsdr::dashboards::Id id) {
 
 void open_dashboard(orcsdr::dashboards::Id id) {
   using Id = orcsdr::dashboards::Id;
+  if (id == Id::rf_lab) {
+    persist_dashboard_open(id);
+    open_rf_lab();
+    return;
+  }
+  rtl_lab_rate_override_sps.store(0, std::memory_order_release);
   RtlBand band = RtlBand::browse;
   uint32_t frequency = rtl_ui_frequency_hz;
   switch (id) {
@@ -10421,6 +10599,7 @@ void run_ui_regression(bool workflow) {
   const bool screen_ok = orcsdr::screens::self_check();
   const bool header_ok = orcsdr::audio_header::self_check();
   const bool home_ok = orcsdr::home::self_check();
+  const bool rf_lab_ok = orcsdr::rf_lab::self_check();
   bool workflow_ok = true;
   bool transitioned = !workflow;
   bool home_font_ok = !workflow;
@@ -10453,13 +10632,14 @@ void run_ui_regression(bool workflow) {
     }
   }
   const bool restored = ui_regression_restored(before);
-  const bool pass = radio_ui_ok && screen_ok && header_ok && home_ok && home_font_ok &&
+  const bool pass = radio_ui_ok && screen_ok && header_ok && home_ok && rf_lab_ok && home_font_ok &&
                     workflow_ok && transitioned && restored;
   Serial.printf(
-      "RTL_UI_REGRESSION_RESULT mode=%s pass=%d radio_ui=%d screen=%d header=%d home=%d "
+      "RTL_UI_REGRESSION_RESULT mode=%s pass=%d radio_ui=%d screen=%d header=%d home=%d rf_lab=%d "
       "home_font=%d workflow=%d transitioned=%d restored=%d active=%s band=%s frequency_hz=%u\n",
       workflow ? "RUN" : "CHECK", pass ? 1 : 0, radio_ui_ok ? 1 : 0,
-      screen_ok ? 1 : 0, header_ok ? 1 : 0, home_ok ? 1 : 0, home_font_ok ? 1 : 0,
+      screen_ok ? 1 : 0, header_ok ? 1 : 0, home_ok ? 1 : 0, rf_lab_ok ? 1 : 0,
+      home_font_ok ? 1 : 0,
       workflow_ok ? 1 : 0, transitioned ? 1 : 0, restored ? 1 : 0,
       orcsdr::screens::name(orcsdr::screens::status().active),
       rtl_band_name(rtl_ui_band), static_cast<unsigned>(rtl_ui_frequency_hz));
@@ -10507,6 +10687,30 @@ void process_command(char* command) {
   // Any command received from an authenticated host proves the session is alive.
   // This also keeps long-running CLI/soak workflows from expiring while polling status.
   if (authenticated) last_ping_ms = millis();
+
+  if (strncmp(command, "RTL_LAB", 7) == 0) {
+    const bool read_only = strcmp(command, "RTL_LAB STATUS") == 0 ||
+                           strcmp(command, "RTL_LAB SELF_CHECK") == 0 ||
+                           strncmp(command, "RTL_LAB GET ", 12) == 0 ||
+                           strcmp(command, "RTL_LAB RECIPE LIST") == 0 ||
+                           strcmp(command, "RTL_LAB RECORDS LIST") == 0;
+    if (!read_only && !authenticated) {
+      Serial.println("RTL_LAB_ERROR auth_required");
+      return;
+    }
+    char response[512]{};
+    if (!orcsdr::rf_lab::process_command(command, response, sizeof(response))) {
+      Serial.println("RTL_LAB_ERROR unknown_command");
+      return;
+    }
+    if (strcmp(response, "RTL_LAB_OPEN_REQUEST") == 0) {
+      open_rf_lab();
+      Serial.println(orcsdr::rf_lab::active() ? "RTL_LAB_OK" : "RTL_LAB_ERROR init_failed");
+    } else {
+      Serial.println(response);
+    }
+    return;
+  }
 
   if (strncmp(command, "RTL_VIS", 7) == 0) {
     const bool read_only = strcmp(command, "RTL_VIS STATUS") == 0 ||
@@ -10587,7 +10791,9 @@ void process_command(char* command) {
     if (strncmp(command, "UI_CAPTURE ", 11) == 0) {
       const char* slug = command + 11;
       const bool visualizer_capture = orcsdr::visualizer::active();
-      if ((!ui_doc.active || !ui_doc.current_screen[0]) && !visualizer_capture) {
+      const bool lab_capture = orcsdr::rf_lab::active();
+      if ((!ui_doc.active || !ui_doc.current_screen[0]) && !visualizer_capture &&
+          !lab_capture) {
         Serial.println("UI_CAPTURE_ERROR documentation_mode_inactive");
         return;
       }
@@ -10681,8 +10887,9 @@ void process_command(char* command) {
     else if (strcmp(name, "P25") == 0) open_dashboard(Id::p25);
     else if (strcmp(name, "ADSB") == 0) open_dashboard(Id::adsb);
     else if (strcmp(name, "LORA") == 0) open_dashboard(Id::lora);
+    else if (strcmp(name, "RF_LAB") == 0) open_dashboard(Id::rf_lab);
     else if (strcmp(name, "SETTINGS") == 0) open_dashboard(Id::settings);
-    else { Serial.println("RTL_UI_OPEN_INVALID use HOME|FM|P25|ADSB|LORA|SETTINGS"); return; }
+    else { Serial.println("RTL_UI_OPEN_INVALID use HOME|FM|P25|ADSB|LORA|RF_LAB|SETTINGS"); return; }
     Serial.printf("RTL_UI_OPEN_OK target=%s\n", name);
     return;
   }
@@ -11265,7 +11472,9 @@ void process_command(char* command) {
     Serial.println("RTL_SCREEN_STATUS             - active screen ownership diagnostics");
     Serial.println("RTL_UI_REGRESSION CHECK|RUN   - passive checks or Home->screen restore test");
     Serial.println("RTL_UI STATUS                  - current screen/dashboard state");
-    Serial.println("RTL_UI OPEN <HOME|FM|P25|ADSB|LORA|SETTINGS> - open dashboard (auth)");
+    Serial.println("RTL_UI OPEN <HOME|FM|P25|ADSB|LORA|RF_LAB|SETTINGS> - open dashboard (auth)");
+    Serial.println("RTL_LAB OPEN|CLOSE|STATUS|PAGE|GET|SET|ACTION|SELF_CHECK - RF Lab UI/control");
+    Serial.println("RTL_LAB REFERENCE|SNAPSHOT|RUN|RECIPE|RECORDS - RF Lab evidence workflow (mutations auth)");
     Serial.println("RTL_UI ACTION <domain> <action> [value] - mirror FM/P25/LoRa/Settings touch action (auth)");
     Serial.println("RTL_TUNE <BAND> <HZ>           - tune band+freq (auth) BAND=FM|AM|WX|CB|LORA|BROWSE|ADSB|P25");
     Serial.println("RTL_FREQ                       - query current band/frequency/mode");
@@ -11961,6 +12170,13 @@ void setup() {
     abort();
   }
   Serial.println("RTL_VIS_SELF_CHECK_OK");
+  const bool rf_lab_initialized = orcsdr::rf_lab::initialize(nullptr);
+  if (!rf_lab_initialized || !orcsdr::rf_lab::self_check()) {
+    Serial.println(rf_lab_initialized ? "RTL_LAB_SELF_CHECK_FAIL"
+                                      : "RTL_LAB_INIT_FAIL");
+    abort();
+  }
+  Serial.println("RTL_LAB_SELF_CHECK_OK");
   configure_navigation_service();
   if (!orcsdr::adsb::self_check() || !orcsdr::adsb_rx::Decoder::self_check() ||
       !orcsdr::offline_map::self_check() || !orcsdr::atc::self_check()) {
@@ -12064,6 +12280,7 @@ void setup() {
     abort();
   }
   const bool test_sd_ready = ensure_tab5_sd();
+  (void)orcsdr::rf_lab::initialize(g_sd_fs);
   if (test_sd_ready) {
     (void)orcsdr::offline_map::load(g_sd_fs);
     refresh_adsb_atc_preset();
@@ -12131,6 +12348,7 @@ void setup() {
   apply_wifi_antenna();
   if (!settings_wifi_power_enabled) stop_wifi();
   if (ensure_tab5_sd()) {
+    (void)orcsdr::rf_lab::initialize(g_sd_fs);
     orcsdr::catalog::begin(g_sd_fs, sd_total_bytes() - orcsdr::storage::used_bytes());
     (void)orcsdr::offline_map::load(g_sd_fs);
     refresh_adsb_atc_preset();
@@ -12197,8 +12415,9 @@ void loop() {
   const bool fm_ui = rtl_ui_band == RtlBand::fm && orcsdr::fm::active();
   const bool p25_ui = rtl_ui_band == RtlBand::p25 && orcsdr::p25::active();
   const bool visualizer_ui = orcsdr::visualizer::active();
+  const bool rf_lab_ui = orcsdr::rf_lab::active();
   if (rtl_stream_ui_refresh_pending.exchange(false, std::memory_order_acq_rel) &&
-      !settings_ui && !home_ui && !visualizer_ui) {
+      !settings_ui && !home_ui && !visualizer_ui && !rf_lab_ui) {
     refresh_active_screen();
   }
   // The main UI task is the sole M5Unified/touch/display owner.
@@ -12208,8 +12427,9 @@ void loop() {
   if (m5_elapsed_ms >= 500)
     Serial.printf("RTL_MAIN_STALL stage=m5_update elapsed_ms=%u\n", m5_elapsed_ms);
   service_visualizer();
+  service_rf_lab();
   if (rtl_stream_spectrum_pending.exchange(false, std::memory_order_acq_rel) &&
-      !orcsdr::visualizer::active() &&
+      !orcsdr::visualizer::active() && !orcsdr::rf_lab::active() &&
       (fm_ui || p25_ui || (rtl_ui_band == RtlBand::lora && orcsdr::lora::active()))) {
     draw_spectrum(nullptr, 0);
   }
@@ -12222,6 +12442,17 @@ void loop() {
   }
   if (orcsdr::visualizer::active()) {
     service_rtl_speaker_watchdog();
+    const uint32_t now = millis();
+    if (!offline_transition_handled && now - last_ping_ms > kSessionTimeoutMs) {
+      authenticated = false;
+      offline_transition_handled = true;
+      append_journal("session_degraded");
+      run_offline_workflow();
+    }
+    delay(1);
+    return;
+  }
+  if (orcsdr::rf_lab::active()) {
     const uint32_t now = millis();
     if (!offline_transition_handled && now - last_ping_ms > kSessionTimeoutMs) {
       authenticated = false;
@@ -12304,6 +12535,7 @@ void loop() {
                                  : entry->id == orcsdr::dashboards::Id::airband ? "airband"
                                  : entry->id == orcsdr::dashboards::Id::marine ? "marine"
                                  : entry->id == orcsdr::dashboards::Id::satellite ? "satellite"
+                                 : entry->id == orcsdr::dashboards::Id::rf_lab ? "rf_lab"
                                  : entry->id == orcsdr::dashboards::Id::settings ? "settings"
                                                                                : "";
               if (strcmp(command.id, name) == 0) {
@@ -12366,6 +12598,7 @@ void loop() {
                              : id == orcsdr::dashboards::Id::airband    ? "airband"
                              : id == orcsdr::dashboards::Id::marine     ? "marine"
                              : id == orcsdr::dashboards::Id::satellite  ? "satellite"
+                             : id == orcsdr::dashboards::Id::rf_lab     ? "rf_lab"
                              : id == orcsdr::dashboards::Id::settings   ? "settings"
                                                                         : "";
           if (name[0] == '\0') continue;

--- a/apps/orcsdr-tab5/ui/rf_analysis.cpp
+++ b/apps/orcsdr-tab5/ui/rf_analysis.cpp
@@ -1,0 +1,515 @@
+#include "rf_analysis.hpp"
+
+#include <M5Unified.h>
+#include <dsps_fft2r.h>
+#include <esp_heap_caps.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstring>
+
+namespace orcsdr::rf_analysis {
+namespace {
+
+constexpr size_t kIqBytes = 16384;
+constexpr size_t kAudioFrames = 2048;
+constexpr size_t kMaxFft = 8192;
+constexpr float kPi = 3.14159265358979323846f;
+
+SemaphoreHandle_t g_iq_mutex = nullptr;
+SemaphoreHandle_t g_audio_mutex = nullptr;
+SemaphoreHandle_t g_snapshot_mutex = nullptr;
+uint8_t* g_iq = nullptr;
+size_t g_iq_bytes = 0;
+uint32_t g_iq_revision = 0;
+int16_t* g_audio_l = nullptr;
+size_t g_audio_frames = 0;
+uint32_t g_audio_revision = 0;
+Snapshot* g_snapshot = nullptr;
+TaskHandle_t g_task = nullptr;
+std::atomic<bool> g_enabled{false};
+std::atomic<bool> g_fft_ready{false};
+std::atomic<uint32_t> g_input_drops{0};
+Config g_config{};
+portMUX_TYPE g_config_mux = portMUX_INITIALIZER_UNLOCKED;
+Observer g_observer = nullptr;
+portMUX_TYPE g_observer_mux = portMUX_INITIALIZER_UNLOCKED;
+float g_last_peak_hz = 0;
+float g_last_peak_db = -160;
+std::atomic<uint8_t> g_stable_frames{0};
+
+int fit_fft_size(int requested, size_t available) {
+  requested = std::min<int>(requested, static_cast<int>(kMaxFft));
+  while (requested > static_cast<int>(available)) requested >>= 1;
+  return requested >= 256 ? requested : 0;
+}
+
+size_t append_audio_window(int16_t* destination, size_t capacity, size_t used,
+                           const int16_t* source, size_t count) {
+  if (!destination || !capacity || !source || !count) return used;
+  if (count >= capacity) {
+    memcpy(destination, source + count - capacity, capacity * sizeof(*destination));
+    return capacity;
+  }
+  used = std::min(used, capacity);
+  const size_t overflow = used + count > capacity ? used + count - capacity : 0;
+  if (overflow) {
+    memmove(destination, destination + overflow, (used - overflow) * sizeof(*destination));
+    used -= overflow;
+  }
+  memcpy(destination + used, source, count * sizeof(*destination));
+  return used + count;
+}
+
+size_t demodulate_audio(const uint8_t* iq, size_t bytes, AudioDemod demod,
+                        uint32_t sample_rate, uint32_t audio_rate,
+                        int16_t* output, size_t capacity) {
+  if (!iq || bytes < 4 || demod == AudioDemod::none || !output || !capacity) return 0;
+  const uint32_t decimation =
+      std::max<uint32_t>(1, sample_rate / std::max<uint32_t>(1, audio_rate));
+  float previous_i = static_cast<int>(iq[0]) - 127.5f;
+  float previous_q = static_cast<int>(iq[1]) - 127.5f;
+  float sum = 0, dc = 0;
+  uint32_t phase = 0;
+  size_t count = 0;
+  for (size_t offset = 2; offset + 1 < bytes && count < capacity; offset += 2) {
+    const float i = static_cast<int>(iq[offset]) - 127.5f;
+    const float q = static_cast<int>(iq[offset + 1]) - 127.5f;
+    float sample = 0;
+    if (demod == AudioDemod::fm) {
+      const float cross = previous_i * q - previous_q * i;
+      const float dot = previous_i * i + previous_q * q;
+      sample = cross / (fabsf(dot) + 64.0f);
+    } else {
+      sample = fabsf(i) + fabsf(q);
+      dc += 0.002f * (sample - dc);
+      sample = (sample - dc) * 0.02f;
+    }
+    previous_i = i;
+    previous_q = q;
+    sum += sample;
+    if (++phase == decimation) {
+      output[count++] = static_cast<int16_t>(std::clamp(
+          sum * (demod == AudioDemod::fm ? 9000.0f : 7000.0f) / decimation,
+          -16000.0f, 16000.0f));
+      phase = 0;
+      sum = 0;
+    }
+  }
+  return count;
+}
+
+float robust_noise(const Snapshot& frame, uint16_t dc_guard_bins,
+                   size_t strongest_bin, float* scratch) {
+  size_t used = 0;
+  const size_t center = frame.bins / 2;
+  for (size_t i = 0; i < frame.bins; ++i) {
+    if (i + dc_guard_bins >= center && i <= center + dc_guard_bins) continue;
+    if (i + 2 >= strongest_bin && i <= strongest_bin + 2) continue;
+    scratch[used++] = frame.live[i];
+  }
+  if (!used) return -160;
+  std::nth_element(scratch, scratch + used / 2, scratch + used);
+  return scratch[used / 2];
+}
+
+uint32_t occupied_bandwidth(const Snapshot& frame, size_t first, size_t last,
+                            float bin_hz) {
+  if (last <= first || last > frame.bins) return 0;
+  float total = 0;
+  for (size_t i = first; i < last; ++i) total += powf(10.0f, frame.live[i] / 10.0f);
+  if (total <= 0) return 0;
+  const float low_target = total * 0.005f;
+  const float high_target = total * 0.995f;
+  float sum = 0;
+  size_t low = first, high = last - 1;
+  bool low_found = false;
+  for (size_t i = first; i < last; ++i) {
+    sum += powf(10.0f, frame.live[i] / 10.0f);
+    if (!low_found && sum >= low_target) {
+      low = i;
+      low_found = true;
+    }
+    if (sum >= high_target) {
+      high = i;
+      break;
+    }
+  }
+  return static_cast<uint32_t>(lroundf((high - low + 1) * bin_hz));
+}
+
+void analyze_audio(Snapshot* next, float* work, int16_t* local_audio,
+                   const uint8_t* iq, size_t iq_bytes, const Config& config) {
+  if (!config.audio_spectrum) {
+    next->audio_bins = 0;
+    return;
+  }
+  static uint32_t analyzed_revision = 0;
+  size_t frames = 0;
+  if (xSemaphoreTake(g_audio_mutex, 0) == pdTRUE) {
+    if (g_audio_revision != analyzed_revision) {
+      frames = std::min(g_audio_frames, kAudioFrames);
+      memcpy(local_audio, g_audio_l, frames * sizeof(*local_audio));
+      analyzed_revision = g_audio_revision;
+    }
+    xSemaphoreGive(g_audio_mutex);
+  }
+  if (frames < 256)
+    frames = demodulate_audio(iq, iq_bytes, config.audio_demod,
+                              config.sample_rate_sps, config.audio_rate_sps,
+                              local_audio, kAudioFrames);
+  const int n = fit_fft_size(config.audio_fft_size, frames);
+  if (!n) return;
+  float coherent_sum = 0;
+  for (int i = 0; i < n; ++i) {
+    const float window = 0.5f - 0.5f * cosf(2.0f * kPi * i / (n - 1));
+    coherent_sum += window;
+    work[i * 2] = local_audio[i] * window / 32768.0f;
+    work[i * 2 + 1] = 0;
+  }
+  if (dsps_fft2r_fc32_ansi(work, n) != ESP_OK ||
+      dsps_bit_rev_fc32_ansi(work, n) != ESP_OK)
+    return;
+  next->audio_bins = static_cast<uint16_t>(std::min<int>(kMaxBins, n / 2));
+  for (size_t x = 0; x < next->audio_bins; ++x) {
+    const size_t source = x * (n / 2) / next->audio_bins;
+    const float amplitude = hypotf(work[source * 2], work[source * 2 + 1]) /
+                            std::max(1.0f, coherent_sum);
+    next->audio[x] = 20.0f * log10f(amplitude + 1.0e-12f);
+  }
+}
+
+bool analyze_iq(const uint8_t* iq, size_t bytes, Snapshot* next, float* work,
+                float* scratch, const Config& config) {
+  if (!iq || !next || !work || !scratch || bytes < 512) return false;
+  const int n = fit_fft_size(config.fft_size, bytes / 2);
+  if (!n) return false;
+  const size_t iq_points = std::min<size_t>(kMaxIqPoints, bytes / 2);
+  float sum_i = 0, sum_q = 0, sum_i2 = 0, sum_q2 = 0;
+  size_t clipped = 0;
+  for (size_t i = 0; i < iq_points; ++i) {
+    const uint8_t raw_i = iq[i * 2], raw_q = iq[i * 2 + 1];
+    const float re = (static_cast<int>(raw_i) - 127.5f) / 127.5f;
+    const float im = (static_cast<int>(raw_q) - 127.5f) / 127.5f;
+    next->iq_i[i] = re;
+    next->iq_q[i] = im;
+    sum_i += re;
+    sum_q += im;
+    sum_i2 += re * re;
+    sum_q2 += im * im;
+    clipped += raw_i == 0 || raw_i == 255 || raw_q == 0 || raw_q == 255;
+  }
+  next->iq_count = static_cast<uint16_t>(iq_points);
+  next->dc_i = sum_i / iq_points;
+  next->dc_q = sum_q / iq_points;
+  const float rms_i = sqrtf(sum_i2 / iq_points);
+  const float rms_q = sqrtf(sum_q2 / iq_points);
+  next->iq_imbalance_db = 20.0f * log10f((rms_i + 1.0e-9f) / (rms_q + 1.0e-9f));
+  next->clipping_percent = 100.0f * clipped / iq_points;
+  for (size_t i = 0; i < iq_points; ++i) {
+    next->iq_i[i] -= next->dc_i;
+    next->iq_q[i] -= next->dc_q;
+  }
+
+  float coherent_sum = 0;
+  for (int i = 0; i < n; ++i) {
+    const float window = 0.5f - 0.5f * cosf(2.0f * kPi * i / (n - 1));
+    coherent_sum += window;
+    work[i * 2] = ((static_cast<int>(iq[i * 2]) - 127.5f) / 127.5f) * window;
+    work[i * 2 + 1] = ((static_cast<int>(iq[i * 2 + 1]) - 127.5f) / 127.5f) * window;
+  }
+  if (dsps_fft2r_fc32_ansi(work, n) != ESP_OK ||
+      dsps_bit_rev_fc32_ansi(work, n) != ESP_OK)
+    return false;
+
+  next->bins = static_cast<uint16_t>(std::min<int>(kMaxBins, n));
+  next->fft_size = static_cast<uint16_t>(n);
+  next->center_hz = config.center_hz;
+  next->span_hz = config.span_hz;
+  next->sample_rate_sps = config.sample_rate_sps;
+  next->window = config.window;
+  next->rbw_hz = static_cast<float>(config.sample_rate_sps) / n * 1.5f;
+  next->strongest = -160;
+  size_t strongest_bin = next->bins / 2;
+  for (size_t x = 0; x < next->bins; ++x) {
+    const size_t first = x * n / next->bins;
+    const size_t last = std::max(first + 1, (x + 1) * n / next->bins);
+    float best = 0;
+    for (size_t source = first; source < last; ++source) {
+      const size_t shifted = (source + n / 2) % n;
+      best = std::max(best, hypotf(work[shifted * 2], work[shifted * 2 + 1]));
+    }
+    const float db = 20.0f * log10f(best / std::max(1.0f, coherent_sum) + 1.0e-12f);
+    next->live[x] = db;
+    const float linear = powf(10.0f, db / 10.0f);
+    const float old_average = powf(10.0f, next->average[x] / 10.0f);
+    next->average[x] = 10.0f * log10f(0.15f * linear + 0.85f * old_average + 1.0e-14f);
+    next->peak[x] = std::max(db, next->peak[x] - 0.15f);
+    if (db > next->strongest) {
+      next->strongest = db;
+      strongest_bin = x;
+    }
+  }
+  next->noise = robust_noise(*next, config.dc_guard_bins, strongest_bin, scratch);
+  next->snr_db = std::max(0.0f, next->strongest - next->noise);
+  const float bin_hz = static_cast<float>(config.span_hz) / std::max<uint16_t>(1, next->bins);
+  float interpolated_bin = static_cast<float>(strongest_bin);
+  if (strongest_bin > 0 && strongest_bin + 1 < next->bins) {
+    const float a = next->live[strongest_bin - 1];
+    const float b = next->live[strongest_bin];
+    const float c = next->live[strongest_bin + 1];
+    const float denominator = a - 2.0f * b + c;
+    if (fabsf(denominator) > 1.0e-6f)
+      interpolated_bin += std::clamp(0.5f * (a - c) / denominator, -0.5f, 0.5f);
+  }
+  next->strongest_offset_hz = (interpolated_bin - next->bins / 2.0f) * bin_hz;
+  next->strongest_frequency_hz = static_cast<uint32_t>(std::max(
+      0.0f, static_cast<float>(config.center_hz) + next->strongest_offset_hz));
+
+  const size_t measure_bins = config.measurement_bandwidth_hz
+                                  ? std::max<size_t>(1, lroundf(config.measurement_bandwidth_hz / bin_hz))
+                                  : next->bins;
+  const size_t first = measure_bins >= next->bins ? 0 : (next->bins - measure_bins) / 2;
+  const size_t last = std::min<size_t>(next->bins, first + measure_bins);
+  float channel_power = 0;
+  for (size_t i = first; i < last; ++i)
+    channel_power += powf(10.0f, next->live[i] / 10.0f) / 1.5f;
+  next->channel_power_dbfs = 10.0f * log10f(channel_power + 1.0e-14f);
+  next->occupied_bandwidth_hz = occupied_bandwidth(*next, first, last, bin_hz);
+
+  const bool stable = fabsf(next->strongest_offset_hz - g_last_peak_hz) <= 2.0f * bin_hz &&
+                      fabsf(next->strongest - g_last_peak_db) <= 1.5f;
+  const uint8_t stable_frames = stable
+                                    ? std::min<uint8_t>(
+                                          20, g_stable_frames.load(std::memory_order_relaxed) + 1)
+                                    : 0;
+  g_stable_frames.store(stable_frames, std::memory_order_relaxed);
+  next->source_stable = stable_frames >= 5;
+  g_last_peak_hz = next->strongest_offset_hz;
+  g_last_peak_db = next->strongest;
+  return true;
+}
+
+void worker(void*) {
+  float* work = static_cast<float*>(heap_caps_aligned_alloc(
+      16, sizeof(float) * kMaxFft * 2, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  float* scratch = static_cast<float*>(
+      heap_caps_malloc(sizeof(float) * kMaxBins, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  uint8_t* local_iq = static_cast<uint8_t*>(
+      heap_caps_malloc(kIqBytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  int16_t* local_audio = static_cast<int16_t*>(
+      heap_caps_malloc(kAudioFrames * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  Snapshot* next = static_cast<Snapshot*>(
+      heap_caps_malloc(sizeof(Snapshot), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  uint32_t seen_revision = 0;
+  uint32_t last_ms = 0;
+  while (true) {
+    if (!g_enabled.load(std::memory_order_acquire) || !work || !scratch || !local_iq ||
+        !local_audio || !next) {
+      vTaskDelay(pdMS_TO_TICKS(50));
+      continue;
+    }
+    Config config{};
+    portENTER_CRITICAL(&g_config_mux);
+    config = g_config;
+    portEXIT_CRITICAL(&g_config_mux);
+    if (millis() - last_ms < config.interval_ms) {
+      vTaskDelay(pdMS_TO_TICKS(5));
+      continue;
+    }
+    size_t bytes = 0;
+    uint32_t revision = 0;
+    if (xSemaphoreTake(g_iq_mutex, 0) == pdTRUE) {
+      revision = g_iq_revision;
+      if (revision != seen_revision) {
+        bytes = g_iq_bytes;
+        memcpy(local_iq, g_iq, bytes);
+      }
+      xSemaphoreGive(g_iq_mutex);
+    }
+    if (!bytes) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      continue;
+    }
+    seen_revision = revision;
+    last_ms = millis();
+    if (xSemaphoreTake(g_snapshot_mutex, pdMS_TO_TICKS(2)) != pdTRUE) continue;
+    *next = *g_snapshot;
+    xSemaphoreGive(g_snapshot_mutex);
+    if (!analyze_iq(local_iq, bytes, next, work, scratch, config)) continue;
+    analyze_audio(next, work, local_audio, local_iq, bytes, config);
+    next->revision = revision;
+    next->analyzed_ms = millis();
+    ++next->frame_count;
+    next->input_drops = g_input_drops.load(std::memory_order_relaxed);
+    if (xSemaphoreTake(g_snapshot_mutex, pdMS_TO_TICKS(2)) == pdTRUE) {
+      *g_snapshot = *next;
+      xSemaphoreGive(g_snapshot_mutex);
+    }
+    Observer observer = nullptr;
+    portENTER_CRITICAL(&g_observer_mux);
+    observer = g_observer;
+    portEXIT_CRITICAL(&g_observer_mux);
+    if (observer) observer(*next, local_iq, bytes);
+  }
+}
+
+}  // namespace
+
+bool initialize_fft() {
+  if (g_fft_ready.load(std::memory_order_acquire)) return true;
+  // ponytail: boot initialization is serialized; add a mutex only if callers become concurrent.
+  if (dsps_fft2r_init_fc32(nullptr, kMaxFft) != ESP_OK) return false;
+  g_fft_ready.store(true, std::memory_order_release);
+  return true;
+}
+
+bool initialize() {
+  if (g_task) return true;
+  g_iq_mutex = xSemaphoreCreateMutex();
+  g_audio_mutex = xSemaphoreCreateMutex();
+  g_snapshot_mutex = xSemaphoreCreateMutex();
+  g_iq = static_cast<uint8_t*>(
+      heap_caps_malloc(kIqBytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  g_audio_l = static_cast<int16_t*>(
+      heap_caps_malloc(kAudioFrames * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  g_snapshot = static_cast<Snapshot*>(
+      heap_caps_calloc(1, sizeof(Snapshot), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  if (!g_iq_mutex || !g_audio_mutex || !g_snapshot_mutex || !g_iq || !g_audio_l ||
+      !g_snapshot)
+    return false;
+  for (float& level : g_snapshot->average) level = -160;
+  for (float& level : g_snapshot->peak) level = -160;
+  if (!initialize_fft()) return false;
+  if (xTaskCreatePinnedToCoreWithCaps(worker, "rf_analysis", 8192, nullptr, 1, &g_task, 1,
+                                      MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) != pdPASS)
+    return false;
+  return true;
+}
+
+void set_enabled(bool value) { g_enabled.store(value, std::memory_order_release); }
+bool enabled() { return g_enabled.load(std::memory_order_acquire); }
+
+void set_config(const Config& value) {
+  Config next = value;
+  next.fft_size = static_cast<uint16_t>(std::clamp<int>(next.fft_size, 256, kMaxFft));
+  next.audio_fft_size = static_cast<uint16_t>(std::clamp<int>(next.audio_fft_size, 256, 2048));
+  next.interval_ms = std::clamp<uint16_t>(next.interval_ms, 16, 1000);
+  portENTER_CRITICAL(&g_config_mux);
+  g_config = next;
+  portEXIT_CRITICAL(&g_config_mux);
+  g_stable_frames.store(0, std::memory_order_relaxed);
+}
+
+void set_observer(Observer observer) {
+  portENTER_CRITICAL(&g_observer_mux);
+  g_observer = observer;
+  portEXIT_CRITICAL(&g_observer_mux);
+}
+
+void offer_iq(const uint8_t* iq, size_t bytes) {
+  if (!enabled() || !iq || bytes < 512 || !g_iq_mutex) return;
+  if (xSemaphoreTake(g_iq_mutex, 0) != pdTRUE) {
+    g_input_drops.fetch_add(1, std::memory_order_relaxed);
+    return;
+  }
+  g_iq_bytes = std::min(bytes, kIqBytes);
+  memcpy(g_iq, iq, g_iq_bytes);
+  ++g_iq_revision;
+  xSemaphoreGive(g_iq_mutex);
+}
+
+void offer_audio(const int16_t* left, const int16_t* right, size_t frames,
+                 uint32_t sample_rate_sps) {
+  (void)right;
+  (void)sample_rate_sps;
+  if (!enabled() || !left || !frames || !g_audio_mutex) return;
+  if (xSemaphoreTake(g_audio_mutex, 0) != pdTRUE) return;
+  const size_t used = g_audio_frames;
+  g_audio_frames = append_audio_window(g_audio_l, kAudioFrames, used, left, frames);
+  ++g_audio_revision;
+  xSemaphoreGive(g_audio_mutex);
+}
+
+bool copy_snapshot(Snapshot* output) {
+  if (!output || !g_snapshot_mutex ||
+      xSemaphoreTake(g_snapshot_mutex, pdMS_TO_TICKS(2)) != pdTRUE)
+    return false;
+  *output = *g_snapshot;
+  xSemaphoreGive(g_snapshot_mutex);
+  return true;
+}
+
+void clear_peak() {
+  if (g_snapshot_mutex && xSemaphoreTake(g_snapshot_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+    for (float& level : g_snapshot->peak) level = -160;
+    xSemaphoreGive(g_snapshot_mutex);
+  }
+}
+
+void clear_average() {
+  if (g_snapshot_mutex && xSemaphoreTake(g_snapshot_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+    for (float& level : g_snapshot->average) level = -160;
+    xSemaphoreGive(g_snapshot_mutex);
+  }
+}
+
+bool self_check() {
+  if (fit_fft_size(1024, 372) != 256 || fit_fft_size(2048, 1024) != 1024 ||
+      fit_fft_size(256, 128) != 0)
+    return false;
+  int16_t audio_window[4] = {1, 2, 3, 4};
+  const int16_t audio_tail[3] = {5, 6, 7};
+  if (append_audio_window(audio_window, 4, 4, audio_tail, 3) != 4 ||
+      audio_window[0] != 4 || audio_window[1] != 5 || audio_window[3] != 7)
+    return false;
+  if (sizeof(Snapshot) >= 32 * 1024 || !g_task) return false;
+
+  constexpr size_t samples = 256;
+  auto* iq = static_cast<uint8_t*>(heap_caps_malloc(samples * 2, MALLOC_CAP_8BIT));
+  auto* work = static_cast<float*>(
+      heap_caps_aligned_alloc(16, samples * 2 * sizeof(float), MALLOC_CAP_8BIT));
+  auto* scratch = static_cast<float*>(
+      heap_caps_malloc(kMaxBins * sizeof(float), MALLOC_CAP_8BIT));
+  auto* snapshot = static_cast<Snapshot*>(
+      heap_caps_calloc(1, sizeof(Snapshot), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  if (!iq || !work || !scratch || !snapshot) {
+    heap_caps_free(iq);
+    heap_caps_free(work);
+    heap_caps_free(scratch);
+    heap_caps_free(snapshot);
+    return false;
+  }
+  for (size_t i = 0; i < samples; ++i) {
+    const float phase = 2.0f * kPi * 32.0f * i / samples;
+    iq[i * 2] = static_cast<uint8_t>(lroundf(127.5f + 80.0f * cosf(phase)));
+    iq[i * 2 + 1] = static_cast<uint8_t>(lroundf(127.5f + 80.0f * sinf(phase)));
+    snapshot->average[i] = -160;
+    snapshot->peak[i] = -160;
+  }
+  Config config{};
+  config.center_hz = 100000000;
+  config.span_hz = 960000;
+  config.sample_rate_sps = 960000;
+  config.measurement_bandwidth_hz = 480000;
+  config.fft_size = samples;
+  const bool analyzed = analyze_iq(iq, samples * 2, snapshot, work, scratch, config);
+  const bool valid = analyzed && snapshot->bins == samples &&
+                     fabsf(snapshot->strongest_offset_hz - 120000.0f) < 8000.0f &&
+                     snapshot->strongest > -8.0f && snapshot->strongest < 0.0f &&
+                     snapshot->clipping_percent == 0.0f &&
+                     fabsf(snapshot->iq_imbalance_db) < 0.5f &&
+                     snapshot->occupied_bandwidth_hz > 0 &&
+                     snapshot->occupied_bandwidth_hz < 100000;
+  heap_caps_free(iq);
+  heap_caps_free(work);
+  heap_caps_free(scratch);
+  heap_caps_free(snapshot);
+  return valid;
+}
+
+}  // namespace orcsdr::rf_analysis

--- a/apps/orcsdr-tab5/ui/rf_analysis.hpp
+++ b/apps/orcsdr-tab5/ui/rf_analysis.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace orcsdr::rf_analysis {
+
+constexpr size_t kMaxBins = 1024;
+constexpr size_t kMaxIqPoints = 1024;
+
+enum class Window : uint8_t { hann };
+enum class AudioDemod : uint8_t { none, fm, am };
+
+struct Config {
+  uint32_t center_hz = 0;
+  uint32_t span_hz = 960000;
+  uint32_t sample_rate_sps = 960000;
+  uint32_t audio_rate_sps = 48000;
+  uint32_t measurement_bandwidth_hz = 0;
+  uint16_t fft_size = 1024;
+  uint16_t audio_fft_size = 1024;
+  uint16_t dc_guard_bins = 3;
+  uint16_t interval_ms = 33;
+  Window window = Window::hann;
+  AudioDemod audio_demod = AudioDemod::none;
+  bool audio_spectrum = false;
+};
+
+struct Snapshot {
+  uint32_t revision = 0;
+  uint32_t analyzed_ms = 0;
+  uint32_t frame_count = 0;
+  uint32_t input_drops = 0;
+  uint32_t center_hz = 0;
+  uint32_t span_hz = 0;
+  uint32_t sample_rate_sps = 0;
+  uint32_t strongest_frequency_hz = 0;
+  uint32_t occupied_bandwidth_hz = 0;
+  uint16_t bins = 0;
+  uint16_t fft_size = 0;
+  uint16_t iq_count = 0;
+  uint16_t audio_bins = 0;
+  Window window = Window::hann;
+  float rbw_hz = 0;
+  float live[kMaxBins]{};
+  float average[kMaxBins]{};
+  float peak[kMaxBins]{};
+  float noise = -160;
+  float strongest = -160;
+  float snr_db = 0;
+  float channel_power_dbfs = -160;
+  float strongest_offset_hz = 0;
+  float clipping_percent = 0;
+  float dc_i = 0;
+  float dc_q = 0;
+  float iq_imbalance_db = 0;
+  bool source_stable = false;
+  float iq_i[kMaxIqPoints]{};
+  float iq_q[kMaxIqPoints]{};
+  float audio[kMaxBins]{};
+};
+
+using Observer = void (*)(const Snapshot& snapshot, const uint8_t* iq, size_t bytes);
+
+bool initialize_fft();
+bool initialize();
+void set_enabled(bool enabled);
+bool enabled();
+void set_config(const Config& config);
+void set_observer(Observer observer);
+void offer_iq(const uint8_t* iq, size_t bytes);
+void offer_audio(const int16_t* left, const int16_t* right, size_t frames,
+                 uint32_t sample_rate_sps);
+bool copy_snapshot(Snapshot* output);
+void clear_peak();
+void clear_average();
+bool self_check();
+
+}  // namespace orcsdr::rf_analysis

--- a/apps/orcsdr-tab5/ui/rf_lab.cpp
+++ b/apps/orcsdr-tab5/ui/rf_lab.cpp
@@ -1,0 +1,1280 @@
+#include "rf_lab.hpp"
+
+#include "rf_analysis.hpp"
+
+#include <M5Unified.h>
+#include <esp_app_desc.h>
+#include <esp_heap_caps.h>
+#include <esp_rtl_sdr.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <mbedtls/sha256.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <iterator>
+
+namespace orcsdr::rf_lab {
+namespace {
+
+constexpr uint16_t kBg = TFT_BLACK;
+constexpr uint16_t kPanel = 0x0841;
+constexpr uint16_t kGrid = 0x2945;
+constexpr uint16_t kCyan = 0x2e7f;
+constexpr uint16_t kGreen = 0x6fe8;
+constexpr uint16_t kMuted = 0x8c71;
+constexpr uint16_t kRed = 0xf800;
+constexpr int kPlotX = 22, kPlotY = 96, kPlotW = 830, kPlotH = 530;
+constexpr int kSpectrumH = 260, kWaterfallY = 372, kWaterfallH = 242;
+constexpr int kSideX = 870, kSideW = 388;
+constexpr int kFooterY = 650, kFooterH = 56;
+constexpr uint32_t kBiasHoldMs = 2000;
+constexpr size_t kActionCapacity = 16;
+constexpr size_t kMaxReadings = 3600;
+constexpr size_t kScreenPixels = 1280u * 720u;
+
+std::atomic<bool> g_active{false};
+Runtime g_runtime{};
+Runtime g_initial{};
+portMUX_TYPE g_runtime_mux = portMUX_INITIALIZER_UNLOCKED;
+Page g_page = Page::live;
+uint8_t g_origin_screen = 0, g_origin_tab = 0;
+bool g_keep_settings = false;
+bool g_dirty = true;
+uint32_t g_last_draw_ms = 0;
+uint32_t g_last_revision = 0;
+rf_analysis::Snapshot g_snapshot{};
+M5Canvas g_waterfall(&M5.Display);
+bool g_waterfall_ready = false;
+Action g_actions[kActionCapacity]{};
+size_t g_action_read = 0, g_action_write = 0;
+bool g_pressed = false;
+int32_t g_press_x = 0, g_press_y = 0;
+uint32_t g_press_ms = 0;
+bool g_bias_ack = false;
+bool g_bias_hold_fired = false;
+char g_message[96]{};
+uint32_t g_message_until_ms = 0;
+uint32_t g_bias_cli_ack_until_ms = 0;
+storage::FileSystem* g_filesystem = nullptr;
+
+struct Reference {
+  bool configured = false;
+  bool calibrated = false;
+  uint32_t frequency_hz = 0;
+  float source_dbm = 0;
+  float path_loss_db = 0;
+  float tolerance_db = 0;
+  float dbm_offset = 0;
+  Runtime calibration_runtime{};
+  char note[64]{};
+};
+
+struct Reading {
+  uint32_t elapsed_ms = 0;
+  uint32_t frequency_hz = 0;
+  uint32_t effective_sps = 0;
+  float peak_dbfs = -160;
+  float peak_offset_hz = 0;
+  float noise_dbfs = -160;
+  float snr_db = 0;
+  float channel_power_dbfs = -160;
+  float occupied_bandwidth_hz = 0;
+  float clipping_percent = 0;
+  float dc_i = 0, dc_q = 0, iq_imbalance_db = 0;
+  bool source_available = false;
+  bool marker = false;
+  char note[48]{};
+};
+
+struct SaveJob {
+  Reading* readings = nullptr;
+  size_t count = 0;
+  uint16_t* screen = nullptr;
+  Runtime runtime{};
+  Reference reference{};
+  uint32_t started_ms = 0;
+  uint32_t stopped_ms = 0;
+  char id[32]{};
+  char result[32]{};
+};
+
+Reference g_reference{};
+Reading* g_readings = nullptr;
+size_t g_reading_count = 0;
+bool g_run_active = false;
+bool g_run_paused = false;
+uint32_t g_run_started_ms = 0;
+uint32_t g_run_duration_ms = 0;
+uint32_t g_last_reading_ms = 0;
+char g_pending_marker[48]{};
+SaveJob g_save_job{};
+std::atomic<bool> g_save_pending{false};
+std::atomic<bool> g_save_busy{false};
+std::atomic<bool> g_save_ok{false};
+std::atomic<bool> g_save_finished{false};
+TaskHandle_t g_save_task = nullptr;
+char g_recent_ids[8][32]{};
+char g_recent_results[8][32]{};
+size_t g_recent_count = 0;
+uint32_t g_session_sequence = 0;
+bool g_last_source_available = false;
+bool g_source_state_known = false;
+uint32_t g_loss_revision = 0;
+char g_recipe[32]{"NONE"};
+char g_recipe_status[64]{"IDLE"};
+uint32_t g_recipe_usb_overruns = 0;
+uint32_t g_recipe_consumer_drops = 0;
+
+bool inside(int32_t x, int32_t y, int bx, int by, int bw, int bh) {
+  return x >= bx && x < bx + bw && y >= by && y < by + bh;
+}
+
+void text(const char* value, int x, int y, uint16_t color = TFT_WHITE,
+          uint8_t size = 2, textdatum_t datum = middle_left) {
+  M5.Display.setFont(nullptr);
+  M5.Display.setTextDatum(datum);
+  M5.Display.setTextColor(color, kBg);
+  M5.Display.setTextSize(size);
+  M5.Display.drawString(value, x, y);
+}
+
+void panel(int x, int y, int w, int h, uint16_t color = kCyan) {
+  M5.Display.fillRoundRect(x, y, w, h, 9, kPanel);
+  M5.Display.drawRoundRect(x, y, w, h, 9, color);
+}
+
+void message(const char* value) {
+  strlcpy(g_message, value, sizeof(g_message));
+  g_message_until_ms = millis() + 3500;
+  g_dirty = true;
+}
+
+bool queue(ActionKind kind, int32_t value) {
+  const size_t next = (g_action_write + 1) % kActionCapacity;
+  if (next == g_action_read) return false;
+  g_actions[g_action_write] = {kind, value};
+  g_action_write = next;
+  return true;
+}
+
+bool safe_note(const char* value) {
+  if (!value || strlen(value) >= sizeof(g_pending_marker)) return false;
+  for (const char* p = value; *p; ++p)
+    if (*p < 32 || *p > 126 || *p == '"' || *p == '\\' || *p == ',') return false;
+  return true;
+}
+
+bool write_hashed(File& file, mbedtls_sha256_context& sha, const void* data,
+                  size_t bytes) {
+  return file.write(static_cast<const uint8_t*>(data), bytes) == bytes &&
+         mbedtls_sha256_update(&sha, static_cast<const uint8_t*>(data), bytes) == 0;
+}
+
+void hex_string(const uint8_t* bytes, size_t count, char* output, size_t capacity) {
+  if (!bytes || !output || capacity < count * 2 + 1) return;
+  for (size_t i = 0; i < count; ++i) snprintf(output + i * 2, 3, "%02x", bytes[i]);
+}
+
+bool begin_part(const char* path, char* part, size_t part_size, File* file) {
+  if (!g_filesystem || !path || !part || !file ||
+      snprintf(part, part_size, "%s.part", path) >= static_cast<int>(part_size)) return false;
+  g_filesystem->remove(part);
+  *file = g_filesystem->open(part, FILE_WRITE, true);
+  if (!*file) *file = g_filesystem->open(part, FILE_WRITE);
+  return static_cast<bool>(*file);
+}
+
+bool finish_part(const char* part, const char* path, File* file) {
+  if (!file || !*file) return false;
+  file->flush();
+  file->close();
+  g_filesystem->remove(path);
+  if (g_filesystem->rename(part, path)) return true;
+  g_filesystem->remove(part);
+  return false;
+}
+
+bool write_csv(const SaveJob& job, const char* directory, uint8_t hash[32]) {
+  char path[112], part[120];
+  snprintf(path, sizeof(path), "%s/readings.csv", directory);
+  File file;
+  if (!begin_part(path, part, sizeof(part), &file)) return false;
+  mbedtls_sha256_context sha;
+  mbedtls_sha256_init(&sha);
+  bool ok = mbedtls_sha256_starts(&sha, 0) == 0;
+  constexpr char header[] =
+      "elapsed_ms,frequency_hz,effective_sps,peak_dbfs,peak_offset_hz,noise_dbfs,snr_db,channel_power_dbfs,occupied_bandwidth_hz,clipping_percent,dc_i,dc_q,iq_imbalance_db,source,marker,note\n";
+  ok = ok && write_hashed(file, sha, header, sizeof(header) - 1);
+  char line[384];
+  for (size_t i = 0; ok && i < job.count; ++i) {
+    const Reading& r = job.readings[i];
+    const int length = snprintf(
+        line, sizeof(line),
+        "%lu,%lu,%lu,%.3f,%.1f,%.3f,%.3f,%.3f,%.1f,%.4f,%.5f,%.5f,%.3f,%d,%d,\"%s\"\n",
+        static_cast<unsigned long>(r.elapsed_ms),
+        static_cast<unsigned long>(r.frequency_hz),
+        static_cast<unsigned long>(r.effective_sps), static_cast<double>(r.peak_dbfs),
+        static_cast<double>(r.peak_offset_hz), static_cast<double>(r.noise_dbfs),
+        static_cast<double>(r.snr_db), static_cast<double>(r.channel_power_dbfs),
+        static_cast<double>(r.occupied_bandwidth_hz),
+        static_cast<double>(r.clipping_percent), static_cast<double>(r.dc_i),
+        static_cast<double>(r.dc_q), static_cast<double>(r.iq_imbalance_db),
+        r.source_available, r.marker, r.note);
+    ok = length > 0 && length < static_cast<int>(sizeof(line)) &&
+         write_hashed(file, sha, line, static_cast<size_t>(length));
+  }
+  ok = ok && mbedtls_sha256_finish(&sha, hash) == 0;
+  mbedtls_sha256_free(&sha);
+  if (!ok) {
+    file.close(); g_filesystem->remove(part); return false;
+  }
+  return finish_part(part, path, &file);
+}
+
+constexpr uint16_t unswap565(uint16_t value) {
+  return static_cast<uint16_t>((value << 8) | (value >> 8));
+}
+
+void put_u16(uint8_t* out, uint16_t value) {
+  out[0] = static_cast<uint8_t>(value); out[1] = static_cast<uint8_t>(value >> 8);
+}
+
+void put_u32(uint8_t* out, uint32_t value) {
+  for (int i = 0; i < 4; ++i) out[i] = static_cast<uint8_t>(value >> (i * 8));
+}
+
+bool write_bmp(const SaveJob& job, const char* directory, uint8_t hash[32]) {
+  if (!job.screen) return false;
+  char path[112], part[120];
+  snprintf(path, sizeof(path), "%s/screen.bmp", directory);
+  File file;
+  if (!begin_part(path, part, sizeof(part), &file)) return false;
+  constexpr uint32_t header_size = 54;
+  constexpr uint32_t image_bytes = 1280u * 720u * 3u;
+  uint8_t header[header_size]{};
+  header[0] = 'B'; header[1] = 'M';
+  put_u32(header + 2, header_size + image_bytes); put_u32(header + 10, header_size);
+  put_u32(header + 14, 40); put_u32(header + 18, 1280); put_u32(header + 22, 720);
+  put_u16(header + 26, 1); put_u16(header + 28, 24); put_u32(header + 34, image_bytes);
+  mbedtls_sha256_context sha;
+  mbedtls_sha256_init(&sha);
+  bool ok = mbedtls_sha256_starts(&sha, 0) == 0 &&
+            write_hashed(file, sha, header, sizeof(header));
+  uint8_t row[1280 * 3];
+  for (int y = 719; ok && y >= 0; --y) {
+    const uint16_t* source = job.screen + static_cast<size_t>(y) * 1280;
+    for (size_t x = 0; x < 1280; ++x) {
+      const uint16_t pixel = unswap565(source[x]);
+      row[x * 3] = static_cast<uint8_t>((pixel & 0x1f) * 255 / 31);
+      row[x * 3 + 1] = static_cast<uint8_t>(((pixel >> 5) & 0x3f) * 255 / 63);
+      row[x * 3 + 2] = static_cast<uint8_t>(((pixel >> 11) & 0x1f) * 255 / 31);
+    }
+    ok = write_hashed(file, sha, row, sizeof(row));
+  }
+  ok = ok && mbedtls_sha256_finish(&sha, hash) == 0;
+  mbedtls_sha256_free(&sha);
+  if (!ok) { file.close(); g_filesystem->remove(part); return false; }
+  return finish_part(part, path, &file);
+}
+
+bool write_json(const SaveJob& job, const char* directory, const uint8_t csv_hash[32],
+                const uint8_t bmp_hash[32]) {
+  char path[112], part[120], csv_hex[65]{}, bmp_hex[65]{};
+  snprintf(path, sizeof(path), "%s/session.json", directory);
+  hex_string(csv_hash, 32, csv_hex, sizeof(csv_hex));
+  hex_string(bmp_hash, 32, bmp_hex, sizeof(bmp_hex));
+  File file;
+  if (!begin_part(path, part, sizeof(part), &file)) return false;
+  const esp_app_desc_t* app = esp_app_get_description();
+  const size_t written = file.printf(
+      "{\n  \"schema_version\":1,\n  \"id\":\"%s\",\n  \"result\":\"%s\",\n"
+      "  \"firmware\":\"%s\",\n  \"driver\":\"%s\",\n  \"device\":\"%s\",\n"
+      "  \"started_ms\":%lu,\n  \"stopped_ms\":%lu,\n  \"readings\":%u,\n"
+      "  \"configuration\":{\"frequency_hz\":%lu,\"sample_rate_sps\":%lu,\"ppm\":%d,\"gain_mode\":\"%s\",\"gain_tenth_db\":%d,\"rtl_agc\":%s,\"bias_tee\":%s},\n"
+      "  \"capabilities\":%lu,\n  \"reference\":{\"configured\":%s,\"frequency_hz\":%lu,\"source_dbm\":%.3f,\"path_loss_db\":%.3f,\"tolerance_db\":%.3f,\"calibrated\":%s,\"dbm_offset\":%.3f,\"note\":\"%s\"},\n"
+      "  \"artifacts\":{\"readings.csv\":\"%s\",\"screen.bmp\":\"%s\"}\n}\n",
+      job.id, job.result, app ? app->version : "unknown", job.runtime.driver_version,
+      job.runtime.device, static_cast<unsigned long>(job.started_ms),
+      static_cast<unsigned long>(job.stopped_ms), static_cast<unsigned>(job.count),
+      static_cast<unsigned long>(job.runtime.frequency_hz),
+      static_cast<unsigned long>(job.runtime.sample_rate_sps), job.runtime.ppm,
+      job.runtime.gain_mode == GainMode::automatic ? "AUTO" : "MANUAL",
+      job.runtime.gain_tenth_db, job.runtime.rtl_agc ? "true" : "false",
+      job.runtime.bias_tee ? "true" : "false",
+      static_cast<unsigned long>(job.runtime.capabilities),
+      job.reference.configured ? "true" : "false",
+      static_cast<unsigned long>(job.reference.frequency_hz),
+      static_cast<double>(job.reference.source_dbm),
+      static_cast<double>(job.reference.path_loss_db),
+      static_cast<double>(job.reference.tolerance_db),
+      job.reference.calibrated ? "true" : "false",
+      static_cast<double>(job.reference.dbm_offset), job.reference.note, csv_hex, bmp_hex);
+  if (written == 0) { file.close(); g_filesystem->remove(part); return false; }
+  return finish_part(part, path, &file);
+}
+
+void save_worker(void*) {
+  while (true) {
+    if (!g_save_pending.exchange(false, std::memory_order_acq_rel)) {
+      vTaskDelay(pdMS_TO_TICKS(50));
+      continue;
+    }
+    g_save_busy.store(true, std::memory_order_release);
+    bool ok = g_filesystem && g_save_job.readings && g_save_job.screen;
+    char directory[96]{};
+    if (ok) {
+      g_filesystem->mkdir("/orcsdr");
+      g_filesystem->mkdir("/orcsdr/rf_lab");
+      snprintf(directory, sizeof(directory), "/orcsdr/rf_lab/%s", g_save_job.id);
+      ok = g_filesystem->mkdir(directory) || g_filesystem->exists(directory);
+    }
+    uint8_t csv_hash[32]{}, bmp_hash[32]{};
+    if (ok) ok = write_csv(g_save_job, directory, csv_hash);
+    if (ok) ok = write_bmp(g_save_job, directory, bmp_hash);
+    if (ok) ok = write_json(g_save_job, directory, csv_hash, bmp_hash);
+    heap_caps_free(g_save_job.readings);
+    heap_caps_free(g_save_job.screen);
+    g_save_job = {};
+    g_save_ok.store(ok, std::memory_order_release);
+    g_save_finished.store(true, std::memory_order_release);
+    g_save_busy.store(false, std::memory_order_release);
+  }
+}
+
+Runtime runtime() {
+  Runtime copy{};
+  portENTER_CRITICAL(&g_runtime_mux);
+  copy = g_runtime;
+  portEXIT_CRITICAL(&g_runtime_mux);
+  return copy;
+}
+
+bool same_calibration_state(const Runtime& a, const Runtime& b) {
+  return a.frequency_hz == b.frequency_hz &&
+         a.sample_rate_sps == b.sample_rate_sps && a.ppm == b.ppm &&
+         a.gain_tenth_db == b.gain_tenth_db && a.gain_mode == b.gain_mode &&
+         a.rtl_agc == b.rtl_agc;
+}
+
+void invalidate_calibration_if_needed(const Runtime& current) {
+  if (g_reference.calibrated &&
+      !same_calibration_state(current, g_reference.calibration_runtime))
+    g_reference.calibrated = false;
+}
+
+Reading make_reading(uint32_t now_ms, const char* note = nullptr, bool marker = false) {
+  Reading reading{};
+  const Runtime r = runtime();
+  reading.elapsed_ms = g_run_started_ms ? now_ms - g_run_started_ms : 0;
+  reading.frequency_hz = r.frequency_hz;
+  reading.effective_sps = r.effective_sps;
+  reading.peak_dbfs = g_snapshot.strongest;
+  reading.peak_offset_hz = g_snapshot.strongest_offset_hz;
+  reading.noise_dbfs = g_snapshot.noise;
+  reading.snr_db = g_snapshot.snr_db;
+  reading.channel_power_dbfs = g_snapshot.channel_power_dbfs;
+  reading.occupied_bandwidth_hz = static_cast<float>(g_snapshot.occupied_bandwidth_hz);
+  reading.clipping_percent = g_snapshot.clipping_percent;
+  reading.dc_i = g_snapshot.dc_i;
+  reading.dc_q = g_snapshot.dc_q;
+  reading.iq_imbalance_db = g_snapshot.iq_imbalance_db;
+  reading.source_available = r.source_available;
+  reading.marker = marker;
+  if (note) strlcpy(reading.note, note, sizeof(reading.note));
+  return reading;
+}
+
+bool start_run(uint32_t seconds, const char* label = "RUN") {
+  if (!g_filesystem || g_run_active || g_save_busy.load(std::memory_order_acquire) ||
+      g_save_pending.load(std::memory_order_acquire)) return false;
+  g_readings = static_cast<Reading*>(heap_caps_calloc(
+      kMaxReadings, sizeof(Reading), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  if (!g_readings) return false;
+  g_reading_count = 0;
+  g_run_active = true;
+  g_run_paused = false;
+  g_run_started_ms = millis();
+  g_run_duration_ms = seconds ? seconds * 1000u : 0;
+  g_last_reading_ms = 0;
+  strlcpy(g_pending_marker, label, sizeof(g_pending_marker));
+  g_dirty = true;
+  return true;
+}
+
+void cancel_run() {
+  heap_caps_free(g_readings);
+  g_readings = nullptr;
+  g_reading_count = 0;
+  g_run_active = false;
+  g_run_paused = false;
+  g_run_duration_ms = 0;
+  strlcpy(g_recipe, "NONE", sizeof(g_recipe));
+  strlcpy(g_recipe_status, "CANCELLED", sizeof(g_recipe_status));
+  g_dirty = true;
+}
+
+bool capture_screen(uint16_t** output) {
+  if (!output) return false;
+  auto* pixels = static_cast<uint16_t*>(heap_caps_malloc(
+      kScreenPixels * sizeof(uint16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  if (!pixels) return false;
+  constexpr int rows = 8;
+  for (int y = 0; y < 720; y += rows)
+    M5.Display.readRect(0, y, 1280, std::min(rows, 720 - y),
+                        pixels + static_cast<size_t>(y) * 1280);
+  *output = pixels;
+  return true;
+}
+
+bool finish_run(const char* result) {
+  if (!g_run_active || !g_readings || g_save_busy.load(std::memory_order_acquire) ||
+      g_save_pending.load(std::memory_order_acquire)) return false;
+  if (g_reading_count == 0) g_readings[g_reading_count++] = make_reading(millis());
+  uint16_t* screen = nullptr;
+  if (!capture_screen(&screen)) return false;
+  SaveJob job{};
+  job.readings = g_readings;
+  job.count = g_reading_count;
+  job.screen = screen;
+  job.runtime = runtime();
+  job.reference = g_reference;
+  job.started_ms = g_run_started_ms;
+  job.stopped_ms = millis();
+  char candidate_path[96];
+  do {
+    snprintf(job.id, sizeof(job.id), "boot-%010lu-%03lu",
+             static_cast<unsigned long>(job.stopped_ms),
+             static_cast<unsigned long>(++g_session_sequence));
+    snprintf(candidate_path, sizeof(candidate_path), "/orcsdr/rf_lab/%s", job.id);
+  } while (g_filesystem->exists(candidate_path));
+  strlcpy(job.result, result ? result : "RECORDED", sizeof(job.result));
+  g_save_job = job;
+  g_readings = nullptr;
+  g_reading_count = 0;
+  g_run_active = false;
+  g_run_paused = false;
+  if (g_recent_count < std::size(g_recent_ids)) ++g_recent_count;
+  for (size_t i = g_recent_count - 1; i > 0; --i) {
+    strlcpy(g_recent_ids[i], g_recent_ids[i - 1], sizeof(g_recent_ids[i]));
+    strlcpy(g_recent_results[i], g_recent_results[i - 1], sizeof(g_recent_results[i]));
+  }
+  strlcpy(g_recent_ids[0], job.id, sizeof(g_recent_ids[0]));
+  strlcpy(g_recent_results[0], job.result, sizeof(g_recent_results[0]));
+  g_save_pending.store(true, std::memory_order_release);
+  g_dirty = true;
+  return true;
+}
+
+bool snapshot_session(const char* note) {
+  if (!start_run(0, "SNAPSHOT")) return false;
+  g_readings[g_reading_count++] = make_reading(millis(), note, note && *note);
+  return finish_run(runtime().source_available ? "RECORDED" : "INCONCLUSIVE_SOURCE_LOST");
+}
+
+bool snapshot_result(const char* note, const char* result) {
+  if (!start_run(0, "RECIPE")) return false;
+  g_readings[g_reading_count++] = make_reading(millis(), note, true);
+  return finish_run(result);
+}
+
+void complete_timed_run() {
+  const Runtime r = runtime();
+  const bool transport = strcmp(g_recipe, "transport") == 0;
+  const bool pass = r.source_available && r.usb_overruns == g_recipe_usb_overruns &&
+                    r.consumer_drops == g_recipe_consumer_drops;
+  const char* result = g_run_paused ? "INCONCLUSIVE_SOURCE_LOST" :
+                       (transport ? (pass ? "PASS" : "FAIL_HEALTH_DELTA") : "RECORDED");
+  if (finish_run(result) && transport) {
+    strlcpy(g_recipe_status, result, sizeof(g_recipe_status));
+    strlcpy(g_recipe, "NONE", sizeof(g_recipe));
+  }
+}
+
+bool has_cap(uint32_t capability) {
+  return (runtime().capabilities & capability) != 0;
+}
+
+const char* page_name(Page value) {
+  switch (value) {
+    case Page::live: return "LIVE";
+    case Page::controls: return "CONTROLS";
+    case Page::measurements: return "MEASUREMENTS";
+    case Page::records: return "RECORDS";
+  }
+  return "LIVE";
+}
+
+void draw_header() {
+  M5.Display.fillRect(0, 0, 1280, 80, kBg);
+  panel(18, 14, 104, 52, kCyan);
+  text("BACK", 70, 40, kCyan, 2, middle_center);
+  text("RF LAB", 148, 39, kGreen, 4);
+  text("LIVE RECEIVER TEST BENCH", 360, 42, kCyan, 2);
+  const Runtime r = runtime();
+  if (r.bias_tee) {
+    M5.Display.fillRoundRect(1010, 14, 246, 52, 8, kRed);
+    text("BIAS ON", 1133, 40, TFT_WHITE, 3, middle_center);
+  } else {
+    panel(1080, 14, 176, 52, r.source_available ? kGreen : TFT_ORANGE);
+    text(r.source_available ? "SOURCE LIVE" : "NO SOURCE", 1168, 40,
+         r.source_available ? kGreen : TFT_ORANGE, 2, middle_center);
+  }
+}
+
+void draw_footer() {
+  const int width = 304;
+  for (int i = 0; i < 4; ++i) {
+    const int x = 20 + i * 312;
+    const auto candidate = static_cast<Page>(i);
+    panel(x, kFooterY, width, kFooterH, candidate == g_page ? kGreen : kCyan);
+    text(page_name(candidate), x + width / 2, kFooterY + kFooterH / 2,
+         candidate == g_page ? kGreen : TFT_WHITE, 2, middle_center);
+  }
+}
+
+void draw_static_live() {
+  panel(kPlotX, kPlotY, kPlotW, kPlotH);
+  M5.Display.drawRect(kPlotX + 10, kPlotY + 12, kPlotW - 20, kSpectrumH, kGrid);
+  text("SPECTRUM", kPlotX + 22, kPlotY + 28, kCyan, 1);
+  M5.Display.drawRect(kPlotX + 10, kWaterfallY, kPlotW - 20, kWaterfallH, kGrid);
+  text("WATERFALL", kPlotX + 22, kWaterfallY + 16, kCyan, 1);
+  panel(kSideX, kPlotY, kSideW, kPlotH);
+}
+
+void draw_button(int x, int y, int w, const char* label, uint16_t color = kCyan) {
+  panel(x, y, w, 48, color);
+  text(label, x + w / 2, y + 24, color, 2, middle_center);
+}
+
+void draw_static_controls() {
+  panel(22, 96, 1236, 530);
+  text("Driver controls report accepted requests and software shadows.", 44, 122,
+       TFT_ORANGE, 2);
+  const Runtime r = runtime();
+  char line[160];
+  snprintf(line, sizeof(line), "Driver %s  Device %.36s  Health %.20s  Passport %s",
+           r.driver_version, r.device, r.health,
+           (r.capabilities & ESP_RTL_SDR_CAP_PASSPORT) ? "SUPPORTED" : "UNAVAILABLE");
+  text(line, 48, 148, kMuted, 1);
+  snprintf(line, sizeof(line), "Frequency  %.6f MHz", r.frequency_hz / 1.0e6);
+  text(line, 48, 178, TFT_WHITE, 2);
+  draw_button(700, 154, 120, "-100k", has_cap(ESP_RTL_SDR_CAP_RETUNE) ? kCyan : kMuted);
+  draw_button(832, 154, 120, "+100k", has_cap(ESP_RTL_SDR_CAP_RETUNE) ? kCyan : kMuted);
+  snprintf(line, sizeof(line), "Sample rate  %.3f MSPS", r.sample_rate_sps / 1.0e6);
+  text(line, 48, 238, TFT_WHITE, 2);
+  draw_button(700, 214, 252, "NEXT RATE",
+              has_cap(ESP_RTL_SDR_CAP_CONTINUOUS_RATE) ? kCyan : kMuted);
+  snprintf(line, sizeof(line), "PPM correction  %+d", r.ppm);
+  text(line, 48, 298, TFT_WHITE, 2);
+  draw_button(700, 274, 120, "-1", has_cap(ESP_RTL_SDR_CAP_FREQ_CORRECTION) ? kCyan : kMuted);
+  draw_button(832, 274, 120, "+1", has_cap(ESP_RTL_SDR_CAP_FREQ_CORRECTION) ? kCyan : kMuted);
+  snprintf(line, sizeof(line), "Tuner gain  %s  %.1f dB",
+           r.gain_mode == GainMode::automatic ? "AUTO" : "MANUAL",
+           r.gain_tenth_db / 10.0);
+  text(line, 48, 358, TFT_WHITE, 2);
+  draw_button(700, 334, 120, r.gain_mode == GainMode::automatic ? "MANUAL" : "AUTO",
+              has_cap(r.gain_mode == GainMode::automatic ? ESP_RTL_SDR_CAP_GAIN
+                                                         : ESP_RTL_SDR_CAP_GAIN_AUTO)
+                  ? kCyan : kMuted);
+  draw_button(832, 334, 120, "+ GAIN", has_cap(ESP_RTL_SDR_CAP_GAIN) ? kCyan : kMuted);
+  text(r.rtl_agc ? "RTL digital AGC  ON" : "RTL digital AGC  OFF", 48, 418,
+       r.rtl_agc ? kGreen : TFT_WHITE, 2);
+  draw_button(700, 394, 252, r.rtl_agc ? "TURN OFF" : "TURN ON",
+              has_cap(ESP_RTL_SDR_CAP_RTL_AGC) ? kCyan : kMuted);
+  text(r.bias_tee ? "Bias tee  ON (software shadow)" : "Bias tee  OFF", 48, 478,
+       r.bias_tee ? kRed : TFT_WHITE, 2);
+  draw_button(700, 454, 252, r.bias_tee ? "BIAS OFF" : "BIAS ON",
+              has_cap(ESP_RTL_SDR_CAP_BIAS_TEE) ? (r.bias_tee ? kRed : TFT_ORANGE) : kMuted);
+  text(g_keep_settings ? "Exit behavior: KEEP SETTINGS" : "Exit behavior: RESTORE ENTRY STATE",
+       48, 538, g_keep_settings ? kGreen : kCyan, 2);
+  draw_button(700, 514, 252, g_keep_settings ? "RESTORE ON EXIT" : "KEEP SETTINGS");
+  text("Automatic hardware: V4 triplexer, HF upconverter and analog filters.", 48, 594,
+       kMuted, 1);
+  text("Unavailable: tuner bandwidth. Unsafe: raw EP0, EEPROM, test mode, bias GPIO.",
+       640, 594, kMuted, 1);
+  text("Not applicable on V4: direct sampling and R828D offset tuning.", 48, 616,
+       kMuted, 1);
+}
+
+void draw_static_measurements() {
+  panel(22, 96, 1236, 530);
+  text("MEASUREMENT SESSION", 48, 128, kCyan, 3);
+  text("Snapshots and timed 5 Hz runs use the live shared analyzer.", 48, 174,
+       TFT_WHITE, 2);
+  draw_button(48, 214, 250, "SNAPSHOT");
+  draw_button(316, 214, 250, "RUN 10 SEC");
+  draw_button(584, 214, 250, "ADD MARKER");
+  draw_button(852, 214, 250, "STOP");
+  char line[112];
+  if (g_run_active) {
+    snprintf(line, sizeof(line), "Run %s  readings=%u%s",
+             g_run_duration_ms ? "TIMED" : "MANUAL",
+             static_cast<unsigned>(g_reading_count), g_run_paused ? "  PAUSED: SOURCE LOST" : "");
+    text(line, 48, 304, g_run_paused ? TFT_ORANGE : kGreen, 2);
+  } else {
+    text(g_save_busy.load(std::memory_order_acquire) ? "Saving session to SD..." :
+         (!g_save_finished.load(std::memory_order_acquire) ? "No active run" :
+          (g_save_ok.load(std::memory_order_acquire) ? "Last save complete" : "Last save FAILED")),
+         48, 304, g_save_busy.load(std::memory_order_acquire) ? kCyan : TFT_WHITE, 2);
+  }
+  if (g_reference.configured) {
+    snprintf(line, sizeof(line), "Reference %.6f MHz  %.1f dBm  path %.1f dB%s",
+             g_reference.frequency_hz / 1.0e6, static_cast<double>(g_reference.source_dbm),
+             static_cast<double>(g_reference.path_loss_db),
+             g_reference.calibrated ? "  ESTIMATED dBm ENABLED" : "");
+    text(line, 48, 344, g_reference.calibrated ? kGreen : kCyan, 2);
+  } else {
+    text("Reference source: not configured; measurements are dBFS.", 48, 344,
+         TFT_ORANGE, 2);
+  }
+  text("Guided recipes are available through RTL_LAB RECIPE LIST.", 48, 410,
+       kCyan, 2);
+}
+
+void draw_static_records() {
+  panel(22, 96, 1236, 530);
+  text("RF LAB RECORDS", 48, 128, kCyan, 3);
+  text(g_filesystem ? "SD storage ready" : "SD storage unavailable", 48, 180,
+       g_filesystem ? kGreen : TFT_ORANGE, 2);
+  text("Completed sessions: /orcsdr/rf_lab/<session>/", 48, 232, TFT_WHITE, 2);
+  text("Use RTL_LAB RECORDS LIST or the existing SD export commands.", 48, 276,
+       kMuted, 2);
+  int y = 340;
+  for (size_t i = 0; i < g_recent_count; ++i) {
+    char line[80];
+    snprintf(line, sizeof(line), "%.31s  %.31s", g_recent_ids[i], g_recent_results[i]);
+    text(line, 48, y, i == 0 ? kGreen : TFT_WHITE, 2);
+    y += 42;
+  }
+}
+
+void draw_page() {
+  M5.Display.fillScreen(kBg);
+  draw_header();
+  if (g_page == Page::live) draw_static_live();
+  else if (g_page == Page::controls) draw_static_controls();
+  else if (g_page == Page::measurements) draw_static_measurements();
+  else draw_static_records();
+  draw_footer();
+  g_dirty = false;
+}
+
+uint16_t waterfall_color(float db, float floor) {
+  const float level = std::clamp((db - floor) / 65.0f, 0.0f, 1.0f);
+  if (level < 0.25f) return M5.Display.color565(0, 0, static_cast<uint8_t>(level * 600));
+  if (level < 0.5f) return M5.Display.color565(0, static_cast<uint8_t>((level - .25f) * 900), 255);
+  if (level < 0.75f) return M5.Display.color565(static_cast<uint8_t>((level - .5f) * 900), 255,
+                                                static_cast<uint8_t>((.75f - level) * 900));
+  return M5.Display.color565(255, static_cast<uint8_t>((1.0f - level) * 900), 0);
+}
+
+void draw_live_dynamic() {
+  if (!g_snapshot.bins) return;
+  constexpr int x0 = kPlotX + 11, y0 = kPlotY + 13, width = kPlotW - 22;
+  M5.Display.fillRect(x0, y0, width, kSpectrumH - 2, kBg);
+  for (int i = 1; i < 8; ++i) M5.Display.drawFastVLine(x0 + i * width / 8, y0, kSpectrumH - 2, kGrid);
+  for (int i = 1; i < 5; ++i) M5.Display.drawFastHLine(x0, y0 + i * (kSpectrumH - 2) / 5, width, kGrid);
+  const float floor = std::clamp(g_snapshot.noise - 15.0f, -140.0f, -45.0f);
+  int px = x0, py = y0 + kSpectrumH - 3;
+  for (int x = 0; x < width; ++x) {
+    const size_t bin = std::min<size_t>(g_snapshot.bins - 1,
+                                        static_cast<size_t>(x) * g_snapshot.bins / width);
+    const int y = y0 + kSpectrumH - 3 - static_cast<int>(
+        std::clamp((g_snapshot.live[bin] - floor) / 75.0f, 0.0f, 1.0f) * (kSpectrumH - 18));
+    if (x) M5.Display.drawLine(px, py, x0 + x, y, kCyan);
+    px = x0 + x; py = y;
+  }
+  if (g_waterfall_ready) {
+    g_waterfall.setScrollRect(0, 0, width, kWaterfallH - 2, kBg);
+    g_waterfall.scroll(0, -2);
+    for (int x = 0; x < width; ++x) {
+      const size_t bin = std::min<size_t>(g_snapshot.bins - 1,
+                                          static_cast<size_t>(x) * g_snapshot.bins / width);
+      g_waterfall.drawFastVLine(x, kWaterfallH - 3, 2,
+                               waterfall_color(g_snapshot.live[bin], floor));
+    }
+    g_waterfall.pushSprite(x0, kWaterfallY + 1);
+  }
+
+  M5.Display.fillRect(kSideX + 10, kPlotY + 10, kSideW - 20, kPlotH - 20, kPanel);
+  char line[80];
+  int y = kPlotY + 38;
+  auto metric = [&](const char* label, const char* value, uint16_t color = TFT_WHITE) {
+    text(label, kSideX + 22, y, kMuted, 1);
+    text(value, kSideX + kSideW - 22, y, color, 2, middle_right);
+    y += 48;
+  };
+  snprintf(line, sizeof(line), "%.6f MHz", g_snapshot.strongest_frequency_hz / 1.0e6);
+  metric("PEAK FREQUENCY", line, kGreen);
+  snprintf(line, sizeof(line), "%.1f dBFS", g_snapshot.strongest); metric("PEAK", line);
+  snprintf(line, sizeof(line), "%.1f dBFS", g_snapshot.noise); metric("NOISE FLOOR", line);
+  snprintf(line, sizeof(line), "%.1f dB", g_snapshot.snr_db); metric("SNR", line, kCyan);
+  if (g_reference.calibrated) {
+    snprintf(line, sizeof(line), "~%.1f dBm", g_snapshot.channel_power_dbfs + g_reference.dbm_offset);
+    metric("REFERENCE-EST. POWER", line, kGreen);
+  } else {
+    snprintf(line, sizeof(line), "%.1f dBFS", g_snapshot.channel_power_dbfs);
+    metric("CHANNEL POWER", line);
+  }
+  snprintf(line, sizeof(line), "%.1f kHz", g_snapshot.occupied_bandwidth_hz / 1000.0); metric("99% OBW", line);
+  snprintf(line, sizeof(line), "%+.0f Hz", g_snapshot.strongest_offset_hz); metric("FREQUENCY ERROR", line);
+  snprintf(line, sizeof(line), "%.2f %%", g_snapshot.clipping_percent); metric("CLIPPING", line,
+         g_snapshot.clipping_percent > 0.1f ? kRed : kGreen);
+  snprintf(line, sizeof(line), "I %+.3f  Q %+.3f", g_snapshot.dc_i, g_snapshot.dc_q); metric("DC OFFSET", line);
+  snprintf(line, sizeof(line), "%+.2f dB", g_snapshot.iq_imbalance_db); metric("IQ BALANCE", line);
+}
+
+void queue_restore() {
+  if (g_keep_settings) return;
+  queue(ActionKind::ppm, g_initial.ppm);
+  queue(ActionKind::sample_rate_sps, static_cast<int32_t>(g_initial.sample_rate_sps));
+  queue(ActionKind::tune_hz, static_cast<int32_t>(g_initial.frequency_hz));
+  queue(ActionKind::gain_mode, g_initial.gain_mode == GainMode::automatic ? 0 : 1);
+  if (g_initial.gain_mode == GainMode::manual)
+    queue(ActionKind::gain_tenth_db, g_initial.gain_tenth_db);
+  queue(ActionKind::rtl_agc, g_initial.rtl_agc ? 1 : 0);
+  queue(ActionKind::bias_tee, g_initial.bias_tee ? 1 : 0);
+}
+
+void request_close() {
+  if (g_run_active && !finish_run("CANCELLED_EXIT")) cancel_run();
+  queue_restore();
+  queue(ActionKind::close, 0);
+}
+
+uint32_t next_rate(uint32_t current) {
+  constexpr uint32_t rates[] = {256000, 960000, 1024000, 1800000, 2048000, 2400000, 2560000};
+  for (uint32_t rate : rates)
+    if (rate > current) return rate;
+  return rates[0];
+}
+
+int next_gain(const Runtime& r) {
+  if (!r.gain_count) return r.gain_tenth_db;
+  for (uint8_t i = 0; i < r.gain_count; ++i)
+    if (r.gain_ladder[i] > r.gain_tenth_db) return r.gain_ladder[i];
+  return r.gain_ladder[0];
+}
+
+bool valid_gain(const Runtime& r, int value) {
+  for (uint8_t i = 0; i < r.gain_count; ++i)
+    if (r.gain_ladder[i] == value) return true;
+  return false;
+}
+
+void handle_tap(int32_t x, int32_t y) {
+  if (inside(x, y, 18, 14, 104, 52)) { request_close(); return; }
+  if (y >= kFooterY) {
+    const int slot = static_cast<int>(std::clamp<int32_t>((x - 20) / 312, 0, 3));
+    g_page = static_cast<Page>(slot);
+    g_dirty = true;
+    return;
+  }
+  if (g_page == Page::measurements) {
+    if (inside(x, y, 48, 214, 250, 48)) {
+      message(snapshot_session(nullptr) ? "Snapshot queued for SD" : "Snapshot unavailable");
+    } else if (inside(x, y, 316, 214, 250, 48)) {
+      message(start_run(10) ? "10 second run started" : "Run unavailable");
+    } else if (inside(x, y, 584, 214, 250, 48) && g_run_active &&
+               g_reading_count < kMaxReadings) {
+      g_readings[g_reading_count++] = make_reading(millis(), "TOUCH MARKER", true);
+      message("Marker recorded");
+    } else if (inside(x, y, 852, 214, 250, 48)) {
+      message(finish_run(g_run_paused ? "INCONCLUSIVE_SOURCE_LOST" : "RECORDED")
+                  ? "Run queued for SD" : "No active run");
+    }
+    g_dirty = true;
+    return;
+  }
+  if (g_page != Page::controls) return;
+  const Runtime r = runtime();
+  if (inside(x, y, 700, 154, 120, 48) && has_cap(ESP_RTL_SDR_CAP_RETUNE)) queue(ActionKind::tune_hz, std::max<int32_t>(500000, r.frequency_hz - 100000));
+  else if (inside(x, y, 832, 154, 120, 48) && has_cap(ESP_RTL_SDR_CAP_RETUNE)) queue(ActionKind::tune_hz, std::min<int32_t>(1766000000, r.frequency_hz + 100000));
+  else if (inside(x, y, 700, 214, 252, 48) && has_cap(ESP_RTL_SDR_CAP_CONTINUOUS_RATE)) queue(ActionKind::sample_rate_sps, next_rate(r.sample_rate_sps));
+  else if (inside(x, y, 700, 274, 120, 48) && has_cap(ESP_RTL_SDR_CAP_FREQ_CORRECTION)) queue(ActionKind::ppm, std::max(-200, r.ppm - 1));
+  else if (inside(x, y, 832, 274, 120, 48) && has_cap(ESP_RTL_SDR_CAP_FREQ_CORRECTION)) queue(ActionKind::ppm, std::min(200, r.ppm + 1));
+  else if (inside(x, y, 700, 334, 120, 48) &&
+           has_cap(r.gain_mode == GainMode::automatic ? ESP_RTL_SDR_CAP_GAIN
+                                                      : ESP_RTL_SDR_CAP_GAIN_AUTO)) queue(ActionKind::gain_mode, r.gain_mode == GainMode::automatic ? 1 : 0);
+  else if (inside(x, y, 832, 334, 120, 48) && has_cap(ESP_RTL_SDR_CAP_GAIN))
+    queue(ActionKind::gain_tenth_db, next_gain(r));
+  else if (inside(x, y, 700, 394, 252, 48) && has_cap(ESP_RTL_SDR_CAP_RTL_AGC)) queue(ActionKind::rtl_agc, r.rtl_agc ? 0 : 1);
+  else if (inside(x, y, 700, 454, 252, 48) && r.bias_tee && has_cap(ESP_RTL_SDR_CAP_BIAS_TEE)) queue(ActionKind::bias_tee, 0);
+  else if (inside(x, y, 700, 454, 252, 48) && !r.bias_tee && !g_bias_ack) {
+    g_bias_ack = true;
+    message("Disconnect DC-short loads, then HOLD BIAS ON for 2 seconds");
+  } else if (inside(x, y, 700, 514, 252, 48)) {
+    g_keep_settings = !g_keep_settings;
+    g_dirty = true;
+  }
+}
+
+bool parse_page(const char* value, Page* output) {
+  if (!value || !output) return false;
+  if (strcasecmp(value, "LIVE") == 0) *output = Page::live;
+  else if (strcasecmp(value, "CONTROLS") == 0) *output = Page::controls;
+  else if (strcasecmp(value, "MEASUREMENTS") == 0) *output = Page::measurements;
+  else if (strcasecmp(value, "RECORDS") == 0) *output = Page::records;
+  else return false;
+  return true;
+}
+
+}  // namespace
+
+bool initialize(storage::FileSystem* filesystem) {
+  g_filesystem = filesystem;
+  if (!rf_analysis::initialize()) return false;
+  if (!g_save_task &&
+      xTaskCreatePinnedToCoreWithCaps(save_worker, "rf_lab_save", 12288, nullptr, 1,
+                                     &g_save_task, 1,
+                                     MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) != pdPASS)
+    return false;
+  return true;
+}
+
+void set_runtime(const Runtime& value) {
+  const Runtime previous = runtime();
+  const bool changed = previous.frequency_hz != value.frequency_hz ||
+                       previous.sample_rate_sps != value.sample_rate_sps ||
+                       previous.capabilities != value.capabilities ||
+                       previous.ppm != value.ppm ||
+                       previous.gain_tenth_db != value.gain_tenth_db ||
+                       previous.gain_mode != value.gain_mode ||
+                       previous.rtl_agc != value.rtl_agc ||
+                       previous.bias_tee != value.bias_tee ||
+                       previous.source_available != value.source_available ||
+                       strcmp(previous.health, value.health) != 0;
+  portENTER_CRITICAL(&g_runtime_mux);
+  g_runtime = value;
+  portEXIT_CRITICAL(&g_runtime_mux);
+  invalidate_calibration_if_needed(value);
+  if (active() && (previous.frequency_hz != value.frequency_hz ||
+                   previous.sample_rate_sps != value.sample_rate_sps)) {
+    rf_analysis::Config config{};
+    config.center_hz = value.frequency_hz;
+    config.span_hz = value.sample_rate_sps ? value.sample_rate_sps : 960000;
+    config.sample_rate_sps = config.span_hz;
+    config.measurement_bandwidth_hz = config.span_hz;
+    config.fft_size = 2048;
+    config.interval_ms = 33;
+    rf_analysis::set_config(config);
+  }
+  if (changed && g_page == Page::controls) g_dirty = true;
+}
+
+bool enter(uint8_t origin_screen_value, uint8_t origin_tab_value) {
+  if (!g_waterfall_ready) {
+    g_waterfall.setColorDepth(16);
+    g_waterfall_ready = g_waterfall.createSprite(kPlotW - 22, kWaterfallH - 2) != nullptr;
+    if (!g_waterfall_ready) return false;
+    g_waterfall.fillScreen(kBg);
+  }
+  g_origin_screen = origin_screen_value;
+  g_origin_tab = origin_tab_value;
+  g_initial = runtime();
+  g_keep_settings = false;
+  g_bias_ack = false;
+  g_page = Page::live;
+  g_last_revision = 0;
+  g_source_state_known = false;
+  g_loss_revision = 0;
+  g_active.store(true, std::memory_order_release);
+  rf_analysis::Config config{};
+  config.center_hz = g_initial.frequency_hz;
+  config.span_hz = g_initial.sample_rate_sps ? g_initial.sample_rate_sps : 960000;
+  config.sample_rate_sps = config.span_hz;
+  config.measurement_bandwidth_hz = config.span_hz;
+  config.fft_size = 2048;
+  config.interval_ms = 33;
+  rf_analysis::set_config(config);
+  rf_analysis::set_enabled(true);
+  g_dirty = true;
+  draw_page();
+  return true;
+}
+
+void leave() {
+  g_active.store(false, std::memory_order_release);
+  rf_analysis::set_enabled(false);
+  if (g_waterfall_ready) {
+    g_waterfall.deleteSprite();
+    g_waterfall_ready = false;
+  }
+}
+
+bool active() { return g_active.load(std::memory_order_acquire); }
+uint8_t origin_screen() { return g_origin_screen; }
+uint8_t origin_tab() { return g_origin_tab; }
+Page page() { return g_page; }
+
+void service_ui(uint32_t now_ms) {
+  static bool last_save_busy = false;
+  if (!active()) return;
+  const Runtime r = runtime();
+  const bool save_busy = g_save_busy.load(std::memory_order_acquire) ||
+                         g_save_pending.load(std::memory_order_acquire);
+  if (save_busy != last_save_busy) {
+    last_save_busy = save_busy;
+    if (g_page == Page::measurements || g_page == Page::records) g_dirty = true;
+  }
+  if (!g_source_state_known || r.source_available != g_last_source_available) {
+    g_source_state_known = true;
+    g_last_source_available = r.source_available;
+    if (!r.source_available) g_loss_revision = g_snapshot.revision;
+    draw_header();
+    if (!r.source_available && g_page == Page::live) {
+      M5.Display.fillRect(kPlotX + 80, kPlotY + 235, kPlotW - 160, 72, 0x2104);
+      text("SOURCE LOST - PAUSED", kPlotX + kPlotW / 2, kPlotY + 271,
+           TFT_ORANGE, 3, middle_center);
+    }
+  }
+  const bool stable_source = r.source_available && g_snapshot.source_stable &&
+                             g_snapshot.revision > g_loss_revision;
+  const bool paused = g_run_active && !stable_source;
+  if (paused != g_run_paused) {
+    g_run_paused = paused;
+    if (paused && g_readings && g_reading_count < kMaxReadings)
+      g_readings[g_reading_count++] = make_reading(now_ms, "SOURCE LOST", true);
+    g_dirty = true;
+  }
+  if (g_run_active && !g_run_paused && now_ms - g_last_reading_ms >= 200 &&
+      g_reading_count < kMaxReadings) {
+    g_last_reading_ms = now_ms;
+    g_readings[g_reading_count++] = make_reading(now_ms,
+        g_pending_marker[0] ? g_pending_marker : nullptr, g_pending_marker[0]);
+    g_pending_marker[0] = '\0';
+  }
+  if (g_run_active && g_reading_count >= kMaxReadings) {
+    finish_run("RECORDED_LIMIT");
+    if (g_page == Page::measurements) g_dirty = true;
+  }
+  if (g_run_active && g_run_duration_ms && now_ms - g_run_started_ms >= g_run_duration_ms) {
+    complete_timed_run();
+    if (g_page == Page::measurements) g_dirty = true;
+  }
+  if (g_dirty) draw_page();
+  if (now_ms - g_last_draw_ms >= 100 && rf_analysis::copy_snapshot(&g_snapshot) &&
+      g_snapshot.revision != g_last_revision) {
+    g_last_draw_ms = now_ms;
+    g_last_revision = g_snapshot.revision;
+    if (g_page == Page::live) {
+      draw_live_dynamic();
+      if (!r.source_available) {
+        M5.Display.fillRect(kPlotX + 80, kPlotY + 235, kPlotW - 160, 72, 0x2104);
+        text("SOURCE LOST - PAUSED", kPlotX + kPlotW / 2, kPlotY + 271,
+             TFT_ORANGE, 3, middle_center);
+      }
+    }
+  }
+  if (g_message_until_ms && static_cast<int32_t>(g_message_until_ms - now_ms) > 0) {
+    M5.Display.fillRoundRect(260, 598, 760, 42, 7, kPanel);
+    M5.Display.drawRoundRect(260, 598, 760, 42, 7, TFT_ORANGE);
+    text(g_message, 640, 619, TFT_ORANGE, 2, middle_center);
+  }
+}
+
+void handle_touch(int32_t x, int32_t y, bool pressed, uint32_t now_ms) {
+  if (!active()) return;
+  const bool bias_button = g_page == Page::controls && inside(x, y, 700, 454, 252, 48);
+  const Runtime r = runtime();
+  if (pressed && !g_pressed) {
+    g_pressed = true; g_press_x = x; g_press_y = y; g_press_ms = now_ms;
+    g_bias_hold_fired = false;
+    return;
+  }
+  if (pressed && g_pressed && bias_button && g_bias_ack && !r.bias_tee &&
+      !g_bias_hold_fired && now_ms - g_press_ms >= kBiasHoldMs) {
+    g_bias_hold_fired = true;
+    g_bias_ack = false;
+    queue(ActionKind::bias_tee, 1);
+    message("BIAS ON request accepted by OrcSDR queue");
+    return;
+  }
+  if (pressed || !g_pressed) return;
+  const bool tap = std::abs(x - g_press_x) < 18 && std::abs(y - g_press_y) < 18 &&
+                   now_ms - g_press_ms < 700 && !g_bias_hold_fired;
+  g_pressed = false;
+  if (tap) handle_tap(x, y);
+}
+
+bool take_action(Action* action) {
+  if (!action || g_action_read == g_action_write) return false;
+  *action = g_actions[g_action_read];
+  g_action_read = (g_action_read + 1) % kActionCapacity;
+  return true;
+}
+
+bool process_command(const char* command, char* response, size_t response_size) {
+  if (!command || !response || !response_size) return false;
+  if (strcmp(command, "RTL_LAB OPEN") == 0) {
+    strlcpy(response, "RTL_LAB_OPEN_REQUEST", response_size); return true;
+  }
+  if (strcmp(command, "RTL_LAB CLOSE") == 0) {
+    request_close(); strlcpy(response, "RTL_LAB_OK close=queued", response_size); return true;
+  }
+  if (strcmp(command, "RTL_LAB STATUS") == 0) {
+    const Runtime r = runtime();
+    snprintf(response, response_size,
+             "RTL_LAB_STATUS active=%d page=%s source=%d frequency_hz=%lu sample_rate_sps=%lu ppm=%d mode=%s gain_tenth_db=%d rtl_agc=%d bias=%d keep=%d",
+             active(), page_name(g_page), r.source_available,
+             static_cast<unsigned long>(r.frequency_hz),
+             static_cast<unsigned long>(r.sample_rate_sps), r.ppm,
+             r.gain_mode == GainMode::automatic ? "AUTO" : "MANUAL",
+             r.gain_tenth_db, r.rtl_agc, r.bias_tee, g_keep_settings);
+    return true;
+  }
+  if (strncmp(command, "RTL_LAB PAGE ", 13) == 0) {
+    Page next{};
+    if (!parse_page(command + 13, &next)) {
+      strlcpy(response, "RTL_LAB_ERROR page", response_size); return true;
+    }
+    g_page = next; g_dirty = true;
+    snprintf(response, response_size, "RTL_LAB_OK page=%s", page_name(next)); return true;
+  }
+  if (strcmp(command, "RTL_LAB SELF_CHECK") == 0) {
+    snprintf(response, response_size, "RTL_LAB_SELF_CHECK pass=%d", self_check()); return true;
+  }
+  if (strcmp(command, "RTL_LAB ACTION bias_ack") == 0) {
+    g_bias_cli_ack_until_ms = millis() + 30000;
+    strlcpy(response, "RTL_LAB_OK bias_ack=30s warning=disconnect_dc_short_loads",
+            response_size);
+    return true;
+  }
+  if (strcmp(command, "RTL_LAB GET frequency_hz") == 0 ||
+      strcmp(command, "RTL_LAB GET sample_rate_sps") == 0 ||
+      strcmp(command, "RTL_LAB GET ppm") == 0 ||
+      strcmp(command, "RTL_LAB GET gain_tenth_db") == 0 ||
+      strcmp(command, "RTL_LAB GET gain_mode") == 0 ||
+      strcmp(command, "RTL_LAB GET rtl_agc") == 0 ||
+      strcmp(command, "RTL_LAB GET bias_tee") == 0) {
+    const Runtime r = runtime();
+    const char* id = command + 12;
+    long value = 0;
+    if (strcmp(id, "frequency_hz") == 0) value = r.frequency_hz;
+    else if (strcmp(id, "sample_rate_sps") == 0) value = r.sample_rate_sps;
+    else if (strcmp(id, "ppm") == 0) value = r.ppm;
+    else if (strcmp(id, "gain_tenth_db") == 0) value = r.gain_tenth_db;
+    else if (strcmp(id, "gain_mode") == 0) value = r.gain_mode == GainMode::manual;
+    else if (strcmp(id, "rtl_agc") == 0) value = r.rtl_agc;
+    else value = r.bias_tee;
+    snprintf(response, response_size, "RTL_LAB_VALUE id=%s value=%ld", id, value);
+    return true;
+  }
+  if (strcmp(command, "RTL_LAB ACTION calibrate") == 0) {
+    if (!g_reference.configured || !runtime().source_available ||
+        !g_snapshot.source_stable) {
+      strlcpy(response, "RTL_LAB_ERROR reference_or_source_unavailable", response_size);
+      return true;
+    }
+    g_reference.dbm_offset = g_reference.source_dbm - g_reference.path_loss_db -
+                             g_snapshot.channel_power_dbfs;
+    g_reference.calibrated = true;
+    g_reference.calibration_runtime = runtime();
+    strlcpy(response, "RTL_LAB_OK calibration=reference_estimated", response_size);
+    g_dirty = true;
+    return true;
+  }
+  if (strcmp(command, "RTL_LAB REFERENCE STATUS") == 0) {
+    snprintf(response, response_size,
+             "RTL_LAB_REFERENCE configured=%d frequency_hz=%lu source_dbm=%.2f path_loss_db=%.2f tolerance_db=%.2f calibrated=%d",
+             g_reference.configured, static_cast<unsigned long>(g_reference.frequency_hz),
+             static_cast<double>(g_reference.source_dbm),
+             static_cast<double>(g_reference.path_loss_db),
+             static_cast<double>(g_reference.tolerance_db), g_reference.calibrated);
+    return true;
+  }
+  if (strcmp(command, "RTL_LAB REFERENCE CLEAR") == 0) {
+    g_reference = {}; g_dirty = true;
+    strlcpy(response, "RTL_LAB_OK reference=cleared", response_size); return true;
+  }
+  unsigned long reference_hz = 0;
+  float source_dbm = 0, path_loss_db = 0, tolerance_db = 0;
+  char note[48]{};
+  const int reference_fields = sscanf(command, "RTL_LAB REFERENCE SET %lu %f %f %f %47[^\n]",
+                                      &reference_hz, &source_dbm, &path_loss_db,
+                                      &tolerance_db, note);
+  if (reference_fields >= 4) {
+    if (reference_hz < 500000 || reference_hz > 1766000000UL ||
+        source_dbm > 20 || source_dbm < -180 || path_loss_db < 0 ||
+        path_loss_db > 200 || tolerance_db < 0 || tolerance_db > 100 ||
+        (reference_fields == 5 && !safe_note(note))) {
+      strlcpy(response, "RTL_LAB_ERROR reference", response_size); return true;
+    }
+    g_reference = {};
+    g_reference.configured = true;
+    g_reference.frequency_hz = static_cast<uint32_t>(reference_hz);
+    g_reference.source_dbm = source_dbm;
+    g_reference.path_loss_db = path_loss_db;
+    g_reference.tolerance_db = tolerance_db;
+    if (reference_fields == 5) strlcpy(g_reference.note, note, sizeof(g_reference.note));
+    g_dirty = true;
+    strlcpy(response, "RTL_LAB_OK reference=configured calibration=invalid", response_size);
+    return true;
+  }
+  if (strncmp(command, "RTL_LAB SNAPSHOT", 16) == 0) {
+    const char* note_value = command[16] == ' ' ? command + 17 : nullptr;
+    if (note_value && !safe_note(note_value)) {
+      strlcpy(response, "RTL_LAB_ERROR note", response_size); return true;
+    }
+    snprintf(response, response_size, "RTL_LAB_%s snapshot=%s",
+             snapshot_session(note_value) ? "OK" : "ERROR",
+             g_save_pending.load(std::memory_order_acquire) ? "queued" : "unavailable");
+    return true;
+  }
+  unsigned long seconds = 0;
+  if (sscanf(command, "RTL_LAB RUN START %lu", &seconds) == 1 ||
+      strcmp(command, "RTL_LAB RUN START") == 0) {
+    if (seconds > kMaxReadings / 5) {
+      strlcpy(response, "RTL_LAB_ERROR duration", response_size); return true;
+    }
+    snprintf(response, response_size, "RTL_LAB_%s run=%s",
+             start_run(static_cast<uint32_t>(seconds)) ? "OK" : "ERROR",
+             g_run_active ? "started" : "unavailable");
+    return true;
+  }
+  if (strncmp(command, "RTL_LAB RUN MARK", 16) == 0) {
+    const char* mark = command[16] == ' ' ? command + 17 : "CLI MARKER";
+    if (!g_run_active || g_reading_count >= kMaxReadings || !safe_note(mark)) {
+      strlcpy(response, "RTL_LAB_ERROR marker", response_size); return true;
+    }
+    g_readings[g_reading_count++] = make_reading(millis(), mark, true);
+    strlcpy(response, "RTL_LAB_OK marker=recorded", response_size); return true;
+  }
+  if (strcmp(command, "RTL_LAB RUN STOP") == 0) {
+    const bool ok = finish_run(g_run_paused ? "INCONCLUSIVE_SOURCE_LOST" : "RECORDED");
+    snprintf(response, response_size, "RTL_LAB_%s run=%s", ok ? "OK" : "ERROR",
+             ok ? "queued" : "inactive"); return true;
+  }
+  if (strcmp(command, "RTL_LAB RECIPE LIST") == 0) {
+    strlcpy(response,
+        "RTL_LAB_RECIPES identity transport rate_passport gain_quick gain_full tuner_auto rtl_agc ppm hf_path source_reconnect bias_off_on_off",
+        response_size); return true;
+  }
+  if (strcmp(command, "RTL_LAB RECIPE STATUS") == 0) {
+    snprintf(response, response_size, "RTL_LAB_RECIPE id=%s status=%s", g_recipe,
+             g_recipe_status); return true;
+  }
+  if (strcmp(command, "RTL_LAB RECIPE CANCEL") == 0) {
+    if (g_run_active) cancel_run();
+    else { strlcpy(g_recipe, "NONE", sizeof(g_recipe));
+           strlcpy(g_recipe_status, "CANCELLED", sizeof(g_recipe_status)); }
+    strlcpy(response, "RTL_LAB_OK recipe=cancelled", response_size); return true;
+  }
+  char recipe[32]{};
+  if (sscanf(command, "RTL_LAB RECIPE START %31s", recipe) == 1) {
+    if (strcmp(recipe, "identity") == 0) {
+      const Runtime r = runtime();
+      const bool pass = r.driver_version[0] && r.capabilities;
+      const bool ok = snapshot_result("IDENTITY CAPABILITY INVENTORY", pass ? "PASS" : "FAIL");
+      strlcpy(g_recipe_status, ok ? (pass ? "PASS" : "FAIL") : "BUSY", sizeof(g_recipe_status));
+      snprintf(response, response_size, "RTL_LAB_%s recipe=identity status=%s",
+               ok ? "OK" : "ERROR", g_recipe_status); return true;
+    }
+    if (strcmp(recipe, "transport") == 0) {
+      const Runtime r = runtime();
+      if (!start_run(10, "TRANSPORT BASELINE")) {
+        strlcpy(response, "RTL_LAB_ERROR recipe=busy_or_no_sd", response_size); return true;
+      }
+      strlcpy(g_recipe, recipe, sizeof(g_recipe));
+      strlcpy(g_recipe_status, "RUNNING_10_SECONDS", sizeof(g_recipe_status));
+      g_recipe_usb_overruns = r.usb_overruns;
+      g_recipe_consumer_drops = r.consumer_drops;
+      strlcpy(response, "RTL_LAB_OK recipe=transport status=running", response_size);
+      return true;
+    }
+    constexpr const char* carrier_recipes[] = {
+        "gain_quick", "gain_full", "tuner_auto", "rtl_agc", "ppm", "hf_path"};
+    bool carrier_recipe = false;
+    for (const char* candidate : carrier_recipes)
+      carrier_recipe |= strcmp(recipe, candidate) == 0;
+    const bool known_guided = carrier_recipe || strcmp(recipe, "rate_passport") == 0 ||
+        strcmp(recipe, "source_reconnect") == 0 ||
+        strcmp(recipe, "bias_off_on_off") == 0;
+    if (!known_guided) {
+      strlcpy(response, "RTL_LAB_ERROR recipe=unknown", response_size); return true;
+    }
+    const char* reason = carrier_recipe && !g_reference.configured
+        ? "INCONCLUSIVE_REFERENCE_UNAVAILABLE"
+        : "INCONCLUSIVE_MANUAL_STEP_REQUIRED";
+    snapshot_result(recipe, reason);
+    strlcpy(g_recipe_status, reason, sizeof(g_recipe_status));
+    snprintf(response, response_size, "RTL_LAB_OK recipe=%s status=%s", recipe, reason);
+    return true;
+  }
+  if (strcmp(command, "RTL_LAB RECORDS LIST") == 0) {
+    snprintf(response, response_size, "RTL_LAB_RECORDS count=%u newest=%s result=%s",
+             static_cast<unsigned>(g_recent_count), g_recent_count ? g_recent_ids[0] : "none",
+             g_recent_count ? g_recent_results[0] : "none"); return true;
+  }
+  char record_id[32]{};
+  if (sscanf(command, "RTL_LAB RECORDS SHOW %31s", record_id) == 1) {
+    for (size_t i = 0; i < g_recent_count; ++i) {
+      if (strcmp(record_id, g_recent_ids[i]) == 0) {
+        snprintf(response, response_size, "RTL_LAB_RECORD id=%s result=%s path=/orcsdr/rf_lab/%s",
+                 record_id, g_recent_results[i], record_id); return true;
+      }
+    }
+    strlcpy(response, "RTL_LAB_ERROR record=not_found", response_size); return true;
+  }
+  char id[40]{};
+  long value = 0;
+  if (sscanf(command, "RTL_LAB SET %39s %ld", id, &value) == 2) {
+    ActionKind kind = ActionKind::none;
+    if (strcmp(id, "frequency_hz") == 0 && value >= 500000 && value <= 1766000000 &&
+        has_cap(ESP_RTL_SDR_CAP_RETUNE)) kind = ActionKind::tune_hz;
+    else if (strcmp(id, "sample_rate_sps") == 0 &&
+             ((value >= 225001 && value <= 300000) ||
+              (value >= 900000 && value <= 3200000)) &&
+             has_cap(ESP_RTL_SDR_CAP_CONTINUOUS_RATE)) kind = ActionKind::sample_rate_sps;
+    else if (strcmp(id, "ppm") == 0 && value >= -200 && value <= 200 &&
+             has_cap(ESP_RTL_SDR_CAP_FREQ_CORRECTION)) kind = ActionKind::ppm;
+    else if (strcmp(id, "gain_tenth_db") == 0 && valid_gain(runtime(), value) &&
+             has_cap(ESP_RTL_SDR_CAP_GAIN)) kind = ActionKind::gain_tenth_db;
+    else if (strcmp(id, "gain_mode") == 0 && (value == 0 || value == 1) &&
+             has_cap(value ? ESP_RTL_SDR_CAP_GAIN : ESP_RTL_SDR_CAP_GAIN_AUTO)) kind = ActionKind::gain_mode;
+    else if (strcmp(id, "rtl_agc") == 0 && (value == 0 || value == 1) &&
+             has_cap(ESP_RTL_SDR_CAP_RTL_AGC)) kind = ActionKind::rtl_agc;
+    else if (strcmp(id, "bias_tee") == 0 && value == 0 &&
+             has_cap(ESP_RTL_SDR_CAP_BIAS_TEE)) kind = ActionKind::bias_tee;
+    else if (strcmp(id, "bias_tee") == 0 && value == 1 &&
+             has_cap(ESP_RTL_SDR_CAP_BIAS_TEE) &&
+             static_cast<int32_t>(g_bias_cli_ack_until_ms - millis()) > 0) {
+      kind = ActionKind::bias_tee;
+      g_bias_cli_ack_until_ms = 0;
+    }
+    if (kind == ActionKind::none) {
+      strlcpy(response, "RTL_LAB_ERROR invalid_or_unsafe", response_size); return true;
+    }
+    queue(kind, static_cast<int32_t>(value));
+    snprintf(response, response_size, "RTL_LAB_OK id=%s queued=1", id); return true;
+  }
+  return false;
+}
+
+bool self_check() {
+  if (next_rate(256000) != 960000 || next_rate(2560000) != 256000 ||
+      !inside(20, kFooterY, 20, kFooterY, 304, kFooterH) ||
+      !safe_note("bounded note") || safe_note("comma,is_not_csv_safe") ||
+      safe_note("quote\"is_not_json_safe")) return false;
+  Page parsed{};
+  Runtime a{}, b{};
+  a.frequency_hz = b.frequency_hz = 100000000;
+  a.sample_rate_sps = b.sample_rate_sps = 960000;
+  a.gain_mode = b.gain_mode = GainMode::manual;
+  a.gain_tenth_db = b.gain_tenth_db = 297;
+  a.gain_count = 3;
+  a.gain_ladder[0] = 0; a.gain_ladder[1] = 297; a.gain_ladder[2] = 496;
+  if (next_gain(a) != 496) return false;
+  if (!same_calibration_state(a, b)) return false;
+  b.ppm = 1;
+  return !same_calibration_state(a, b) && parse_page("measurements", &parsed) &&
+         parsed == Page::measurements && kPlotY + kPlotH < kFooterY &&
+         sizeof(g_pending_marker) == 48 &&
+         rf_analysis::self_check();
+}
+
+}  // namespace orcsdr::rf_lab

--- a/apps/orcsdr-tab5/ui/rf_lab.cpp
+++ b/apps/orcsdr-tab5/ui/rf_lab.cpp
@@ -128,6 +128,8 @@ char g_recipe[32]{"NONE"};
 char g_recipe_status[64]{"IDLE"};
 uint32_t g_recipe_usb_overruns = 0;
 uint32_t g_recipe_consumer_drops = 0;
+float g_bias_volts[3]{};
+uint8_t g_bias_stage = 0;
 
 bool inside(int32_t x, int32_t y, int bx, int by, int bw, int bh) {
   return x >= bx && x < bx + bw && y >= by && y < by + bh;
@@ -177,6 +179,17 @@ bool write_hashed(File& file, mbedtls_sha256_context& sha, const void* data,
 void hex_string(const uint8_t* bytes, size_t count, char* output, size_t capacity) {
   if (!bytes || !output || capacity < count * 2 + 1) return;
   for (size_t i = 0; i < count; ++i) snprintf(output + i * 2, 3, "%02x", bytes[i]);
+}
+
+void json_sanitize(const char* input, char* output, size_t capacity) {
+  if (!output || !capacity) return;
+  size_t written = 0;
+  for (const unsigned char* p = reinterpret_cast<const unsigned char*>(input ? input : "");
+       *p && written + 1 < capacity; ++p)
+    output[written++] = (*p >= 32 && *p <= 126 && *p != '"' && *p != '\\')
+                            ? static_cast<char>(*p)
+                            : '_';
+  output[written] = '\0';
 }
 
 bool begin_part(const char* path, char* part, size_t part_size, File* file) {
@@ -283,28 +296,34 @@ bool write_bmp(const SaveJob& job, const char* directory, uint8_t hash[32]) {
 
 bool write_json(const SaveJob& job, const char* directory, const uint8_t csv_hash[32],
                 const uint8_t bmp_hash[32]) {
-  char path[112], part[120], csv_hex[65]{}, bmp_hex[65]{};
+  char path[112], part[120], csv_hex[65]{}, bmp_hex[65]{}, device[48]{}, health[28]{};
   snprintf(path, sizeof(path), "%s/session.json", directory);
   hex_string(csv_hash, 32, csv_hex, sizeof(csv_hex));
   hex_string(bmp_hash, 32, bmp_hex, sizeof(bmp_hex));
+  json_sanitize(job.runtime.device, device, sizeof(device));
+  json_sanitize(job.runtime.health, health, sizeof(health));
   File file;
   if (!begin_part(path, part, sizeof(part), &file)) return false;
   const esp_app_desc_t* app = esp_app_get_description();
   const size_t written = file.printf(
       "{\n  \"schema_version\":1,\n  \"id\":\"%s\",\n  \"result\":\"%s\",\n"
-      "  \"firmware\":\"%s\",\n  \"driver\":\"%s\",\n  \"device\":\"%s\",\n"
+      "  \"firmware\":\"%s\",\n  \"driver\":\"%s\",\n  \"device\":\"%s\",\n  \"health\":\"%s\",\n"
       "  \"started_ms\":%lu,\n  \"stopped_ms\":%lu,\n  \"readings\":%u,\n"
       "  \"configuration\":{\"frequency_hz\":%lu,\"sample_rate_sps\":%lu,\"ppm\":%d,\"gain_mode\":\"%s\",\"gain_tenth_db\":%d,\"rtl_agc\":%s,\"bias_tee\":%s},\n"
+      "  \"stream\":{\"effective_sps\":%lu,\"usb_overruns\":%lu,\"consumer_drops\":%lu},\n"
       "  \"capabilities\":%lu,\n  \"reference\":{\"configured\":%s,\"frequency_hz\":%lu,\"source_dbm\":%.3f,\"path_loss_db\":%.3f,\"tolerance_db\":%.3f,\"calibrated\":%s,\"dbm_offset\":%.3f,\"note\":\"%s\"},\n"
       "  \"artifacts\":{\"readings.csv\":\"%s\",\"screen.bmp\":\"%s\"}\n}\n",
       job.id, job.result, app ? app->version : "unknown", job.runtime.driver_version,
-      job.runtime.device, static_cast<unsigned long>(job.started_ms),
+      device, health, static_cast<unsigned long>(job.started_ms),
       static_cast<unsigned long>(job.stopped_ms), static_cast<unsigned>(job.count),
       static_cast<unsigned long>(job.runtime.frequency_hz),
       static_cast<unsigned long>(job.runtime.sample_rate_sps), job.runtime.ppm,
       job.runtime.gain_mode == GainMode::automatic ? "AUTO" : "MANUAL",
       job.runtime.gain_tenth_db, job.runtime.rtl_agc ? "true" : "false",
       job.runtime.bias_tee ? "true" : "false",
+      static_cast<unsigned long>(job.runtime.effective_sps),
+      static_cast<unsigned long>(job.runtime.usb_overruns),
+      static_cast<unsigned long>(job.runtime.consumer_drops),
       static_cast<unsigned long>(job.runtime.capabilities),
       job.reference.configured ? "true" : "false",
       static_cast<unsigned long>(job.reference.frequency_hz),
@@ -766,6 +785,10 @@ bool valid_gain(const Runtime& r, int value) {
   return false;
 }
 
+bool bias_voltage_pass(float initial_off, float on, float final_off) {
+  return initial_off <= 0.2f && on >= 4.0f && on <= 5.0f && final_off <= 0.2f;
+}
+
 void handle_tap(int32_t x, int32_t y) {
   if (inside(x, y, 18, 14, 104, 52)) { request_close(); return; }
   if (y >= kFooterY) {
@@ -970,6 +993,19 @@ void service_ui(uint32_t now_ms) {
       }
     }
   }
+  if (strcmp(g_recipe, "source_reconnect") == 0) {
+    if (strcmp(g_recipe_status, "WAITING_FOR_SOURCE_LOSS") == 0 && !r.source_available) {
+      strlcpy(g_recipe_status, "WAITING_FOR_STABLE_RECONNECT", sizeof(g_recipe_status));
+    } else if (strcmp(g_recipe_status, "WAITING_FOR_STABLE_RECONNECT") == 0 &&
+               r.source_available && g_snapshot.source_stable &&
+               g_snapshot.revision > g_loss_revision) {
+      if (g_readings && g_reading_count < kMaxReadings)
+        g_readings[g_reading_count++] = make_reading(now_ms, "SOURCE RESTORED", true);
+      const bool ok = finish_run("PASS");
+      strlcpy(g_recipe_status, ok ? "PASS" : "SAVE_FAILED", sizeof(g_recipe_status));
+      strlcpy(g_recipe, "NONE", sizeof(g_recipe));
+    }
+  }
   if (g_message_until_ms && static_cast<int32_t>(g_message_until_ms - now_ms) > 0) {
     M5.Display.fillRoundRect(260, 598, 760, 42, 7, kPanel);
     M5.Display.drawRoundRect(260, 598, 760, 42, 7, TFT_ORANGE);
@@ -986,7 +1022,8 @@ void handle_touch(int32_t x, int32_t y, bool pressed, uint32_t now_ms) {
     g_bias_hold_fired = false;
     return;
   }
-  if (pressed && g_pressed && bias_button && g_bias_ack && !r.bias_tee &&
+  if (pressed && g_pressed && bias_button &&
+      inside(g_press_x, g_press_y, 700, 454, 252, 48) && g_bias_ack && !r.bias_tee &&
       !g_bias_hold_fired && now_ms - g_press_ms >= kBiasHoldMs) {
     g_bias_hold_fired = true;
     g_bias_ack = false;
@@ -1098,7 +1135,9 @@ bool process_command(const char* command, char* response, size_t response_size) 
                                       &reference_hz, &source_dbm, &path_loss_db,
                                       &tolerance_db, note);
   if (reference_fields >= 4) {
-    if (reference_hz < 500000 || reference_hz > 1766000000UL ||
+    if (!std::isfinite(source_dbm) || !std::isfinite(path_loss_db) ||
+        !std::isfinite(tolerance_db) || reference_hz < 500000 ||
+        reference_hz > 1766000000UL ||
         source_dbm > 20 || source_dbm < -180 || path_loss_db < 0 ||
         path_loss_db > 200 || tolerance_db < 0 || tolerance_db > 100 ||
         (reference_fields == 5 && !safe_note(note))) {
@@ -1115,7 +1154,8 @@ bool process_command(const char* command, char* response, size_t response_size) 
     strlcpy(response, "RTL_LAB_OK reference=configured calibration=invalid", response_size);
     return true;
   }
-  if (strncmp(command, "RTL_LAB SNAPSHOT", 16) == 0) {
+  if (strncmp(command, "RTL_LAB SNAPSHOT", 16) == 0 &&
+      (command[16] == '\0' || command[16] == ' ')) {
     const char* note_value = command[16] == ' ' ? command + 17 : nullptr;
     if (note_value && !safe_note(note_value)) {
       strlcpy(response, "RTL_LAB_ERROR note", response_size); return true;
@@ -1159,10 +1199,69 @@ bool process_command(const char* command, char* response, size_t response_size) 
              g_recipe_status); return true;
   }
   if (strcmp(command, "RTL_LAB RECIPE CANCEL") == 0) {
+    if (strcmp(g_recipe, "bias_off_on_off") == 0) queue(ActionKind::bias_tee, 0);
     if (g_run_active) cancel_run();
     else { strlcpy(g_recipe, "NONE", sizeof(g_recipe));
            strlcpy(g_recipe_status, "CANCELLED", sizeof(g_recipe_status)); }
     strlcpy(response, "RTL_LAB_OK recipe=cancelled", response_size); return true;
+  }
+  if (strcmp(command, "RTL_LAB RECIPE CONFIRM_BIAS_SAFE") == 0) {
+    if (strcmp(g_recipe, "bias_off_on_off") != 0 || g_bias_stage != 1) {
+      strlcpy(response, "RTL_LAB_ERROR recipe=not_waiting_for_bias_confirmation",
+              response_size); return true;
+    }
+    if (g_bias_volts[0] > 0.2f) {
+      queue(ActionKind::bias_tee, 0);
+      finish_run("FAIL_INITIAL_OFF_VOLTAGE");
+      strlcpy(g_recipe, "NONE", sizeof(g_recipe));
+      strlcpy(g_recipe_status, "FAIL_INITIAL_OFF_VOLTAGE", sizeof(g_recipe_status));
+      strlcpy(response, "RTL_LAB_OK recipe=bias_off_on_off status=failed_initial_off",
+              response_size); return true;
+    }
+    queue(ActionKind::bias_tee, 1);
+    g_bias_stage = 2;
+    strlcpy(g_recipe_status, "ENTER_ON_VOLTS", sizeof(g_recipe_status));
+    strlcpy(response, "RTL_LAB_OK recipe=bias_off_on_off status=measure_on_volts",
+            response_size); return true;
+  }
+  float entered_volts = 0;
+  if (sscanf(command, "RTL_LAB RECIPE INPUT %f", &entered_volts) == 1) {
+    if (!std::isfinite(entered_volts) || strcmp(g_recipe, "bias_off_on_off") != 0 ||
+        entered_volts < 0 ||
+        entered_volts > 20 || (g_bias_stage != 0 && g_bias_stage != 2 && g_bias_stage != 3)) {
+      strlcpy(response, "RTL_LAB_ERROR recipe=input_not_expected", response_size); return true;
+    }
+    const uint8_t input_stage = g_bias_stage;
+    char marker[40];
+    if (g_bias_stage == 0) {
+      g_bias_volts[0] = entered_volts;
+      snprintf(marker, sizeof(marker), "BIAS OFF %.3f V", static_cast<double>(entered_volts));
+      g_bias_stage = 1;
+      strlcpy(g_recipe_status, "CONFIRM_SAFE_FOR_ON", sizeof(g_recipe_status));
+    } else if (g_bias_stage == 2) {
+      g_bias_volts[1] = entered_volts;
+      snprintf(marker, sizeof(marker), "BIAS ON %.3f V", static_cast<double>(entered_volts));
+      queue(ActionKind::bias_tee, 0);
+      g_bias_stage = 3;
+      strlcpy(g_recipe_status, "ENTER_FINAL_OFF_VOLTS", sizeof(g_recipe_status));
+    } else {
+      g_bias_volts[2] = entered_volts;
+      snprintf(marker, sizeof(marker), "BIAS FINAL OFF %.3f V",
+               static_cast<double>(entered_volts));
+    }
+    if (g_readings && g_reading_count < kMaxReadings)
+      g_readings[g_reading_count++] = make_reading(millis(), marker, true);
+    if (input_stage == 3) {
+      const bool pass = bias_voltage_pass(g_bias_volts[0], g_bias_volts[1],
+                                          g_bias_volts[2]);
+      const bool saved = finish_run(pass ? "PASS" : "FAIL_VOLTAGE_RANGE");
+      strlcpy(g_recipe, "NONE", sizeof(g_recipe));
+      strlcpy(g_recipe_status, !saved ? "SAVE_FAILED" :
+              (pass ? "PASS" : "FAIL_VOLTAGE_RANGE"),
+              sizeof(g_recipe_status));
+    }
+    snprintf(response, response_size, "RTL_LAB_OK recipe=bias_off_on_off status=%s",
+             g_recipe_status); return true;
   }
   char recipe[32]{};
   if (sscanf(command, "RTL_LAB RECIPE START %31s", recipe) == 1) {
@@ -1186,14 +1285,38 @@ bool process_command(const char* command, char* response, size_t response_size) 
       strlcpy(response, "RTL_LAB_OK recipe=transport status=running", response_size);
       return true;
     }
+    if (strcmp(recipe, "source_reconnect") == 0) {
+      if (!runtime().source_available || !start_run(0, "SOURCE RECONNECT BASELINE")) {
+        strlcpy(response, "RTL_LAB_ERROR recipe=source_or_sd_unavailable", response_size);
+        return true;
+      }
+      strlcpy(g_recipe, recipe, sizeof(g_recipe));
+      strlcpy(g_recipe_status, "WAITING_FOR_SOURCE_LOSS", sizeof(g_recipe_status));
+      strlcpy(response, "RTL_LAB_OK recipe=source_reconnect status=disconnect_source",
+              response_size);
+      return true;
+    }
+    if (strcmp(recipe, "bias_off_on_off") == 0) {
+      if (!has_cap(ESP_RTL_SDR_CAP_BIAS_TEE) ||
+          !start_run(0, "BIAS OFF-ON-OFF")) {
+        strlcpy(response, "RTL_LAB_ERROR recipe=capability_or_sd_unavailable",
+                response_size); return true;
+      }
+      g_bias_volts[0] = g_bias_volts[1] = g_bias_volts[2] = 0;
+      g_bias_stage = 0;
+      strlcpy(g_recipe, recipe, sizeof(g_recipe));
+      strlcpy(g_recipe_status, "ENTER_INITIAL_OFF_VOLTS", sizeof(g_recipe_status));
+      queue(ActionKind::bias_tee, 0);
+      strlcpy(response,
+          "RTL_LAB_OK recipe=bias_off_on_off status=measure_off_volts_then_RECIPE_INPUT",
+          response_size); return true;
+    }
     constexpr const char* carrier_recipes[] = {
         "gain_quick", "gain_full", "tuner_auto", "rtl_agc", "ppm", "hf_path"};
     bool carrier_recipe = false;
     for (const char* candidate : carrier_recipes)
       carrier_recipe |= strcmp(recipe, candidate) == 0;
-    const bool known_guided = carrier_recipe || strcmp(recipe, "rate_passport") == 0 ||
-        strcmp(recipe, "source_reconnect") == 0 ||
-        strcmp(recipe, "bias_off_on_off") == 0;
+    const bool known_guided = carrier_recipe || strcmp(recipe, "rate_passport") == 0;
     if (!known_guided) {
       strlcpy(response, "RTL_LAB_ERROR recipe=unknown", response_size); return true;
     }
@@ -1269,6 +1392,9 @@ bool self_check() {
   a.gain_count = 3;
   a.gain_ladder[0] = 0; a.gain_ladder[1] = 297; a.gain_ladder[2] = 496;
   if (next_gain(a) != 496) return false;
+  if (!bias_voltage_pass(0.0f, 4.5f, 0.1f) ||
+      bias_voltage_pass(0.3f, 4.5f, 0.0f) ||
+      bias_voltage_pass(0.0f, 3.9f, 0.0f)) return false;
   if (!same_calibration_state(a, b)) return false;
   b.ppm = 1;
   return !same_calibration_state(a, b) && parse_page("measurements", &parsed) &&

--- a/apps/orcsdr-tab5/ui/rf_lab.hpp
+++ b/apps/orcsdr-tab5/ui/rf_lab.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "orcsdr_storage.hpp"
+
+#include <cstddef>
+#include <cstdint>
+
+namespace orcsdr::rf_lab {
+
+enum class Page : uint8_t { live, controls, measurements, records };
+enum class GainMode : uint8_t { automatic, manual };
+
+struct Runtime {
+  uint32_t frequency_hz = 0;
+  uint32_t sample_rate_sps = 0;
+  uint32_t capabilities = 0;
+  uint32_t usb_overruns = 0;
+  uint32_t consumer_drops = 0;
+  uint32_t effective_sps = 0;
+  int ppm = 0;
+  int gain_tenth_db = 0;
+  int gain_ladder[28]{};
+  uint8_t gain_count = 0;
+  GainMode gain_mode = GainMode::automatic;
+  bool rtl_agc = false;
+  bool bias_tee = false;
+  bool source_available = false;
+  bool sound_enabled = true;
+  uint8_t volume = 0;
+  bool sd_writable = false;
+  char driver_version[20]{};
+  char device[48]{};
+  char health[28]{};
+};
+
+enum class ActionKind : uint8_t {
+  none,
+  close,
+  tune_hz,
+  sample_rate_sps,
+  ppm,
+  gain_mode,
+  gain_tenth_db,
+  rtl_agc,
+  bias_tee,
+};
+
+struct Action {
+  ActionKind kind = ActionKind::none;
+  int32_t value = 0;
+};
+
+bool initialize(storage::FileSystem* filesystem);
+void set_runtime(const Runtime& runtime);
+bool enter(uint8_t origin_screen, uint8_t origin_tab = 0);
+void leave();
+bool active();
+uint8_t origin_screen();
+uint8_t origin_tab();
+Page page();
+void service_ui(uint32_t now_ms);
+void handle_touch(int32_t x, int32_t y, bool pressed, uint32_t now_ms);
+bool take_action(Action* action);
+bool process_command(const char* command, char* response, size_t response_size);
+bool self_check();
+
+}  // namespace orcsdr::rf_lab

--- a/apps/orcsdr-tab5/ui/rf_visualizer.cpp
+++ b/apps/orcsdr-tab5/ui/rf_visualizer.cpp
@@ -1,10 +1,10 @@
 #include "rf_visualizer.hpp"
 
 #include "nvs_store.hpp"
+#include "rf_analysis.hpp"
 #include "text_editor.hpp"
 
 #include <M5Unified.h>
-#include <dsps_fft2r.h>
 #include <esp_heap_caps.h>
 #include <lgfx/v1/platforms/esp32p4/Panel_DSI.hpp>
 #include <freertos/FreeRTOS.h>
@@ -27,10 +27,7 @@ constexpr uint16_t kPersistVersion = 1;
 constexpr size_t kMaxControls = 192;
 constexpr size_t kPresetValues = 32;
 constexpr size_t kCustomPresets = 4;
-constexpr size_t kIqBytes = 16384;
-constexpr size_t kIqPoints = kIqBytes / 2;
 constexpr size_t kBins = 1024;
-constexpr size_t kAudioFrames = 2048;
 constexpr int kPlotX = 42;
 constexpr int kPlotY = 82;
 constexpr int kPlotW = 1196;
@@ -72,22 +69,7 @@ struct Persisted {
   Preset presets[static_cast<size_t>(View::count)][kCustomPresets];
 };
 
-struct SpectrumFrame {
-  uint32_t revision = 0;
-  uint32_t analyzed_ms = 0;
-  uint16_t bins = 0;
-  float live[kBins]{};
-  float average[kBins]{};
-  float peak[kBins]{};
-  float noise = -120;
-  float strongest = -120;
-  int32_t strongest_offset_hz = 0;
-  uint16_t iq_count = 0;
-  float iq_i[1024]{};
-  float iq_q[1024]{};
-  uint16_t audio_bins = 0;
-  float audio[kBins]{};
-};
+using SpectrumFrame = rf_analysis::Snapshot;
 
 struct Gesture {
   bool down = false;
@@ -120,25 +102,15 @@ Persisted* g_persist_storage = nullptr;
 #define g_persist (*g_persist_storage)
 Runtime g_runtime{};
 portMUX_TYPE g_runtime_mux = portMUX_INITIALIZER_UNLOCKED;
-SemaphoreHandle_t g_iq_mutex = nullptr;
-SemaphoreHandle_t g_audio_mutex = nullptr;
-uint8_t* g_iq = nullptr;
-size_t g_iq_bytes = 0;
-uint32_t g_iq_revision = 0;
-int16_t* g_audio_l = nullptr;
-int16_t* g_audio_r = nullptr;
-size_t g_audio_frames = 0;
-uint32_t g_audio_rate = 48000;
-uint32_t g_audio_revision = 0;
-TaskHandle_t g_analysis_task = nullptr;
 std::atomic<bool> g_active{false};
 std::atomic<bool> g_source_available{false};
 std::atomic<uint8_t> g_view{0};
-std::atomic<uint32_t> g_dropped_input{0};
 SemaphoreHandle_t g_frame_mutex = nullptr;
 SemaphoreHandle_t g_history_mutex = nullptr;
 SpectrumFrame* g_frame = nullptr;
 SpectrumFrame* g_ui_frame = nullptr;
+SpectrumFrame* g_observer_frame = nullptr;
+bool g_initialized = false;
 uint32_t g_drawn_revision = 0;
 uint8_t* g_history = nullptr;
 bool g_history_audio = false;
@@ -202,6 +174,8 @@ size_t g_selected_preset = 0;
 
 void set_value(size_t index, float next, bool persist);
 void allocate_view_buffers(View next);
+void configure_analysis();
+void process_channel_audio(const uint8_t* iq, size_t bytes);
 
 size_t copy_view_values(View current, float* output, size_t capacity) {
   size_t count = 0, descriptor_count = 0;
@@ -296,6 +270,7 @@ void set_value(size_t index, float next, bool persist = true) {
     g_channels[g_selected_channel].offset_hz = next;
   if (strcmp(c.id, "visual.freeze") == 0) persist = false;
   if (persist) g_persist_due_ms = millis() + 2000;
+  if (g_initialized) configure_analysis();
 }
 
 uint32_t capabilities() {
@@ -492,28 +467,6 @@ int selected_fft_size(View current) {
   return sizes[std::clamp(i, 0, 4)];
 }
 
-int fit_fft_size(int requested, size_t available) {
-  while (requested > static_cast<int>(available)) requested >>= 1;
-  return requested >= 256 ? requested : 0;
-}
-
-size_t append_audio_window(int16_t* destination, size_t capacity, size_t used,
-                           const int16_t* source, size_t count) {
-  if (!destination || !capacity || !source || !count) return used;
-  if (count >= capacity) {
-    memcpy(destination, source + count - capacity, capacity * sizeof(*destination));
-    return capacity;
-  }
-  used = std::min(used, capacity);
-  const size_t overflow = used + count > capacity ? used + count - capacity : 0;
-  if (overflow) {
-    memmove(destination, destination + overflow, (used - overflow) * sizeof(*destination));
-    used -= overflow;
-  }
-  memcpy(destination + used, source, count * sizeof(*destination));
-  return used + count;
-}
-
 void add_history_row(const SpectrumFrame& frame, bool audio) {
   if (!g_history || !g_history_rows) return;
   if (g_history_mutex && xSemaphoreTake(g_history_mutex, 0) != pdTRUE) return;
@@ -593,220 +546,127 @@ void update_occupancy(const SpectrumFrame& frame) {
   }
 }
 
-void analyze_iq(const uint8_t* iq, size_t bytes, SpectrumFrame* next, float* work) {
-  if (!iq || !next || !work || bytes < 512) return;
-  const View current = static_cast<View>(g_view.load(std::memory_order_acquire));
-  int n = selected_fft_size(current);
-  n = std::min<int>(n, static_cast<int>(bytes / 2));
-  int power = 1;
-  while ((power << 1) <= n) power <<= 1;
-  n = std::max(256, power);
-  constexpr float pi = 3.14159265358979323846f;
-  float sum_i = 0, sum_q = 0;
-  const size_t iq_points = std::min<size_t>(1024, bytes / 2);
-  for (size_t i = 0; i < iq_points; ++i) {
-    const float re = (static_cast<int>(iq[i * 2]) - 127.5f) / 127.5f;
-    const float im = (static_cast<int>(iq[i * 2 + 1]) - 127.5f) / 127.5f;
-    next->iq_i[i] = re;
-    next->iq_q[i] = im;
-    sum_i += re;
-    sum_q += im;
-  }
-  next->iq_count = static_cast<uint16_t>(iq_points);
-  const float dc_i = sum_i / iq_points;
-  const float dc_q = sum_q / iq_points;
-  for (size_t i = 0; i < iq_points; ++i) {
-    next->iq_i[i] -= dc_i;
-    next->iq_q[i] -= dc_q;
-  }
-  if (current == View::constellation || current == View::polar) {
-    const char* prefix = current == View::constellation ? "constellation." : "polar.";
-    const int source = static_cast<int>(value(current == View::constellation
-                                                   ? "constellation.source"
-                                                   : "polar.source"));
-    const float manual_deg = value(current == View::constellation
-                                        ? "constellation.phase_deg"
-                                        : "polar.rotation_deg");
-    const float manual = manual_deg * pi / 180.0f;
-    static float filtered_i = 0, filtered_q = 0, carrier_phase = 0, carrier_rate = 0;
-    if (source > 0) {
-      Runtime runtime{};
-      portENTER_CRITICAL(&g_runtime_mux);
-      runtime = g_runtime;
-      portEXIT_CRITICAL(&g_runtime_mux);
-      const float bandwidth = current == View::constellation
-                                  ? value("constellation.channel_bw_hz")
-                                  : std::max(2400.0f, runtime.span_hz / 8.0f);
-      const float alpha = std::clamp(6.2831853f * bandwidth /
-                                         std::max(1.0f, static_cast<float>(runtime.sample_rate_sps)),
-                                     0.002f, 0.35f);
-      const int recovery = current == View::constellation
-                               ? static_cast<int>(value("constellation.carrier_recovery"))
-                               : (value("polar.phase_reference") == 2 ? 1 : 0);
-      for (size_t i = 0; i < iq_points; ++i) {
-        filtered_i += alpha * (next->iq_i[i] - filtered_i);
-        filtered_q += alpha * (next->iq_q[i] - filtered_q);
-        const float phase = carrier_phase + manual;
-        const float c = cosf(phase), s = sinf(phase);
-        const float rotated_i = filtered_i * c + filtered_q * s;
-        const float rotated_q = filtered_q * c - filtered_i * s;
-        next->iq_i[i] = rotated_i;
-        next->iq_q[i] = rotated_q;
-        if (recovery) {
-          const float error = recovery == 2
-                                  ? copysignf(1.0f, rotated_i) * rotated_q -
-                                        copysignf(1.0f, rotated_q) * rotated_i
-                                  : atan2f(rotated_q, rotated_i);
-          carrier_rate = std::clamp(carrier_rate + 0.00002f * error, -0.08f, 0.08f);
-          carrier_phase += carrier_rate + 0.002f * error;
-          if (carrier_phase > pi) carrier_phase -= 2 * pi;
-          if (carrier_phase < -pi) carrier_phase += 2 * pi;
-        }
-      }
-      if (source > 1 && current == View::constellation) {
-        const float symbol_rate = value("constellation.symbol_rate");
-        if (symbol_rate > 0 && runtime.sample_rate_sps > symbol_rate) {
-          const float samples_per_symbol = runtime.sample_rate_sps / symbol_rate;
-          float cursor = 0;
-          size_t output = 0;
-          while (cursor < iq_points && output < iq_points) {
-            const size_t index = std::min(iq_points - 1, static_cast<size_t>(cursor));
-            next->iq_i[output] = next->iq_i[index];
-            next->iq_q[output++] = next->iq_q[index];
-            cursor += samples_per_symbol;
-          }
-          next->iq_count = static_cast<uint16_t>(output);
-        }
-      }
-    } else if (manual != 0) {
-      const float c = cosf(manual), s = sinf(manual);
-      for (size_t i = 0; i < iq_points; ++i) {
-        const float re = next->iq_i[i], im = next->iq_q[i];
-        next->iq_i[i] = re * c + im * s;
-        next->iq_q[i] = im * c - re * s;
-      }
-    }
-    (void)prefix;
-  }
-  for (int i = 0; i < n; ++i) {
-    const float window = 0.5f - 0.5f * cosf(2.0f * pi * i / (n - 1));
-    work[i * 2] = ((static_cast<int>(iq[i * 2]) - 127.5f) / 127.5f) * window;
-    work[i * 2 + 1] = ((static_cast<int>(iq[i * 2 + 1]) - 127.5f) / 127.5f) * window;
-  }
-  // ESP-DSP's P4 assembly path assumes internal RAM; visualizer FFT buffers live in PSRAM.
-  if (dsps_fft2r_fc32_ansi(work, n) != ESP_OK || dsps_bit_rev_fc32_ansi(work, n) != ESP_OK)
-    return;
-  next->bins = static_cast<uint16_t>(std::min<int>(kBins, n));
-  next->strongest = -160;
-  float noise_sum = 0;
-  size_t strongest_bin = next->bins / 2;
-  for (size_t x = 0; x < next->bins; ++x) {
-    const size_t source = x * n / next->bins;
-    const size_t shifted = (source + n / 2) % n;
-    const float re = work[shifted * 2];
-    const float im = work[shifted * 2 + 1];
-    const float db = 10.0f * log10f(re * re + im * im + 1.0e-12f) -
-                     20.0f * log10f(static_cast<float>(n));
-    next->live[x] = db;
-    const float linear = powf(10.0f, db / 10.0f);
-    const float old_average = powf(10.0f, next->average[x] / 10.0f);
-    next->average[x] = 10.0f * log10f(0.15f * linear + 0.85f * old_average + 1.0e-14f);
-    next->peak[x] = std::max(db, next->peak[x] - 0.15f);
-    noise_sum += db;
-    if (db > next->strongest) {
-      next->strongest = db;
-      strongest_bin = x;
-    }
-  }
-  next->noise = noise_sum / next->bins;
+
+void configure_analysis() {
   Runtime runtime{};
   portENTER_CRITICAL(&g_runtime_mux);
   runtime = g_runtime;
   portEXIT_CRITICAL(&g_runtime_mux);
-  next->strongest_offset_hz = static_cast<int32_t>(
-      (static_cast<int64_t>(strongest_bin) - next->bins / 2) * runtime.span_hz /
-      std::max<int>(1, next->bins));
+  const View current = static_cast<View>(g_view.load(std::memory_order_acquire));
+  rf_analysis::Config config{};
+  config.center_hz = runtime.center_hz;
+  config.span_hz = runtime.span_hz;
+  config.sample_rate_sps = runtime.sample_rate_sps;
+  config.audio_rate_sps = runtime.audio_rate_sps;
+  config.measurement_bandwidth_hz = runtime.filter_bandwidth_hz;
+  config.fft_size = static_cast<uint16_t>(
+      current == View::audio_spectrogram ? 1024 : selected_fft_size(current));
+  config.audio_fft_size = static_cast<uint16_t>(selected_fft_size(View::audio_spectrogram));
+  config.interval_ms = g_effective_quality == 0 ? 33 : g_effective_quality == 1 ? 66 : 200;
+  config.audio_spectrum = current == View::audio_spectrogram;
+  config.audio_demod = runtime.audio_demod == AudioDemod::fm
+                           ? rf_analysis::AudioDemod::fm
+                           : runtime.audio_demod == AudioDemod::am
+                                 ? rf_analysis::AudioDemod::am
+                                 : rf_analysis::AudioDemod::none;
+  rf_analysis::set_config(config);
 }
 
-size_t demodulate_audio_snapshot(const uint8_t* iq, size_t bytes, AudioDemod demod,
-                                 uint32_t sample_rate, uint32_t audio_rate,
-                                 int16_t* output, size_t capacity) {
-  if (!iq || bytes < 4 || demod == AudioDemod::none || !output || !capacity) return 0;
-  const uint32_t decimation =
-      std::max<uint32_t>(1, sample_rate / std::max<uint32_t>(1, audio_rate));
-  float previous_i = static_cast<int>(iq[0]) - 127.5f;
-  float previous_q = static_cast<int>(iq[1]) - 127.5f;
-  float sum = 0, dc = 0;
-  uint32_t phase = 0;
-  size_t count = 0;
-  for (size_t offset = 2; offset + 1 < bytes && count < capacity; offset += 2) {
-    const float i = static_cast<int>(iq[offset]) - 127.5f;
-    const float q = static_cast<int>(iq[offset + 1]) - 127.5f;
-    float sample = 0;
-    if (demod == AudioDemod::fm) {
-      const float cross = previous_i * q - previous_q * i;
-      const float dot = previous_i * i + previous_q * q;
-      sample = cross / (fabsf(dot) + 64.0f);
-    } else {
-      sample = fabsf(i) + fabsf(q);
-      dc += 0.002f * (sample - dc);
-      sample = (sample - dc) * 0.02f;
-    }
-    previous_i = i;
-    previous_q = q;
-    sum += sample;
-    if (++phase == decimation) {
-      output[count++] = static_cast<int16_t>(std::clamp(
-          sum * (demod == AudioDemod::fm ? 9000.0f : 7000.0f) / decimation,
-          -16000.0f, 16000.0f));
-      phase = 0;
-      sum = 0;
-    }
-  }
-  return count;
-}
-
-void analyze_audio(SpectrumFrame* next, float* work, const uint8_t* iq, size_t iq_bytes) {
-  if (!next || !work || !g_audio_l || !g_audio_mutex) return;
-  static uint32_t analyzed_revision = 0;
-  int16_t local[kAudioFrames];
-  size_t frames = 0;
-  if (xSemaphoreTake(g_audio_mutex, 0) == pdTRUE) {
-    if (g_audio_revision != analyzed_revision) {
-      frames = std::min(g_audio_frames, kAudioFrames);
-      memcpy(local, g_audio_l, frames * sizeof(int16_t));
-      analyzed_revision = g_audio_revision;
-    }
-    xSemaphoreGive(g_audio_mutex);
-  }
-  if (frames < 256) {
+void transform_iq_frame(SpectrumFrame* frame) {
+  if (!frame || !frame->iq_count) return;
+  const View current = static_cast<View>(g_view.load(std::memory_order_acquire));
+  if (current != View::constellation && current != View::polar) return;
+  const int source = static_cast<int>(value(current == View::constellation
+                                                 ? "constellation.source"
+                                                 : "polar.source"));
+  const float manual_deg = value(current == View::constellation
+                                      ? "constellation.phase_deg"
+                                      : "polar.rotation_deg");
+  const float manual = manual_deg * 3.14159265358979323846f / 180.0f;
+  static float filtered_i = 0, filtered_q = 0, carrier_phase = 0, carrier_rate = 0;
+  if (source > 0) {
     Runtime runtime{};
     portENTER_CRITICAL(&g_runtime_mux);
     runtime = g_runtime;
     portEXIT_CRITICAL(&g_runtime_mux);
-    frames = demodulate_audio_snapshot(iq, iq_bytes, runtime.audio_demod,
-                                       runtime.sample_rate_sps, runtime.audio_rate_sps,
-                                       local, std::size(local));
+    const float bandwidth = current == View::constellation
+                                ? value("constellation.channel_bw_hz")
+                                : std::max(2400.0f, runtime.span_hz / 8.0f);
+    const float alpha = std::clamp(6.2831853f * bandwidth /
+                                       std::max(1.0f, static_cast<float>(runtime.sample_rate_sps)),
+                                   0.002f, 0.35f);
+    const int recovery = current == View::constellation
+                             ? static_cast<int>(value("constellation.carrier_recovery"))
+                             : (value("polar.phase_reference") == 2 ? 1 : 0);
+    for (size_t i = 0; i < frame->iq_count; ++i) {
+      filtered_i += alpha * (frame->iq_i[i] - filtered_i);
+      filtered_q += alpha * (frame->iq_q[i] - filtered_q);
+      const float phase = carrier_phase + manual;
+      const float c = cosf(phase), s = sinf(phase);
+      const float rotated_i = filtered_i * c + filtered_q * s;
+      const float rotated_q = filtered_q * c - filtered_i * s;
+      frame->iq_i[i] = rotated_i;
+      frame->iq_q[i] = rotated_q;
+      if (recovery) {
+        const float error = recovery == 2
+                                ? copysignf(1.0f, rotated_i) * rotated_q -
+                                      copysignf(1.0f, rotated_q) * rotated_i
+                                : atan2f(rotated_q, rotated_i);
+        carrier_rate = std::clamp(carrier_rate + 0.00002f * error, -0.08f, 0.08f);
+        carrier_phase += carrier_rate + 0.002f * error;
+        if (carrier_phase > 3.14159265358979323846f)
+          carrier_phase -= 6.28318530717958647692f;
+        if (carrier_phase < -3.14159265358979323846f)
+          carrier_phase += 6.28318530717958647692f;
+      }
+    }
+    if (source > 1 && current == View::constellation) {
+      const float symbol_rate = value("constellation.symbol_rate");
+      if (symbol_rate > 0 && runtime.sample_rate_sps > symbol_rate) {
+        const float samples_per_symbol = runtime.sample_rate_sps / symbol_rate;
+        float cursor = 0;
+        size_t output = 0;
+        while (cursor < frame->iq_count && output < frame->iq_count) {
+          const size_t index =
+              std::min<size_t>(frame->iq_count - 1, static_cast<size_t>(cursor));
+          frame->iq_i[output] = frame->iq_i[index];
+          frame->iq_q[output++] = frame->iq_q[index];
+          cursor += samples_per_symbol;
+        }
+        frame->iq_count = static_cast<uint16_t>(output);
+      }
+    }
+  } else if (manual != 0) {
+    const float c = cosf(manual), s = sinf(manual);
+    for (size_t i = 0; i < frame->iq_count; ++i) {
+      const float re = frame->iq_i[i], im = frame->iq_q[i];
+      frame->iq_i[i] = re * c + im * s;
+      frame->iq_q[i] = im * c - re * s;
+    }
   }
-  if (frames < 256) return;
-  const int n = fit_fft_size(selected_fft_size(View::audio_spectrogram), frames);
-  if (!n) return;
-  constexpr float pi = 3.14159265358979323846f;
-  for (int i = 0; i < n; ++i) {
-    const float window = 0.5f - 0.5f * cosf(2.0f * pi * i / (n - 1));
-    work[i * 2] = local[i] * window / 32768.0f;
-    work[i * 2 + 1] = 0;
+}
+
+void analysis_observer(const rf_analysis::Snapshot& snapshot, const uint8_t* iq,
+                       size_t bytes) {
+  if (!g_active.load(std::memory_order_acquire) || !g_observer_frame) return;
+  *g_observer_frame = snapshot;
+  transform_iq_frame(g_observer_frame);
+  if (xSemaphoreTake(g_frame_mutex, pdMS_TO_TICKS(2)) == pdTRUE) {
+    *g_frame = *g_observer_frame;
+    xSemaphoreGive(g_frame_mutex);
   }
-  if (dsps_fft2r_fc32_ansi(work, n) != ESP_OK || dsps_bit_rev_fc32_ansi(work, n) != ESP_OK)
-    return;
-  next->audio_bins = static_cast<uint16_t>(std::min<int>(kBins, n / 2));
-  for (size_t x = 0; x < next->audio_bins; ++x) {
-    const size_t source = x * (n / 2) / next->audio_bins;
-    const float re = work[source * 2];
-    const float im = work[source * 2 + 1];
-    next->audio[x] = 10.0f * log10f(re * re + im * im + 1.0e-12f) -
-                     20.0f * log10f(static_cast<float>(n));
+  const View current = static_cast<View>(g_view.load(std::memory_order_acquire));
+  if (!value("visual.freeze")) {
+    if (current == View::phosphor) add_density(*g_observer_frame);
+    else if (current == View::waterfall || current == View::spectrum3d ||
+             current == View::occupancy || current == View::doppler)
+      add_history_row(*g_observer_frame, false);
+    else if (current == View::audio_spectrogram)
+      add_history_row(*g_observer_frame, true);
+    if (current == View::occupancy) update_occupancy(*g_observer_frame);
   }
+  if (current == View::channelizer) process_channel_audio(iq, bytes);
+  ++g_analysis_frames;
 }
 
 void process_channel_audio(const uint8_t* iq, size_t bytes) {
@@ -872,70 +732,6 @@ void process_channel_audio(const uint8_t* iq, size_t bytes) {
   if (pcm_count) g_audio_sink(pcm, pcm_count);
 }
 
-void analysis_worker(void*) {
-  float* work = static_cast<float*>(
-      heap_caps_aligned_alloc(16, sizeof(float) * 8192 * 2,
-                              MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-  uint8_t* local_iq = static_cast<uint8_t*>(
-      heap_caps_malloc(kIqBytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-  SpectrumFrame* next = static_cast<SpectrumFrame*>(
-      heap_caps_malloc(sizeof(SpectrumFrame), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-  uint32_t seen_revision = 0;
-  while (true) {
-    if (!g_active.load(std::memory_order_acquire) || !work || !local_iq || !next) {
-      vTaskDelay(pdMS_TO_TICKS(50));
-      continue;
-    }
-    const uint8_t quality = static_cast<uint8_t>(std::clamp(value("visual.quality"), 0.0f, 2.0f));
-    const uint32_t interval = quality <= 1 ? 30 : 66;
-    static uint32_t last_ms = 0;
-    if (millis() - last_ms < interval) {
-      vTaskDelay(pdMS_TO_TICKS(5));
-      continue;
-    }
-    size_t bytes = 0;
-    uint32_t revision = 0;
-    if (xSemaphoreTake(g_iq_mutex, 0) == pdTRUE) {
-      revision = g_iq_revision;
-      if (revision != seen_revision) {
-        bytes = g_iq_bytes;
-        memcpy(local_iq, g_iq, bytes);
-      }
-      xSemaphoreGive(g_iq_mutex);
-    }
-    if (!bytes) {
-      vTaskDelay(pdMS_TO_TICKS(10));
-      continue;
-    }
-    seen_revision = revision;
-    last_ms = millis();
-    if (xSemaphoreTake(g_frame_mutex, pdMS_TO_TICKS(2)) != pdTRUE) continue;
-    *next = *g_frame;
-    xSemaphoreGive(g_frame_mutex);
-    analyze_iq(local_iq, bytes, next, work);
-    if (static_cast<View>(g_view.load()) == View::audio_spectrogram)
-      analyze_audio(next, work, local_iq, bytes);
-    if (static_cast<View>(g_view.load()) == View::channelizer)
-      process_channel_audio(local_iq, bytes);
-    next->revision = revision;
-    next->analyzed_ms = millis();
-    if (xSemaphoreTake(g_frame_mutex, pdMS_TO_TICKS(2)) == pdTRUE) {
-      *g_frame = *next;
-      xSemaphoreGive(g_frame_mutex);
-    }
-    const View current = static_cast<View>(g_view.load());
-    if (!value("visual.freeze")) {
-      if (current == View::phosphor) add_density(*next);
-      else if (current == View::waterfall || current == View::spectrum3d ||
-               current == View::occupancy || current == View::doppler)
-        add_history_row(*next, false);
-      else if (current == View::audio_spectrogram)
-        add_history_row(*next, true);
-      if (current == View::occupancy) update_occupancy(*next);
-    }
-    ++g_analysis_frames;
-  }
-}
 
 void draw_frame_chrome() {
   g_canvas.setFont(nullptr);
@@ -1343,7 +1139,8 @@ void draw_hud() {
   button(954, 14, 104, 52, g_hud_locked ? "LOCKED" : "LOCK", kCyan, g_hud_locked);
   char fps[64];
   snprintf(fps, sizeof(fps), "P %.0f  A %.0f  DROP %lu", static_cast<double>(g_presentation_fps),
-           static_cast<double>(g_analysis_fps), static_cast<unsigned long>(g_dropped_input.load()));
+           static_cast<double>(g_analysis_fps),
+           static_cast<unsigned long>(g_ui_frame ? g_ui_frame->input_drops : 0));
   text(fps, 1260, 40, kMuted, 1, middle_right);
 }
 
@@ -1484,6 +1281,7 @@ void switch_view(int delta) {
   g_persist.last_view = static_cast<uint8_t>(next);
   g_persist_due_ms = millis() + 2000;
   allocate_view_buffers(static_cast<View>(next));
+  configure_analysis();
   g_drawn_revision = 0;
   g_name_until_ms = millis() + kNameTimeoutMs;
   draw_frame_chrome();
@@ -1499,16 +1297,19 @@ void reset_view_defaults() {
       g_persist.values[i] = list[i].default_value;
   g_persist_due_ms = millis() + 1;
   allocate_view_buffers(current);
+  configure_analysis();
 }
 
 void run_action(const ControlDescriptor& c) {
   if (strcmp(c.id, "visual.reset") == 0) reset_view_defaults();
   else if (strcmp(c.id, "fft.clear_peak") == 0 || strcmp(c.id, "peakavg.clear_hold") == 0) {
+    rf_analysis::clear_peak();
     if (xSemaphoreTake(g_frame_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
       for (float& p : g_frame->peak) p = -160;
       xSemaphoreGive(g_frame_mutex);
     }
   } else if (strcmp(c.id, "peakavg.clear_average") == 0) {
+    rf_analysis::clear_average();
     if (xSemaphoreTake(g_frame_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
       for (float& p : g_frame->average) p = -160;
       xSemaphoreGive(g_frame_mutex);
@@ -1709,6 +1510,7 @@ void service_health(uint32_t now) {
   const bool stressed = runtime.usb_overruns > g_last_usb_overruns ||
                         runtime.consumer_drops > g_last_consumer_drops ||
                         runtime.audio_drops > g_last_audio_drops;
+  const uint8_t before = g_effective_quality;
   if (stressed) {
     g_effective_quality = std::min<uint8_t>(2, static_cast<uint8_t>(g_effective_quality + 1));
     g_stable_since_ms = now;
@@ -1720,6 +1522,7 @@ void service_health(uint32_t now) {
   g_last_usb_overruns = runtime.usb_overruns;
   g_last_consumer_drops = runtime.consumer_drops;
   g_last_audio_drops = runtime.audio_drops;
+  if (g_effective_quality != before) configure_analysis();
 }
 
 }  // namespace
@@ -1735,7 +1538,7 @@ bool initialize(NvsStore* store, AudioSink audio_sink) {
   size_t count = 0;
   const auto* list = controls(&count);
   if (count > kMaxControls || !controls_self_check()) return false;
-  if (g_analysis_task) {
+  if (g_initialized) {
     if (g_store) {
       Persisted saved{};
       if (g_store->get_bytes("rf_vis", &saved, sizeof(saved)) == sizeof(saved) &&
@@ -1746,6 +1549,8 @@ bool initialize(NvsStore* store, AudioSink audio_sink) {
                                       static_cast<uint8_t>(View::count) - 1));
       }
     }
+    rf_analysis::set_observer(analysis_observer);
+    configure_analysis();
     return true;
   }
   g_canvas.setPsram(true);
@@ -1779,29 +1584,22 @@ bool initialize(NvsStore* store, AudioSink audio_sink) {
   g_persist.last_view = std::min<uint8_t>(g_persist.last_view,
                                           static_cast<uint8_t>(View::count) - 1);
   g_view.store(g_persist.last_view);
-  g_iq_mutex = xSemaphoreCreateMutex();
-  g_audio_mutex = xSemaphoreCreateMutex();
   g_frame_mutex = xSemaphoreCreateMutex();
   g_history_mutex = xSemaphoreCreateMutex();
-  g_iq = static_cast<uint8_t*>(heap_caps_malloc(kIqBytes, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-  g_audio_l = static_cast<int16_t*>(
-      heap_caps_malloc(kAudioFrames * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-  g_audio_r = static_cast<int16_t*>(
-      heap_caps_malloc(kAudioFrames * sizeof(int16_t), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
   g_frame = static_cast<SpectrumFrame*>(
       heap_caps_calloc(1, sizeof(SpectrumFrame), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
   g_ui_frame = static_cast<SpectrumFrame*>(
       heap_caps_calloc(1, sizeof(SpectrumFrame), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
-  if (!g_iq_mutex || !g_audio_mutex || !g_frame_mutex || !g_history_mutex || !g_iq ||
-      !g_audio_l || !g_audio_r || !g_frame || !g_ui_frame)
+  g_observer_frame = static_cast<SpectrumFrame*>(
+      heap_caps_calloc(1, sizeof(SpectrumFrame), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT));
+  if (!g_frame_mutex || !g_history_mutex || !g_frame || !g_ui_frame || !g_observer_frame)
     return false;
   for (float& level : g_frame->average) level = -160;
   for (float& level : g_frame->peak) level = -160;
-  if (dsps_fft2r_init_fc32(nullptr, 8192) != ESP_OK) return false;
-  if (xTaskCreatePinnedToCoreWithCaps(analysis_worker, "rf_visualizer", 8192, nullptr, 1,
-                                      &g_analysis_task, 1,
-                                      MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) != pdPASS)
-    return false;
+  if (!rf_analysis::initialize() || !rf_analysis::self_check()) return false;
+  rf_analysis::set_observer(analysis_observer);
+  g_initialized = true;
+  configure_analysis();
   return true;
 }
 
@@ -1810,30 +1608,16 @@ void set_runtime(const Runtime& runtime) {
   g_runtime = runtime;
   portEXIT_CRITICAL(&g_runtime_mux);
   g_source_available.store(runtime.source_available, std::memory_order_release);
+  if (g_initialized) configure_analysis();
 }
 
 void offer_iq(const uint8_t* iq, size_t bytes) {
-  if (!g_active.load(std::memory_order_relaxed) || !iq || bytes < 512 || !g_iq_mutex) return;
-  if (xSemaphoreTake(g_iq_mutex, 0) != pdTRUE) {
-    g_dropped_input.fetch_add(1, std::memory_order_relaxed);
-    return;
-  }
-  g_iq_bytes = std::min(bytes, kIqBytes);
-  memcpy(g_iq, iq, g_iq_bytes);
-  ++g_iq_revision;
-  xSemaphoreGive(g_iq_mutex);
+  rf_analysis::offer_iq(iq, bytes);
 }
 
 void offer_audio(const int16_t* left, const int16_t* right, size_t frames,
                  uint32_t sample_rate_sps) {
-  if (!g_active.load(std::memory_order_relaxed) || !left || !frames || !g_audio_mutex) return;
-  if (xSemaphoreTake(g_audio_mutex, 0) != pdTRUE) return;
-  const size_t used = g_audio_frames;
-  g_audio_frames = append_audio_window(g_audio_l, kAudioFrames, used, left, frames);
-  append_audio_window(g_audio_r, kAudioFrames, used, right ? right : left, frames);
-  g_audio_rate = sample_rate_sps;
-  ++g_audio_revision;
-  xSemaphoreGive(g_audio_mutex);
+  rf_analysis::offer_audio(left, right, frames, sample_rate_sps);
 }
 
 bool enter(uint8_t origin_screen_value, uint8_t origin_tab_value) {
@@ -1844,6 +1628,8 @@ bool enter(uint8_t origin_screen_value, uint8_t origin_tab_value) {
   g_effective_quality = static_cast<uint8_t>(std::clamp(value("visual.quality"), 0.0f, 2.0f));
   allocate_view_buffers(static_cast<View>(g_view.load()));
   g_active.store(true, std::memory_order_release);
+  configure_analysis();
+  rf_analysis::set_enabled(true);
   g_name_until_ms = millis() + kNameTimeoutMs;
   g_drawn_revision = 0;
   draw_frame_chrome();
@@ -1854,6 +1640,7 @@ bool enter(uint8_t origin_screen_value, uint8_t origin_tab_value) {
 
 void leave() {
   g_active.store(false, std::memory_order_release);
+  rf_analysis::set_enabled(false);
   g_channel_solo = false;
   if (!g_history_mutex || xSemaphoreTake(g_history_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
     free_view_buffers();
@@ -2054,7 +1841,8 @@ bool process_command(const char* command, char* response, size_t response_size) 
              active() ? 1 : 0, view_slug(view()), g_source_available.load() ? 1 : 0,
              value("visual.freeze") ? 1 : 0, g_inspect ? 1 : 0, g_drawer ? 1 : 0,
              static_cast<double>(g_presentation_fps), static_cast<double>(g_analysis_fps),
-             static_cast<unsigned long>(g_dropped_input.load()), g_effective_quality);
+             static_cast<unsigned long>(g_ui_frame ? g_ui_frame->input_drops : 0),
+             g_effective_quality);
     return true;
   }
   if (strcmp(command, "RTL_VIS NEXT") == 0) { switch_view(1); strlcpy(response, "RTL_VIS_OK", response_size); return true; }
@@ -2146,10 +1934,7 @@ bool self_check() {
   if (!preset_slot("1", &slot) || slot != 0 || preset_slot("5", &slot) ||
       choice_count("A|B|C") != 3)
     return false;
-  if (kDrawerY + kDrawerH != 720 || kHudH < 58) return false;
-  if (fit_fft_size(1024, 372) != 256 || fit_fft_size(2048, 1024) != 1024 ||
-      fit_fft_size(256, 128) != 0)
-    return false;
+  if (kDrawerY + kDrawerH != 720 || kHudH < 58 || !rf_analysis::self_check()) return false;
   if (density_decay_scale(3000, 3.0f) != 128 ||
       density_linear_decay(3000, 3.0f) != 128 ||
       density_accumulate(20, 80, 0) != 80 ||
@@ -2157,22 +1942,6 @@ bool self_check() {
       density_accumulate(250, 80, 2) != 255 ||
       density_display_intensity(24, 1.0f) != 240 ||
       density_display_intensity(24, 0.25f) != 60)
-    return false;
-  int16_t audio_window[4] = {1, 2, 3, 4};
-  const int16_t audio_tail[3] = {5, 6, 7};
-  if (append_audio_window(audio_window, 4, 4, audio_tail, 3) != 4 ||
-      audio_window[0] != 4 || audio_window[1] != 5 || audio_window[3] != 7)
-    return false;
-  uint8_t rotating_iq[1024];
-  constexpr uint8_t phases[][2] = {{255, 128}, {128, 255}, {0, 128}, {128, 0}};
-  for (size_t i = 0; i < std::size(rotating_iq) / 2; ++i) {
-    rotating_iq[i * 2] = phases[i % 4][0];
-    rotating_iq[i * 2 + 1] = phases[i % 4][1];
-  }
-  int16_t demodulated[512]{};
-  if (demodulate_audio_snapshot(rotating_iq, sizeof(rotating_iq), AudioDemod::fm,
-                                48000, 48000, demodulated,
-                                std::size(demodulated)) < 256 || demodulated[4] == 0)
     return false;
   if (waterfall_rate(0) != 30 || waterfall_rate(1) != 5 || waterfall_rate(7) != 60 ||
       waterfall_intensity(-100, -100, -20, 1) != 0 ||

--- a/apps/orcsdr-tab5/ui/screen_controller.cpp
+++ b/apps/orcsdr-tab5/ui/screen_controller.cpp
@@ -56,6 +56,7 @@ const char* name(Id id) {
     case Id::lora: return "lora";
     case Id::radio: return "radio";
     case Id::visualizer: return "visualizer";
+    case Id::rf_lab: return "rf_lab";
     case Id::settings: return "settings";
     case Id::documentation: return "documentation";
     default: return "none";
@@ -90,11 +91,14 @@ bool self_check() {
   begin_transition(Id::visualizer, now++, false);
   finish_transition();
   const bool visualizer_owns = owns(Id::visualizer);
-  const bool restored = g_status.transitions == 19;
+  begin_transition(Id::rf_lab, now++, false);
+  finish_transition();
+  const bool rf_lab_owns = owns(Id::rf_lab);
+  const bool restored = g_status.transitions == 20;
   g_status = saved;
   g_transitioning = saved_transitioning;
   return entering_blocks_draw && home_owns && settings_return && documentation_owns &&
-         documentation_restores && visualizer_owns && restored;
+         documentation_restores && visualizer_owns && rf_lab_owns && restored;
 }
 
 }  // namespace orcsdr::screens

--- a/apps/orcsdr-tab5/ui/screen_controller.hpp
+++ b/apps/orcsdr-tab5/ui/screen_controller.hpp
@@ -7,7 +7,7 @@ namespace orcsdr::screens {
 // Exactly one surface may own the framebuffer.  Radio/decoder work is not a
 // surface and continues independently of this state.
 enum class Id : uint8_t {
-  none, home, fm, p25, adsb, lora, radio, visualizer, settings, documentation
+  none, home, fm, p25, adsb, lora, radio, visualizer, rf_lab, settings, documentation
 };
 
 struct Status {


### PR DESCRIPTION
## Summary

- add the RF Lab dashboard and shared RF analysis service
- migrate full-screen visualizers to the shared analyzer
- keep RTL-SDR DSP outside the driver callback
- stabilize speaker startup and P25/RF Lab transitions
- harden the monitored UI regression harness

## Verification

- native ESP-IDF 5.5.4 Tab5 build passed
- built-in regression harness self-check passed
- five-cycle COM17 UI/radio/RF Lab soak passed
- FM audio and mute recovery passed
- esp_rtl_sdr v0.7.9 gain/AUTO/RTL-AGC regression passed
- zero USB overruns and consumer drops in the final soak
- no panic, stack fault, or unexpected reset
- bias-tee was not exercised

## Release

Planned prerelease: `v0.2.0-alpha.6`

Hardware evidence remains separate from CI. Build directories and test artifacts are not included.