### PR TITLE
feat(tab5): add RF24 Wi-Fi analysis dashboard

### DIFF
--- a/apps/orcsdr-tab5/main/CMakeLists.txt
+++ b/apps/orcsdr-tab5/main/CMakeLists.txt
@@ -32,6 +32,7 @@ idf_component_register(
         "../ui/text_editor.cpp"
         "../ui/ui_capture.cpp"
         "../ui/web_console.cpp"
+        "../ui/rf24_dashboard.cpp"
         "../ui/wifi_service.cpp"
     INCLUDE_DIRS "." "../ui"
     REQUIRES

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -18,6 +18,8 @@ param(
   [string]$LogPath,
   [switch]$SelfCheck,
   [switch]$Driver079,
+  [switch]$WifiOnly,
+  [switch]$RequireWifiConnection,
   [switch]$TestBiasTee
 )
 
@@ -74,7 +76,7 @@ function Send-And-Wait([string]$Command, [string]$Pattern, [int]$Seconds = $Time
   return Read-MatchingLine $Pattern $Seconds
 }
 
-function Wait-DeviceReady([int]$Seconds = 60) {
+function Wait-DeviceReady([int]$Seconds = 60, [int]$MinimumUptimeMs = 0) {
   $deadline = [DateTime]::UtcNow.AddSeconds($Seconds)
   $nextProbe = [DateTime]::MinValue
   while ([DateTime]::UtcNow -lt $deadline) {
@@ -88,7 +90,8 @@ function Wait-DeviceReady([int]$Seconds = 60) {
       $script:linesSeen++
       Write-SoakLine $line
       if (Test-FatalLine $line) { throw "Device crash/reset detected: $line" }
-      if ($line -match '^RTL_HEALTH_STATUS ') { return }
+      if ($line -match '^RTL_HEALTH_STATUS uptime_ms=(\d+)' -and
+          [int64]$Matches[1] -ge $MinimumUptimeMs) { return }
     } catch [System.TimeoutException] {}
   }
   throw 'Timed out waiting for device readiness.'
@@ -128,26 +131,27 @@ function Connect-Authenticated {
 
 function Get-UiState {
   $line = Send-And-Wait 'RTL_UI STATUS' '^RTL_UI_STATUS '
-  if ($line -notmatch 'screen=(\S+) band=(\S+) frequency_hz=(\d+) settings=([01]) fm=([01]) p25=([01]) adsb=([01]) lora=([01]) home_font=([01])') {
+  if ($line -notmatch 'screen=(\S+) band=(\S+) frequency_hz=(\d+) settings=([01]) fm=([01]) p25=([01]) adsb=([01]) lora=([01]) rf24=([01]) home_font=([01])') {
     throw "Malformed UI status: $line"
   }
   return [pscustomobject]@{
     Screen = $Matches[1].ToUpperInvariant()
     Band = $Matches[2].ToUpperInvariant()
     Frequency = [uint32]$Matches[3]
-    Active = @([int]$Matches[4], [int]$Matches[5], [int]$Matches[6], [int]$Matches[7], [int]$Matches[8])
-    HomeFont = [int]$Matches[9]
+    Active = @([int]$Matches[4], [int]$Matches[5], [int]$Matches[6], [int]$Matches[7], [int]$Matches[8], [int]$Matches[9])
+    HomeFont = [int]$Matches[10]
   }
 }
 
 function Test-ExclusiveScreen($State, [string]$Screen) {
   $expected = switch ($Screen) {
-    'FM' { @(0,1,0,0,0) }
-    'P25' { @(0,0,1,0,0) }
-    'ADSB' { @(0,0,0,1,0) }
-    'LORA' { @(0,0,0,0,1) }
-    'SETTINGS' { @(1,0,0,0,0) }
-    'HOME' { @(0,0,0,0,0) }
+    'FM' { @(0,1,0,0,0,0) }
+    'P25' { @(0,0,1,0,0,0) }
+    'ADSB' { @(0,0,0,1,0,0) }
+    'LORA' { @(0,0,0,0,1,0) }
+    'WIFI_ANALYSIS' { @(0,0,0,0,0,1) }
+    'SETTINGS' { @(1,0,0,0,0,0) }
+    'HOME' { @(0,0,0,0,0,0) }
     default { return $true }
   }
   return ($State.Active -join ',') -eq ($expected -join ',')
@@ -257,6 +261,106 @@ function Assert-WifiCycle {
   Write-SoakLine 'RTL_UI_SOAK_WIFI pass=1'
 }
 
+function Get-WifiStatus {
+  $line = Send-And-Wait 'RTL_WIFI_STATUS' '^RTL_WIFI_STATUS '
+  if ($line -notmatch 'station=([01]).*connected=([01]).*saved_profiles=(\d+).*power=([01]).*auto_connect=([01]).*antenna=(internal|external).*ap_count=(\d+)') {
+    throw "Malformed Wi-Fi status: $line"
+  }
+  return [pscustomobject]@{
+    Line = $line
+    Station = [int]$Matches[1]
+    Connected = [int]$Matches[2]
+    Profiles = [int]$Matches[3]
+    Power = [int]$Matches[4]
+    AutoConnect = [int]$Matches[5]
+    Antenna = $Matches[6]
+    AccessPoints = [int]$Matches[7]
+  }
+}
+
+function Wait-WifiScan {
+  $result = Read-MatchingLine '^RTL_WIFI_SCAN_RESULTS count=([0-9]+)$' 45
+  if ($result -notmatch 'count=([1-9][0-9]*)$') { throw "Wi-Fi scan returned no APs: $result" }
+  $count = [int]$Matches[1]
+  [void](Read-MatchingLine '^RTL_WIFI_COEX event=scan_complete ' 10)
+  return $count
+}
+
+function Assert-WifiLists([int]$ExpectedAccessPoints) {
+  $begin = Send-And-Wait 'RTL_WIFI_RESULTS' '^RTL_WIFI_RESULTS_BEGIN count=([0-9]+) revision=([0-9]+)$'
+  if ($begin -notmatch 'count=([0-9]+) ' -or [int]$Matches[1] -ne $ExpectedAccessPoints) {
+    throw "Wi-Fi result count changed: $begin"
+  }
+  for ($i = 0; $i -lt $ExpectedAccessPoints; $i++) {
+    [void](Read-MatchingLine "^RTL_WIFI_AP index=$i ssid_hex=[0-9A-Fa-f]* bssid=[0-9A-Fa-f]{12} rssi=-?[0-9]+ channel=[0-9]+ secure=[01]$")
+  }
+  [void](Read-MatchingLine '^RTL_WIFI_RESULTS_END$')
+
+  $profiles = Send-And-Wait 'RTL_WIFI_PROFILES' '^RTL_WIFI_PROFILES_BEGIN count=([0-9]+)$'
+  if ($profiles -notmatch 'count=([0-9]+)$') { throw "Malformed Wi-Fi profiles: $profiles" }
+  $profileCount = [int]$Matches[1]
+  for ($i = 0; $i -lt $profileCount; $i++) {
+    [void](Read-MatchingLine "^RTL_WIFI_PROFILE index=$i ssid_hex=[0-9A-Fa-f]+ connected=[01]$")
+  }
+  [void](Read-MatchingLine '^RTL_WIFI_PROFILES_END$')
+  return $profileCount
+}
+
+function Assert-WifiCli {
+  $initialUi = Get-UiState
+  $initial = Get-WifiStatus
+  try {
+    [void](Send-And-Wait 'SET_WIFI 00 00 00' '^WIFI_INVALID$')
+    [void](Send-And-Wait 'RTL_UI ACTION SETTINGS CONNECT_SAVED 99' '^RTL_UI_ACTION_INVALID profile_index$')
+    [void](Send-And-Wait 'RTL_UI ACTION SETTINGS FORGET 99' '^RTL_UI_ACTION_INVALID profile_index$')
+    [void](Send-And-Wait 'RTL_UI ACTION SETTINGS MOVE_UP 0' '^RTL_UI_ACTION_INVALID profile_move$')
+
+    [void](Send-And-Wait "RTL_UI ACTION SETTINGS WIFI_BOOT $(1 - $initial.AutoConnect)" '^RTL_UI_ACTION_OK$')
+    if ((Get-WifiStatus).AutoConnect -eq $initial.AutoConnect) { throw 'Auto-connect toggle did not apply.' }
+    [void](Send-And-Wait "RTL_UI ACTION SETTINGS WIFI_BOOT $($initial.AutoConnect)" '^RTL_UI_ACTION_OK$')
+
+    $otherAntenna = if ($initial.Antenna -eq 'internal') { 1 } else { 0 }
+    [void](Send-And-Wait "RTL_UI ACTION SETTINGS ANTENNA $otherAntenna" '^RTL_UI_ACTION_OK$')
+    if ((Get-WifiStatus).Antenna -eq $initial.Antenna) { throw 'Antenna toggle did not apply.' }
+    [void](Send-And-Wait "RTL_UI ACTION SETTINGS ANTENNA $(if ($initial.Antenna -eq 'external') { 1 } else { 0 })" '^RTL_UI_ACTION_OK$')
+
+    [void](Send-And-Wait 'RTL_UI ACTION SETTINGS WIFI_POWER 0' '^RTL_UI_ACTION_OK$' 20)
+    $off = Get-WifiStatus
+    if ($off.Power -ne 0 -or $off.Station -ne 0 -or $off.Connected -ne 0) {
+      throw "Wi-Fi power-off state is inconsistent: $($off.Line)"
+    }
+    [void](Send-And-Wait 'RTL_UI ACTION SETTINGS WIFI_POWER 1' '^RTL_UI_ACTION_OK$' 20)
+
+    [void](Open-Ui 'WIFI_ANALYSIS' $initialUi.Band)
+    $autoCount = Wait-WifiScan
+    [void](Send-And-Wait 'RTL_WIFI_SCAN' '^RTL_WIFI_SCAN_QUEUED$')
+    $manualCount = Wait-WifiScan
+    $profileCount = Assert-WifiLists $manualCount
+
+    [void](Send-And-Wait 'RTL_WIFI_DISCONNECT' '^RTL_WIFI_DISCONNECT_OK$')
+    if ((Get-WifiStatus).Connected -ne 0) { throw 'Wi-Fi disconnect did not apply.' }
+    if ($profileCount -gt 0) {
+      [void](Send-And-Wait 'RTL_UI ACTION SETTINGS CONNECT_SAVED 0' '^RTL_UI_ACTION_OK$')
+      [void](Read-MatchingLine '^RTL_WIFI_COEX event=connect_complete ' 45)
+      if ((Get-WifiStatus).Connected -ne 1) { throw 'Saved Wi-Fi profile did not connect.' }
+    } elseif ($RequireWifiConnection) {
+      throw 'Connection proof required, but the device has no saved Wi-Fi profile.'
+    } else {
+      Write-SoakLine 'RTL_WIFI_CLI_CONNECT skipped=no_saved_profile'
+    }
+    Assert-Health
+    Write-SoakLine "RTL_WIFI_CLI_RESULT pass=1 auto_aps=$autoCount manual_aps=$manualCount profiles=$profileCount connected=$([int]($profileCount -gt 0))"
+  } finally {
+    try {
+      Connect-Authenticated
+      [void](Send-And-Wait "RTL_UI ACTION SETTINGS WIFI_BOOT $($initial.AutoConnect)" '^RTL_UI_ACTION_OK$')
+      [void](Send-And-Wait "RTL_UI ACTION SETTINGS ANTENNA $(if ($initial.Antenna -eq 'external') { 1 } else { 0 })" '^RTL_UI_ACTION_OK$')
+      [void](Send-And-Wait "RTL_UI ACTION SETTINGS WIFI_POWER $($initial.Power)" '^RTL_UI_ACTION_OK$' 20)
+      [void](Send-And-Wait "RTL_UI OPEN $($initialUi.Screen)" '^RTL_UI_OPEN_(?:OK|INVALID)')
+    } catch { Write-Warning "Could not restore initial Wi-Fi/UI state: $($_.Exception.Message)" }
+  }
+}
+
 function Capture-ResetEvidence {
   Write-SoakLine 'RTL_UI_SOAK_RECOVERY begin=1'
   $deadline = [DateTime]::UtcNow.AddSeconds(20)
@@ -294,18 +398,18 @@ function Invoke-SelfCheck {
   }
   $audio = '{"type":"rtl_audio_test","speaker_enabled":1,"speaker_running":1,"audio_chunks":42}' | ConvertFrom-Json
   if ($audio.speaker_running -ne 1 -or $audio.audio_chunks -ne 42) { throw 'Audio parser failed.' }
-  if (-not (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,0,0,1,0) }) 'ADSB')) {
+  if (-not (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,0,0,1,0,0) }) 'ADSB')) {
     throw 'Exclusive dashboard check rejected valid ADS-B state.'
   }
-  if (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,1,0,1,0) }) 'ADSB') {
+  if (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,1,0,1,0,0) }) 'ADSB') {
     throw 'Exclusive dashboard check accepted stale FM state.'
   }
   Write-SoakLine 'RTL_UI_SOAK_SELF_CHECK pass=1'
 }
 
 if ($SelfCheck) { Invoke-SelfCheck; exit 0 }
-if (@($Run, $Soak, $Driver079).Where({ $_ }).Count -gt 1) {
-  throw 'Choose only one of -Run, -Soak, or -Driver079.'
+if (@($Run, $Soak, $Driver079, $WifiOnly).Where({ $_ }).Count -gt 1) {
+  throw 'Choose only one of -Run, -Soak, -Driver079, or -WifiOnly.'
 }
 
 function Get-DriverStatus {
@@ -400,6 +504,12 @@ try {
   $script:serial.DiscardInBuffer()
 
   if ($Driver079) { Invoke-Driver079Test; exit 0 }
+  if ($WifiOnly) {
+    Wait-DeviceReady 60 11000
+    Connect-Authenticated
+    Assert-WifiCli
+    exit 0
+  }
 
   if ($Profile) {
     $commit = (& git -C (Join-Path $PSScriptRoot '..\..\..') rev-parse --short HEAD 2>$null)

--- a/apps/orcsdr-tab5/tools/test-tab5-wifi-release.ps1
+++ b/apps/orcsdr-tab5/tools/test-tab5-wifi-release.ps1
@@ -31,6 +31,10 @@ try {
   if ($status -notmatch 'hosted_match=1') {
     Wait-Line '^RTL_WIFI_HOSTED .* match=1$' $TimeoutSeconds | Out-Null
   }
+  $results = Wait-Line '^RTL_WIFI_SCAN_RESULTS count=([0-9]+)$' $TimeoutSeconds
+  if ($results -notmatch 'count=([1-9][0-9]*)$') {
+    throw "Wi-Fi scan returned no access points: $results"
+  }
   Wait-Line '^RTL_WIFI_COEX event=scan_complete ' $TimeoutSeconds | Out-Null
   $serial.WriteLine('RTL_WIFI_STATUS')
   $status = Wait-Line '^RTL_WIFI_STATUS .*hosted_match=1' $TimeoutSeconds

--- a/apps/orcsdr-tab5/ui/dashboard_registry.cpp
+++ b/apps/orcsdr-tab5/ui/dashboard_registry.cpp
@@ -18,6 +18,7 @@ constexpr Descriptor kEntries[] = {
     {Id::marine, "MARINE", "VHF marine receiver", Category::audio, true},
     {Id::satellite, "SATELLITE", "Satellite receive workspace", Category::digital, true},
     {Id::rf_lab, "RF LAB", "Live measurements and driver tests", Category::utility, true},
+    {Id::wifi_analysis, "2.4 GHz ANALYZER", "Real Wi-Fi access-point survey", Category::utility, true},
     {Id::settings, "SETTINGS", "Global device settings", Category::system, true},
 };
 
@@ -99,7 +100,8 @@ bool self_check() {
                      g_recent[1] == Id::fm && !record_open(Id::p25);
   g_recent = saved;
   g_recent_count = saved_count;
-  return loaded && moved && std::size(kEntries) == 12 && find(Id::rf_lab) != nullptr;
+  return loaded && moved && std::size(kEntries) == 13 && find(Id::rf_lab) != nullptr &&
+         find(Id::wifi_analysis) != nullptr;
 }
 
 }  // namespace orcsdr::dashboards

--- a/apps/orcsdr-tab5/ui/dashboard_registry.hpp
+++ b/apps/orcsdr-tab5/ui/dashboard_registry.hpp
@@ -20,6 +20,7 @@ enum class Id : uint8_t {
   utilities,
   settings,
   rf_lab,
+  wifi_analysis,
   count,
 };
 

--- a/apps/orcsdr-tab5/ui/home_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/home_dashboard.cpp
@@ -125,6 +125,10 @@ void draw_menu_icon(dashboards::Id id, int x, int y, uint16_t color) {
   } else if (id == dashboards::Id::settings) {
     M5.Display.drawCircle(x, y, 15, color);
     M5.Display.fillCircle(x, y, 5, color);
+  } else if (id == dashboards::Id::wifi_analysis) {
+    M5.Display.drawCircle(x, y + 7, 3, color);
+    M5.Display.drawArc(x, y + 7, 12, 12, 210, 330, color);
+    M5.Display.drawArc(x, y + 7, 20, 20, 210, 330, color);
   } else {
     M5.Display.drawLine(x - 13, y - 13, x + 13, y + 13, color);
     M5.Display.drawLine(x + 13, y - 13, x - 13, y + 13, color);

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -72,6 +72,7 @@ extern "C" {
 #include "settings_app.hpp"
 #include "ui_capture.hpp"
 #include "web_console.hpp"
+#include "rf24_dashboard.hpp"
 #include "wifi_service.hpp"
 #include "esp_rtl_sdr.h"
 
@@ -1394,8 +1395,8 @@ bool settings_wifi_external_antenna = false;
 bool wifi_connected = false;
 bool wifi_connecting = false;
 bool wifi_radio_paused = false;
-uint32_t wifi_radio_resume_due_ms = 0;
 bool radio_io_resume_pending = false;
+bool radio_io_speaker_resume_pending = false;
 bool wifi_save_after_connect = false;
 uint32_t wifi_connect_started_ms = 0;
 int wifi_network_count = -1;
@@ -1414,12 +1415,15 @@ EXT_RAM_BSS_ATTR WifiProfile wifi_profiles[4]{};
 uint8_t wifi_profile_count = 0;
 struct WifiScanResult {
   char ssid[33]{};
+  uint8_t bssid[6]{};
   int16_t rssi = 0;
+  uint8_t channel = 0;
   bool secure = false;
 };
-EXT_RAM_BSS_ATTR WifiScanResult wifi_scan_results[6]{};
+EXT_RAM_BSS_ATTR WifiScanResult wifi_scan_results[orcsdr::rf24::kAccessPointCapacity]{};
 uint8_t wifi_scan_result_count = 0;
 uint32_t wifi_scan_started_ms = 0;
+uint32_t wifi_scan_revision = 0;
 uint8_t settings_brightness = 180;
 uint8_t settings_rotation = 1;
 uint16_t settings_screen_timeout_sec = 0;
@@ -1873,6 +1877,7 @@ void draw_home_dashboard();
 void handle_home_action(const orcsdr::home::Action& action);
 void persist_dashboard_open(orcsdr::dashboards::Id id);
 void open_global_settings(orcsdr::settings::Section section);
+void close_global_settings();
 void handle_global_settings_touch(int32_t x, int32_t y);
 void update_global_settings();
 void redraw_global_settings();
@@ -4874,6 +4879,38 @@ void draw_lora_dashboard(bool static_panel) {
   else orcsdr::lora::update(snapshot);
 }
 
+orcsdr::rf24::Snapshot rf24_dashboard_snapshot() {
+  orcsdr::rf24::Snapshot snapshot{};
+  snapshot.ready = wifi_station_ready;
+  snapshot.scanning = wifi_scan_running;
+  snapshot.sound_enabled = rtl_audio_user_enabled.load(std::memory_order_acquire);
+  snapshot.visualizer_available =
+      rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running;
+  strlcpy(snapshot.message, wifi_status_message, sizeof(snapshot.message));
+  snapshot.revision = wifi_scan_revision;
+  snapshot.access_point_count = std::min<uint8_t>(wifi_scan_result_count,
+                                                   orcsdr::rf24::kAccessPointCapacity);
+  for (uint8_t i = 0; i < snapshot.access_point_count; ++i) {
+    auto& access_point = snapshot.access_points[i];
+    strlcpy(access_point.ssid, wifi_scan_results[i].ssid, sizeof(access_point.ssid));
+    memcpy(access_point.bssid, wifi_scan_results[i].bssid, sizeof(access_point.bssid));
+    access_point.rssi = wifi_scan_results[i].rssi;
+    access_point.channel = wifi_scan_results[i].channel;
+    access_point.secure = wifi_scan_results[i].secure;
+  }
+  std::sort(snapshot.access_points, snapshot.access_points + snapshot.access_point_count,
+            [](const auto& left, const auto& right) { return left.rssi > right.rssi; });
+  return snapshot;
+}
+
+void draw_rf24_dashboard(bool static_panel) {
+  if (!static_panel && !orcsdr::screens::may_draw(orcsdr::screens::Id::wifi_analysis)) return;
+  if (!static_panel) orcsdr::screens::note_visible_update(orcsdr::screens::Id::wifi_analysis);
+  const auto snapshot = rf24_dashboard_snapshot();
+  if (static_panel || !orcsdr::rf24::active()) orcsdr::rf24::enter(snapshot);
+  else orcsdr::rf24::update(snapshot);
+}
+
 
 void draw_fm_dashboard(bool static_panel) {
   if (!static_panel && !orcsdr::screens::may_draw(orcsdr::screens::Id::fm)) return;
@@ -4909,6 +4946,7 @@ void refresh_active_screen() {
     case Id::p25: draw_p25_dashboard(false); break;
     case Id::adsb: draw_adsb_dashboard(false); break;
     case Id::lora: draw_lora_dashboard(false); break;
+    case Id::wifi_analysis: draw_rf24_dashboard(false); break;
     default: break;  // Settings, documentation, and no screen own their draws.
   }
 }
@@ -4961,6 +4999,7 @@ void close_visualizer() {
     case orcsdr::screens::Id::p25: orcsdr::p25::draw(); break;
     case orcsdr::screens::Id::adsb: orcsdr::adsb::draw(); break;
     case orcsdr::screens::Id::lora: orcsdr::lora::draw(); break;
+    case orcsdr::screens::Id::wifi_analysis: draw_rf24_dashboard(true); break;
     default: show_home(); break;
   }
 }
@@ -7440,8 +7479,17 @@ void prepare_wifi_coprocessor() {
   Serial.println("RTL_WIFI_C6_POWER_CYCLE ok");
 }
 
+bool pause_radio_for_wifi();
+void resume_radio_after_wifi();
+
 void initialize_wifi() {
   if (wifi_station_ready) return;
+  const bool wifi_pause_already_owned = wifi_radio_paused;
+  if (!pause_radio_for_wifi()) {
+    strlcpy(wifi_status_message, "Radio pause failed", sizeof(wifi_status_message));
+    Serial.println("RTL_WIFI_INIT_ERROR radio_pause_failed");
+    return;
+  }
   prepare_wifi_coprocessor();
   const uint32_t dma_free = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA);
   const uint32_t dma_largest =
@@ -7450,23 +7498,6 @@ void initialize_wifi() {
                 static_cast<unsigned long>(dma_free),
                 static_cast<unsigned long>(dma_largest),
                 CONFIG_ESP_HOSTED_HOST_SDIO_TX_Q_SIZE, CONFIG_ESP_HOSTED_HOST_SDIO_RX_Q_SIZE);
-  const bool radio_was_running =
-      rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running;
-  if (radio_was_running) {
-    Serial.println("RTL_WIFI_INIT pause_radio");
-    rtl_restart_requested.store(false, std::memory_order_release);
-    rtl_stop_requested.store(true, std::memory_order_release);
-    for (int spin = 0; spin < 80 &&
-                       rtl_capture_state.load(std::memory_order_acquire) ==
-                           RtlCaptureState::running;
-         ++spin)
-      delay(20);
-    Serial.printf("RTL_WIFI_DMA after_pause free=%lu largest=%lu\n",
-                  static_cast<unsigned long>(
-                      heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA)),
-                  static_cast<unsigned long>(heap_caps_get_largest_free_block(
-                      MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA)));
-  }
   apply_wifi_antenna();
   wifi_station_ready = orcsdr::wifi::start();
   strlcpy(wifi_hosted_failure_stage, orcsdr::wifi::hosted_failure_stage(),
@@ -7490,12 +7521,7 @@ void initialize_wifi() {
   }
   Serial.printf("RTL_WIFI_INIT station=%d core=%d\n", wifi_station_ready ? 1 : 0,
                 xPortGetCoreID());
-  if (radio_was_running) {
-    rtl_stop_requested.store(false, std::memory_order_release);
-    rtl_restart_requested.store(true, std::memory_order_release);
-    rtl_capture_requested.store(true, std::memory_order_release);
-    Serial.println("RTL_WIFI_INIT resume_radio");
-  }
+  if (!wifi_pause_already_owned) resume_radio_after_wifi();
   log_dram_budget("after_wifi");
   draw_wifi_state();
 }
@@ -7513,35 +7539,39 @@ void log_wifi_coexistence(const char* event, uint32_t elapsed_ms = 0) {
 
 bool pause_radio_for_catalog();
 void resume_radio_after_catalog();
-bool pause_radio_for_wifi();
-void resume_radio_after_wifi();
-
 void start_wifi_inventory() {
   if (!settings_wifi_power_enabled) return;
-  if (!wifi_station_ready) initialize_wifi();
-  if (!wifi_station_ready) return;
-  if (wifi_scan_running) return;
-  wifi_radio_resume_due_ms = 0;
   if (!pause_radio_for_wifi()) return;
+  if (!wifi_station_ready) initialize_wifi();
+  if (!wifi_station_ready) {
+    resume_radio_after_wifi();
+    return;
+  }
+  if (wifi_scan_running) return;
   wifi_scan_result_count = 0;
   wifi_scan_started_ms = millis();
+  ++wifi_scan_revision;
   strlcpy(wifi_status_message, "Scanning networks", sizeof(wifi_status_message));
   wifi_network_count = orcsdr::wifi::begin_scan() ? -2 : -1;
   if (wifi_network_count != -2) {
+    strlcpy(wifi_status_message, "Scan unavailable", sizeof(wifi_status_message));
     resume_radio_after_wifi();
   }
   begin_power_monitor("wifi_scan");
   wifi_scan_running = wifi_network_count == -2;
   log_wifi_coexistence(wifi_scan_running ? "scan_started" : "scan_start_failed");
   draw_wifi_state();
+  if (orcsdr::rf24::active()) draw_rf24_dashboard(false);
 }
 
 void start_wifi_connection() {
   if (!settings_wifi_power_enabled) return;
-  if (!wifi_station_ready) initialize_wifi();
-  if (!wifi_station_ready || !wifi_ssid[0]) return;
-  wifi_radio_resume_due_ms = 0;
   if (!pause_radio_for_wifi()) return;
+  if (!wifi_station_ready) initialize_wifi();
+  if (!wifi_station_ready || !wifi_ssid[0]) {
+    resume_radio_after_wifi();
+    return;
+  }
   wifi_scan_running = false;
   wifi_network_count = -1;
   wifi_connected = false;
@@ -7566,6 +7596,11 @@ void start_wifi_connection() {
 }
 
 void stop_wifi() {
+  if (!pause_radio_for_wifi()) {
+    strlcpy(wifi_status_message, "Radio pause failed", sizeof(wifi_status_message));
+    Serial.println("RTL_WIFI_OFF_ERROR radio_pause_failed");
+    return;
+  }
   if (wifi_station_ready) {
     orcsdr::wifi::stop();
   }
@@ -7575,10 +7610,26 @@ void stop_wifi() {
   wifi_connected = false;
   wifi_connecting = false;
   wifi_scan_running = false;
-  wifi_radio_resume_due_ms = 0;
   resume_radio_after_wifi();
   strlcpy(wifi_status_message, "Wi-Fi off", sizeof(wifi_status_message));
   Serial.println("RTL_WIFI_OFF");
+}
+
+bool disconnect_wifi() {
+  wifi_connect_requested.store(false, std::memory_order_release);
+  wifi_connecting = false;
+  wifi_save_after_connect = false;
+  if (wifi_connected) {
+    if (!pause_radio_for_wifi()) {
+      strlcpy(wifi_status_message, "Radio pause failed", sizeof(wifi_status_message));
+      return false;
+    }
+    orcsdr::wifi::disconnect();
+  }
+  wifi_connected = false;
+  if (wifi_radio_paused) resume_radio_after_wifi();
+  strlcpy(wifi_status_message, "Wi-Fi disconnected", sizeof(wifi_status_message));
+  return true;
 }
 
 void start_wifi_connection(const char* ssid, const char* password, bool save_on_success) {
@@ -7594,20 +7645,32 @@ bool pause_radio_for_io(bool& paused) {
   const bool already_owned = wifi_radio_paused || catalog_radio_paused;
   paused = true;
   if (already_owned) return true;
-  if (rtl_capture_state.load(std::memory_order_acquire) != RtlCaptureState::running) return true;
-  // A queued auto-start can otherwise relaunch the radio immediately after
-  // the current stream stops, defeating the caller's exclusive I/O window.
-  rtl_capture_requested.store(false, std::memory_order_release);
-  rtl_restart_requested.store(false, std::memory_order_release);
-  rtl_stop_requested.store(true, std::memory_order_release);
-  const uint32_t deadline = millis() + 5000;
-  while (rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running &&
-         static_cast<int32_t>(deadline - millis()) > 0) delay(10);
-  if (rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running) {
-    paused = false;
-    return false;
+  const bool radio_was_active =
+      rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running ||
+      rtl_capture_requested.load(std::memory_order_acquire) ||
+      rtl_restart_requested.load(std::memory_order_acquire);
+  if (radio_was_active) {
+    // Cancel both a running stream and a queued restart before granting the
+    // exclusive I/O window.
+    rtl_capture_requested.store(false, std::memory_order_release);
+    rtl_restart_requested.store(false, std::memory_order_release);
+    rtl_stop_requested.store(true, std::memory_order_release);
+    const uint32_t deadline = millis() + 5000;
+    while ((rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::queued ||
+            rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running) &&
+           static_cast<int32_t>(deadline - millis()) > 0) delay(10);
+    const auto state = rtl_capture_state.load(std::memory_order_acquire);
+    if (state == RtlCaptureState::queued || state == RtlCaptureState::running) {
+      paused = false;
+      return false;
+    }
+    radio_io_resume_pending = true;
   }
-  radio_io_resume_pending = true;
+  if (M5.Speaker.isRunning()) {
+    M5.Speaker.stop();
+    M5.Speaker.end();
+    radio_io_speaker_resume_pending = true;
+  }
   return true;
 }
 
@@ -7615,11 +7678,17 @@ void resume_radio_after_io(bool& paused) {
   if (!paused) return;
   paused = false;
   if (wifi_radio_paused || catalog_radio_paused) return;
-  if (!radio_io_resume_pending) return;
+  const bool resume_radio = radio_io_resume_pending;
+  const bool resume_speaker = radio_io_speaker_resume_pending;
   radio_io_resume_pending = false;
-  rtl_stop_requested.store(false, std::memory_order_release);
-  rtl_restart_requested.store(true, std::memory_order_release);
-  rtl_capture_requested.store(true, std::memory_order_release);
+  radio_io_speaker_resume_pending = false;
+  if (resume_radio) {
+    rtl_capture_state.store(RtlCaptureState::queued, std::memory_order_release);
+    rtl_stop_requested.store(false, std::memory_order_release);
+    rtl_restart_requested.store(true, std::memory_order_release);
+    rtl_capture_requested.store(true, std::memory_order_release);
+  }
+  if (resume_speaker) resume_rtl_speaker();
 }
 
 bool pause_radio_for_catalog() { return pause_radio_for_io(catalog_radio_paused); }
@@ -7639,12 +7708,6 @@ void poll_wifi() {
   if (!wifi_scan_running && !wifi_connecting && !wifi_connected) return;
   static uint32_t last_wifi_status_ms = 0;
   const uint32_t now_ms = millis();
-  if (wifi_radio_resume_due_ms != 0 &&
-      static_cast<int32_t>(now_ms - wifi_radio_resume_due_ms) >= 0) {
-    wifi_radio_resume_due_ms = 0;
-    resume_radio_after_wifi();
-    Serial.println("RTL_WIFI_RADIO_RESUME connected");
-  }
   const uint32_t status_interval_ms =
       (wifi_connected && !wifi_scan_running && !wifi_connecting) ? 3000u : 250u;
   if (now_ms - last_wifi_status_ms < status_interval_ms) return;
@@ -7654,7 +7717,6 @@ void poll_wifi() {
     const int result = orcsdr::wifi::scan_results(nullptr, 0);
     if (result >= 0) {
       wifi_scan_running = false;
-      resume_radio_after_wifi();
       wifi_network_count = result;
       wifi_scan_result_count = result > 0
                                    ? static_cast<uint8_t>(std::min<int>(
@@ -7662,21 +7724,32 @@ void poll_wifi() {
                                    : 0;
       orcsdr::wifi::ScanResult scan[16]{};
       const int received = orcsdr::wifi::scan_results(scan, std::size(scan));
-      wifi_scan_result_count = received > 0 ? static_cast<uint8_t>(received) : 0;
+      wifi_scan_result_count = received > 0 ? static_cast<uint8_t>(std::min<int>(
+                                      received, std::size(wifi_scan_results))) : 0;
       for (uint8_t i = 0; i < wifi_scan_result_count; ++i) {
         strlcpy(wifi_scan_results[i].ssid, scan[i].ssid, sizeof(wifi_scan_results[i].ssid));
-        wifi_scan_results[i].rssi = scan[i].rssi; wifi_scan_results[i].secure = scan[i].secure;
+        memcpy(wifi_scan_results[i].bssid, scan[i].bssid, sizeof(wifi_scan_results[i].bssid));
+        wifi_scan_results[i].rssi = scan[i].rssi;
+        wifi_scan_results[i].channel = scan[i].channel;
+        wifi_scan_results[i].secure = scan[i].secure;
       }
+      Serial.printf("RTL_WIFI_SCAN_RESULTS count=%u\n",
+                    static_cast<unsigned>(wifi_scan_result_count));
       log_wifi_coexistence("scan_complete", millis() - wifi_scan_started_ms);
+      resume_radio_after_wifi();
+      state_changed = true;
+    } else if (millis() - wifi_scan_started_ms >= 15000u) {
+      wifi_scan_running = false;
+      resume_radio_after_wifi();
+      strlcpy(wifi_status_message, "Scan timed out", sizeof(wifi_status_message));
+      log_wifi_coexistence("scan_timeout", millis() - wifi_scan_started_ms);
       state_changed = true;
     }
   }
   const bool connected = orcsdr::wifi::connected();
   if (wifi_connecting && connected) {
     wifi_connecting = false;
-    // Let the C6/SDIO association settle before relaunching USB RTL.
-    wifi_radio_resume_due_ms = millis() + 1000u;
-    Serial.println("RTL_WIFI_RADIO_RESUME_PENDING connected");
+    Serial.println("RTL_WIFI_RADIO_PAUSED connected");
     if (wifi_save_after_connect) {
       int existing = -1;
       for (uint8_t i = 0; i < wifi_profile_count; ++i)
@@ -7725,7 +7798,9 @@ void poll_wifi() {
     state_changed = true;
   }
   if (state_changed) {
+    ++wifi_scan_revision;
     draw_wifi_state();
+    if (orcsdr::rf24::active()) draw_rf24_dashboard(false);
   }
 }
 
@@ -8411,7 +8486,7 @@ const orcsdr::settings::State& global_settings_state() {
         wifi_connected && strcmp(orcsdr::wifi::ssid(), wifi_profiles[i].ssid) == 0;
   }
   if (!wifi_scan_running && wifi_scan_result_count > 0) {
-    state.network_count = wifi_scan_result_count;
+    state.network_count = std::min<uint8_t>(wifi_scan_result_count, std::size(state.networks));
     for (uint8_t i = 0; i < state.network_count; ++i) {
       strlcpy(state.networks[i].ssid, wifi_scan_results[i].ssid,
               sizeof(state.networks[i].ssid));
@@ -8615,6 +8690,8 @@ void navigation_restore_screen(orcsdr::screens::Id restore) {
     bump_rtl_ui();
   } else if (restore == orcsdr::screens::Id::lora) {
     orcsdr::lora::draw();
+  } else if (restore == orcsdr::screens::Id::wifi_analysis) {
+    draw_rf24_dashboard(true);
   } else {
     draw_sdr_screen(rtl_ui_band, rtl_ui_frequency_hz,
                     rtl_live_volume.load(std::memory_order_acquire));
@@ -8672,11 +8749,32 @@ void persist_dashboard_open(orcsdr::dashboards::Id id) {
   preferences.putBytes("dash_recent", recent, count);
 }
 
+void open_rf24_dashboard() {
+  persist_dashboard_open(orcsdr::dashboards::Id::wifi_analysis);
+  orcsdr::home::leave();
+  orcsdr::screens::begin_transition(orcsdr::screens::Id::wifi_analysis, millis());
+  draw_rf24_dashboard(true);
+  orcsdr::screens::finish_transition();
+  wifi_scan_requested.store(true, std::memory_order_release);
+}
+
+void close_rf24_dashboard() {
+  orcsdr::rf24::leave();
+  orcsdr::screens::begin_transition(orcsdr::screens::Id::home, millis());
+  orcsdr::home::draw();
+  orcsdr::screens::finish_transition();
+}
+
 void open_dashboard(orcsdr::dashboards::Id id) {
   using Id = orcsdr::dashboards::Id;
+  if (id != Id::settings && orcsdr::settings::active()) close_global_settings();
   if (id == Id::rf_lab) {
     persist_dashboard_open(id);
     open_rf_lab();
+    return;
+  }
+  if (id == Id::wifi_analysis) {
+    open_rf24_dashboard();
     return;
   }
   rtl_lab_rate_override_sps.store(0, std::memory_order_release);
@@ -8833,8 +8931,7 @@ void handle_global_settings_action(const orcsdr::settings::Action& action) {
       if (action.value >= 0 && action.value < wifi_profile_count) {
         const uint8_t index = static_cast<uint8_t>(action.value);
         if (wifi_connected && strcmp(orcsdr::wifi::ssid(), wifi_profiles[index].ssid) == 0) {
-          orcsdr::wifi::disconnect();
-          wifi_connected = false;
+          if (!disconnect_wifi()) break;
         }
         for (uint8_t i = index; i + 1 < wifi_profile_count; ++i)
           wifi_profiles[i] = wifi_profiles[i + 1];
@@ -9807,6 +9904,22 @@ void poll_sdr_touch(bool from_stream) {
 void handle_sdr_touch(int32_t x, int32_t y) {
   if (orcsdr::settings::active()) {
     handle_global_settings_touch(x, y);
+    return;
+  }
+  if (orcsdr::rf24::active()) {
+    const auto action = orcsdr::rf24::handle_touch(x, y, rf24_dashboard_snapshot());
+    if (action.kind == orcsdr::rf24::ActionKind::close) close_rf24_dashboard();
+    else if (action.kind == orcsdr::rf24::ActionKind::rescan)
+      wifi_scan_requested.store(true, std::memory_order_release);
+    else if (action.kind == orcsdr::rf24::ActionKind::open_settings)
+      open_global_settings(orcsdr::settings::Section::connectivity);
+    else if (action.kind == orcsdr::rf24::ActionKind::toggle_mute) {
+      set_rtl_audio_user_enabled(
+          !rtl_audio_user_enabled.load(std::memory_order_acquire));
+      orcsdr::rf24::update_header(rf24_dashboard_snapshot());
+    } else if (action.kind == orcsdr::rf24::ActionKind::open_visualizer) {
+      open_visualizer();
+    }
     return;
   }
   if (orcsdr::audio_header::visualizer_hit(x, y)) {
@@ -10916,12 +11029,13 @@ void process_command(char* command) {
   }
   if (strcmp(command, "RTL_UI STATUS") == 0) {
     Serial.printf("RTL_UI_STATUS screen=%s band=%s frequency_hz=%u settings=%d fm=%d p25=%d "
-                  "adsb=%d lora=%d home_font=%d\n",
+                  "adsb=%d lora=%d rf24=%d home_font=%d\n",
                   orcsdr::screens::name(orcsdr::screens::status().active),
                   rtl_band_name(rtl_ui_band), rtl_ui_frequency_hz,
                   orcsdr::settings::active() ? 1 : 0, orcsdr::fm::active() ? 1 : 0,
                   orcsdr::p25::active() ? 1 : 0, orcsdr::adsb::active() ? 1 : 0,
                   orcsdr::lora::active() ? 1 : 0,
+                  orcsdr::rf24::active() ? 1 : 0,
                   M5.Display.getFont() == &fonts::Font0 ? 1 : 0);
     return;
   }
@@ -10973,8 +11087,9 @@ void process_command(char* command) {
     else if (strcmp(name, "ADSB") == 0) open_dashboard(Id::adsb);
     else if (strcmp(name, "LORA") == 0) open_dashboard(Id::lora);
     else if (strcmp(name, "RF_LAB") == 0) open_dashboard(Id::rf_lab);
+    else if (strcmp(name, "WIFI_ANALYSIS") == 0) open_dashboard(Id::wifi_analysis);
     else if (strcmp(name, "SETTINGS") == 0) open_dashboard(Id::settings);
-    else { Serial.println("RTL_UI_OPEN_INVALID use HOME|FM|P25|ADSB|LORA|RF_LAB|SETTINGS"); return; }
+    else { Serial.println("RTL_UI_OPEN_INVALID use HOME|FM|P25|ADSB|LORA|RF_LAB|WIFI_ANALYSIS|SETTINGS"); return; }
     Serial.printf("RTL_UI_OPEN_OK target=%s\n", name);
     return;
   }
@@ -11034,6 +11149,22 @@ void process_command(char* command) {
       else if (!strcmp(action, "GRAPHICS")) kind=K::graphics_changed; else if (!strcmp(action, "WEB")) kind=K::web_console_changed;
       else if (!strcmp(action, "CATALOG_CHECK")) kind=K::catalog_check; else if (!strcmp(action, "CATALOG_INSTALL")) kind=K::catalog_install;
       else if (!strcmp(action, "CATALOG_REMOVE")) kind=K::catalog_remove; else if (!strcmp(action, "CLOSE")) kind=K::close;
+      if ((kind == K::wifi_power_changed || kind == K::wifi_start_at_boot_changed ||
+           kind == K::wifi_antenna_changed) && value > 1) {
+        Serial.println("RTL_UI_ACTION_INVALID value_must_be_0_or_1");
+        return;
+      }
+      if ((kind == K::connect_saved_wifi || kind == K::forget_wifi) &&
+          value >= wifi_profile_count) {
+        Serial.println("RTL_UI_ACTION_INVALID profile_index");
+        return;
+      }
+      if ((kind == K::move_wifi_up && (value == 0 || value >= wifi_profile_count)) ||
+          (kind == K::move_wifi_down &&
+           (wifi_profile_count < 2 || value >= wifi_profile_count - 1))) {
+        Serial.println("RTL_UI_ACTION_INVALID profile_move");
+        return;
+      }
       if (kind != K::none) { handle_global_settings_action({kind, static_cast<int32_t>(value)}); Serial.println("RTL_UI_ACTION_OK"); return; }
     }
     Serial.println("RTL_UI_ACTION_INVALID unknown_action");
@@ -11054,12 +11185,56 @@ void process_command(char* command) {
     Serial.println("RTL_WIFI_CONNECT_QUEUED saved_profile=0");
     return;
   }
+  if (strcmp(command, "RTL_WIFI_RESULTS") == 0) {
+    Serial.printf("RTL_WIFI_RESULTS_BEGIN count=%u revision=%u\n",
+                  static_cast<unsigned>(wifi_scan_result_count),
+                  static_cast<unsigned>(wifi_scan_revision));
+    for (uint8_t i = 0; i < wifi_scan_result_count; ++i) {
+      Serial.printf("RTL_WIFI_AP index=%u ssid_hex=", static_cast<unsigned>(i));
+      print_hex(reinterpret_cast<const uint8_t*>(wifi_scan_results[i].ssid),
+                strlen(wifi_scan_results[i].ssid));
+      Serial.print(" bssid=");
+      print_hex(wifi_scan_results[i].bssid, sizeof(wifi_scan_results[i].bssid));
+      Serial.printf(" rssi=%d channel=%u secure=%d\n", wifi_scan_results[i].rssi,
+                    static_cast<unsigned>(wifi_scan_results[i].channel),
+                    wifi_scan_results[i].secure ? 1 : 0);
+    }
+    Serial.println("RTL_WIFI_RESULTS_END");
+    return;
+  }
+  if (strcmp(command, "RTL_WIFI_PROFILES") == 0) {
+    Serial.printf("RTL_WIFI_PROFILES_BEGIN count=%u\n",
+                  static_cast<unsigned>(wifi_profile_count));
+    for (uint8_t i = 0; i < wifi_profile_count; ++i) {
+      Serial.printf("RTL_WIFI_PROFILE index=%u ssid_hex=", static_cast<unsigned>(i));
+      print_hex(reinterpret_cast<const uint8_t*>(wifi_profiles[i].ssid),
+                strlen(wifi_profiles[i].ssid));
+      Serial.printf(" connected=%d\n",
+                    wifi_connected && strcmp(orcsdr::wifi::ssid(), wifi_profiles[i].ssid) == 0);
+    }
+    Serial.println("RTL_WIFI_PROFILES_END");
+    return;
+  }
+  if (strcmp(command, "RTL_WIFI_DISCONNECT") == 0) {
+    if (!authenticated) {
+      Serial.println("RTL_WIFI_DISCONNECT_ERROR auth_required");
+      return;
+    }
+    Serial.println(disconnect_wifi() ? "RTL_WIFI_DISCONNECT_OK"
+                                     : "RTL_WIFI_DISCONNECT_ERROR radio_pause_failed");
+    return;
+  }
   if (strcmp(command, "RTL_WIFI_STATUS") == 0) {
     Serial.printf("RTL_WIFI_STATUS station=%d hosted_match=%d scanning=%d connecting=%d "
-                  "connected=%d saved_profiles=%u\n",
+                  "connected=%d saved_profiles=%u power=%d auto_connect=%d antenna=%s "
+                  "ap_count=%u\n",
                   wifi_station_ready ? 1 : 0, wifi_hosted_versions_match ? 1 : 0,
                   wifi_scan_running ? 1 : 0, wifi_connecting ? 1 : 0,
-                  wifi_connected ? 1 : 0, wifi_profile_count);
+                  wifi_connected ? 1 : 0, wifi_profile_count,
+                  settings_wifi_power_enabled ? 1 : 0,
+                  settings_wifi_start_at_boot ? 1 : 0,
+                  settings_wifi_external_antenna ? "external" : "internal",
+                  static_cast<unsigned>(wifi_scan_result_count));
     return;
   }
   if (strcmp(command, "RTL_SCREEN_STATUS") == 0) {
@@ -11557,10 +11732,13 @@ void process_command(char* command) {
     Serial.println("RTL_SCREEN_STATUS             - active screen ownership diagnostics");
     Serial.println("RTL_UI_REGRESSION CHECK|RUN   - passive checks or Home->screen restore test");
     Serial.println("RTL_UI STATUS                  - current screen/dashboard state");
-    Serial.println("RTL_UI OPEN <HOME|FM|P25|ADSB|LORA|RF_LAB|SETTINGS> - open dashboard (auth)");
+    Serial.println("RTL_UI OPEN <HOME|FM|P25|ADSB|LORA|RF_LAB|WIFI_ANALYSIS|SETTINGS> - open dashboard (auth)");
     Serial.println("RTL_LAB OPEN|CLOSE|STATUS|PAGE|GET|SET|ACTION|SELF_CHECK - RF Lab UI/control");
     Serial.println("RTL_LAB REFERENCE|SNAPSHOT|RUN|RECIPE|RECORDS - RF Lab evidence workflow (mutations auth)");
     Serial.println("RTL_UI ACTION <domain> <action> [value] - mirror FM/P25/LoRa/Settings touch action (auth)");
+    Serial.println("RTL_WIFI_STATUS|SCAN|RESULTS|PROFILES - Wi-Fi state and bounded AP/profile lists");
+    Serial.println("RTL_WIFI_CONNECT_SAVED|DISCONNECT - connect profile 0 or disconnect (disconnect auth)");
+    Serial.println("SET_WIFI <ssid_hex> <pass_hex> <hmac> - signed slot-0 provisioning (auth)");
     Serial.println("RTL_TUNE <BAND> <HZ>           - tune band+freq (auth) BAND=FM|AM|WX|CB|LORA|BROWSE|ADSB|P25");
     Serial.println("RTL_FREQ                       - query current band/frequency/mode");
     Serial.println("RTL_FREQ <HZ>                  - hot-retune within current band (auth)");
@@ -12333,6 +12511,11 @@ void setup() {
     abort();
   }
   Serial.println("RTL_LORA_DASHBOARD_SELF_CHECK_OK");
+  if (!orcsdr::rf24::self_check()) {
+    Serial.println("RF24_DASHBOARD_SELF_CHECK_FAIL");
+    abort();
+  }
+  Serial.println("RF24_DASHBOARD_SELF_CHECK_OK");
   if (!orcsdr::lora_native::self_check()) {
     Serial.println("RTL_LORA_NATIVE_SELF_CHECK_FAIL");
     abort();
@@ -12777,6 +12960,7 @@ void loop() {
   // Receive tasks only request this handoff; this UI path is the sole writer.
   if (rtl_screen_transition_requested.exchange(false, std::memory_order_acq_rel) &&
       !settings_ui && orcsdr::screens::status().active != orcsdr::screens::Id::documentation &&
+      orcsdr::screens::status().active != orcsdr::screens::Id::wifi_analysis &&
       !orcsdr::home::active()) {
     draw_sdr_screen(rtl_ui_band, rtl_ui_frequency_hz,
                     rtl_live_volume.load(std::memory_order_acquire));

--- a/apps/orcsdr-tab5/ui/rf24_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/rf24_dashboard.cpp
@@ -1,0 +1,231 @@
+#include "rf24_dashboard.hpp"
+
+#include "dashboard_audio_control.hpp"
+#include "orc_badge.hpp"
+
+#include <M5Unified.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+
+namespace orcsdr::rf24 {
+namespace {
+constexpr uint16_t kBg = TFT_BLACK, kPanel = 0x0841, kCyan = 0x2e7f, kGreen = 0x6fe8;
+constexpr uint16_t kMuted = 0x8c71, kYellow = 0xffe0, kRed = 0xf800;
+constexpr int kTabY = 648, kTabW = 242, kTabH = 52;
+Page g_page = Page::overview;
+bool g_active = false;
+bool g_scanning = false;
+uint32_t g_revision = 0;
+
+bool hit(int32_t x, int32_t y, int bx, int by, int bw, int bh) {
+  return x >= bx && x < bx + bw && y >= by && y < by + bh;
+}
+
+Page tab_at(int32_t x) {
+  if (x < 20 || x >= 20 + 248 * static_cast<int>(Page::count)) return Page::count;
+  return static_cast<Page>((x - 20) / 248);
+}
+
+void text(const char* value, int x, int y, uint16_t color = TFT_WHITE, uint8_t size = 2,
+          textdatum_t datum = middle_left) {
+  M5.Display.setFont(nullptr); M5.Display.setTextDatum(datum); M5.Display.setTextSize(size);
+  M5.Display.setTextColor(color, kBg); M5.Display.drawString(value, x, y);
+}
+
+void panel(int x, int y, int w, int h, uint16_t border = kCyan) {
+  M5.Display.fillRoundRect(x, y, w, h, 8, kPanel);
+  M5.Display.drawRoundRect(x, y, w, h, 8, border);
+}
+
+void bssid(const uint8_t mac[6], char* out, size_t size) {
+  snprintf(out, size, "%02X:%02X:%02X", mac[3], mac[4], mac[5]);
+}
+
+const char* page_name(Page page) {
+  switch (page) {
+    case Page::overview: return "OVERVIEW";
+    case Page::channels: return "CHANNELS";
+    case Page::devices: return "DEVICES";
+    case Page::csi: return "CSI";
+    case Page::settings: return "SETTINGS";
+    default: return "";
+  }
+}
+
+void draw_header(const Snapshot& snapshot) {
+  M5.Display.fillRect(0, 0, 1280, 82, kBg);
+  M5.Display.drawFastHLine(20, 80, 1240, kCyan);
+  if (!badge::draw(12, 6, 70)) text("ORC", 46, 38, kGreen, 2, middle_center);
+  text("OrcSDR", 96, 34, kGreen, 2);
+  text("2.4 GHz ANALYZER", 270, 34, TFT_WHITE, 3);
+  text(snapshot.ready ? "READY" : "OFFLINE", 808, 34,
+       snapshot.scanning ? kYellow : snapshot.ready ? kGreen : kRed, 1, middle_right);
+  panel(830, 16, 190, 46, snapshot.scanning ? kMuted : kGreen);
+  text(snapshot.scanning ? "SCANNING" : "RESCAN", 925, 39,
+       snapshot.scanning ? kMuted : kGreen, 1, middle_center);
+  audio_header::draw_home_button();
+  audio_header::draw_mute_button(snapshot.sound_enabled);
+  audio_header::draw_visualizer_button(snapshot.visualizer_available);
+  audio_header::draw_settings_button();
+  text(snapshot.message, 270, 66, kMuted, 1);
+}
+
+void draw_tabs() {
+  for (uint8_t i = 0; i < static_cast<uint8_t>(Page::count); ++i) {
+    const Page page = static_cast<Page>(i); const int x = 20 + i * 248;
+    const bool selected = page == g_page;
+    panel(x, kTabY, kTabW, kTabH, selected ? kGreen : kCyan);
+    text(page_name(page), x + kTabW / 2, kTabY + kTabH / 2,
+         selected ? kGreen : kCyan, 2, middle_center);
+  }
+}
+
+void draw_overview(const Snapshot& snapshot) {
+  panel(20, 100, 400, 180); panel(438, 100, 822, 180); panel(20, 298, 1240, 326);
+  text("SCAN STATUS", 40, 126, kCyan, 1);
+  char value[48]{}; snprintf(value, sizeof(value), "%u ACCESS POINTS", snapshot.access_point_count);
+  text(value, 40, 172, kGreen, 3);
+  const auto* strongest = snapshot.access_point_count ? &snapshot.access_points[0] : nullptr;
+  text("STRONGEST OBSERVED", 40, 220, kMuted, 1);
+  text(strongest ? (strongest->ssid[0] ? strongest->ssid : "<hidden>") : "--", 40, 250, TFT_WHITE, 2);
+  uint8_t secured = 0;
+  for (uint8_t i = 0; i < snapshot.access_point_count; ++i) secured += snapshot.access_points[i].secure;
+  snprintf(value, sizeof(value), "SECURITY: %u SECURED / %u OPEN", secured,
+           snapshot.access_point_count - secured);
+  text(value, 40, 272, kMuted, 1);
+  text("AP OBSERVATIONS BY CHANNEL", 458, 126, kCyan, 1);
+  uint8_t counts[15]{};
+  for (uint8_t i = 0; i < snapshot.access_point_count; ++i)
+    if (snapshot.access_points[i].channel <= 14 && snapshot.access_points[i].channel > 0)
+      ++counts[snapshot.access_points[i].channel];
+  uint8_t observed = 0;
+  for (int channel = 1; channel <= 14; ++channel) {
+    if (!counts[channel]) continue;
+    const int x = 458 + observed++ * 56; char label[4]{};
+    snprintf(label, sizeof(label), "%d", channel); text(label, x + 18, 254, kMuted, 1, middle_center);
+    M5.Display.drawRect(x, 158, 38, 82, kMuted);
+    const int height = std::min<int>(72, counts[channel] * 12);
+    if (height) M5.Display.fillRect(x + 2, 238 - height, 34, height, kGreen);
+  }
+  text("TOP OBSERVED ACCESS POINTS", 40, 324, kCyan, 1);
+  text("SSID", 48, 354, kMuted, 1); text("BSSID", 560, 354, kMuted, 1);
+  text("CH", 730, 354, kMuted, 1); text("RSSI", 840, 354, kMuted, 1); text("SECURITY", 1010, 354, kMuted, 1);
+  const uint8_t shown = std::min<uint8_t>(snapshot.access_point_count, 6);
+  for (uint8_t i = 0; i < shown; ++i) {
+    const auto& ap = snapshot.access_points[i]; char short_bssid[12]{}, rssi[16]{}, channel[8]{};
+    const int y = 392 + i * 36; bssid(ap.bssid, short_bssid, sizeof(short_bssid));
+    snprintf(channel, sizeof(channel), "%u", ap.channel); snprintf(rssi, sizeof(rssi), "%d dBm", ap.rssi);
+    text(ap.ssid[0] ? ap.ssid : "<hidden>", 48, y, TFT_WHITE, 2); text(short_bssid, 560, y, kMuted, 2);
+    text(channel, 730, y, kCyan, 2); text(rssi, 840, y, ap.rssi >= -67 ? kGreen : kYellow, 2);
+    text(ap.secure ? "SECURED" : "OPEN", 1010, y, ap.secure ? kGreen : kRed, 2);
+  }
+}
+
+void draw_channels(const Snapshot& snapshot) {
+  panel(20, 100, 1240, 524); text("CHANNEL OBSERVATIONS", 40, 126, kCyan, 1);
+  text("AP count and strongest scan RSSI. Not airtime or occupancy.", 40, 154, kMuted, 1);
+  uint8_t row = 0;
+  for (uint8_t channel = 1; channel <= 14; ++channel) {
+    uint8_t count = 0; int16_t strongest = -127;
+    for (uint8_t i = 0; i < snapshot.access_point_count; ++i) {
+      const auto& ap = snapshot.access_points[i];
+      if (ap.channel == channel) { ++count; strongest = std::max(strongest, ap.rssi); }
+    }
+    if (!count) continue;
+    const int y = 184 + row++ * 30; char label[48]{};
+    snprintf(label, sizeof(label), "CH %2u   %u AP%s", channel, count, count == 1 ? "" : "s");
+    text(label, 52, y, TFT_WHITE, 2); M5.Display.drawRect(330, y - 9, 600, 18, kMuted);
+    M5.Display.fillRect(332, y - 7, std::min<int>(596, count * 100), 14, kGreen);
+    snprintf(label, sizeof(label), "%d dBm strongest", strongest); text(label, 960, y, strongest >= -67 ? kGreen : kYellow, 1);
+  }
+  if (!row) text("No channel observations yet.", 52, 190, kMuted, 2);
+}
+
+void draw_devices(const Snapshot& snapshot) {
+  panel(20, 100, 1240, 524); text("OBSERVED ACCESS POINTS", 40, 126, kCyan, 1);
+  text("Station discovery requires separately proven promiscuous capture.", 40, 154, kMuted, 1);
+  text("SSID", 48, 194, kMuted, 1); text("BSSID", 560, 194, kMuted, 1);
+  text("CHANNEL", 730, 194, kMuted, 1); text("RSSI", 880, 194, kMuted, 1); text("SECURITY", 1050, 194, kMuted, 1);
+  const uint8_t shown = std::min<uint8_t>(snapshot.access_point_count, 10);
+  for (uint8_t i = 0; i < shown; ++i) {
+    const auto& ap = snapshot.access_points[i]; char short_bssid[12]{}, value[16]{}; const int y = 232 + i * 36;
+    bssid(ap.bssid, short_bssid, sizeof(short_bssid)); snprintf(value, sizeof(value), "%u", ap.channel);
+    text(ap.ssid[0] ? ap.ssid : "<hidden>", 48, y, TFT_WHITE, 2); text(short_bssid, 560, y, kMuted, 2);
+    text(value, 730, y, kCyan, 2); snprintf(value, sizeof(value), "%d dBm", ap.rssi);
+    text(value, 880, y, ap.rssi >= -67 ? kGreen : kYellow, 2); text(ap.secure ? "SECURED" : "OPEN", 1050, y, ap.secure ? kGreen : kRed, 2);
+  }
+}
+
+void draw_csi() {
+  panel(20, 100, 1240, 524, kYellow); text("CSI / EXPERIMENTAL", 40, 132, kYellow, 2);
+  text("CSI is unavailable in Real Survey v1.", 40, 202, TFT_WHITE, 3);
+  text("Next proof: stock ESP-Hosted 3.0.6 remote CSI APIs, bounded callback queue,", 40, 250, kMuted, 2);
+  text("and measured hardware callbacks with controlled traffic.", 40, 282, kMuted, 2);
+  text("No CSI, motion, presence, or spectrum values are shown until that proof exists.", 40, 344, kYellow, 2);
+}
+
+void draw_settings() {
+  panel(20, 100, 1240, 524); text("ANALYZER SETTINGS", 40, 132, kCyan, 2);
+  text("Real Survey v1 uses existing Connectivity settings.", 40, 210, TFT_WHITE, 3);
+  text("Wi-Fi power, saved profiles, and antenna selection remain in Global Settings.", 40, 256, kMuted, 2);
+  panel(930, 520, 290, 62, kGreen); text("OPEN CONNECTIVITY", 1075, 551, kGreen, 2, middle_center);
+}
+
+void draw_page(const Snapshot& snapshot) {
+  M5.Display.fillRect(0, 82, 1280, 554, kBg);
+  switch (g_page) {
+    case Page::overview: draw_overview(snapshot); break;
+    case Page::channels: draw_channels(snapshot); break;
+    case Page::devices: draw_devices(snapshot); break;
+    case Page::csi: draw_csi(); break;
+    case Page::settings: draw_settings(); break;
+    default: break;
+  }
+}
+
+void draw_all(const Snapshot& snapshot) {
+  M5.Display.fillScreen(kBg); draw_header(snapshot); draw_page(snapshot); draw_tabs();
+}
+}  // namespace
+
+void enter(const Snapshot& snapshot) {
+  g_revision = snapshot.revision; g_scanning = snapshot.scanning;
+  g_page = Page::overview; g_active = true; draw_all(snapshot);
+}
+void update(const Snapshot& snapshot) {
+  if (!g_active || snapshot.revision == g_revision) return;
+  g_revision = snapshot.revision; g_scanning = snapshot.scanning;
+  draw_header(snapshot); draw_page(snapshot);
+}
+void update_header(const Snapshot& snapshot) {
+  if (g_active) draw_header(snapshot);
+}
+void leave() { g_active = false; }
+bool active() { return g_active; }
+Action handle_touch(int32_t x, int32_t y, const Snapshot& snapshot) {
+  if (!g_active) return {};
+  if (audio_header::home_hit(x, y)) return {ActionKind::close};
+  if (audio_header::mute_hit(x, y)) return {ActionKind::toggle_mute};
+  if (audio_header::visualizer_hit(x, y)) return {ActionKind::open_visualizer};
+  if (audio_header::settings_hit(x, y)) return {ActionKind::open_settings};
+  if (hit(x, y, 20, kTabY, kTabW * 5 + 24, kTabH)) {
+    const Page page = tab_at(x);
+    if (page != Page::count && g_page != page) {
+      g_page = page; draw_page(snapshot); draw_tabs();
+    }
+    return {};
+  }
+  if (g_page == Page::settings && hit(x, y, 930, 520, 290, 62)) return {ActionKind::open_settings};
+  if (!g_scanning && hit(x, y, 830, 16, 190, 46)) return {ActionKind::rescan};
+  return {};
+}
+bool self_check() {
+  return kAccessPointCapacity == 16 && static_cast<uint8_t>(Page::count) == 5 &&
+         tab_at(21) == Page::overview && tab_at(20 + 248 * 4) == Page::settings &&
+         tab_at(1280) == Page::count && audio_header::self_check() &&
+         static_cast<uint8_t>(ActionKind::open_visualizer) == 5;
+}
+
+}  // namespace orcsdr::rf24

--- a/apps/orcsdr-tab5/ui/rf24_dashboard.hpp
+++ b/apps/orcsdr-tab5/ui/rf24_dashboard.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+
+namespace orcsdr::rf24 {
+
+constexpr uint8_t kAccessPointCapacity = 16;
+
+enum class Page : uint8_t { overview, channels, devices, csi, settings, count };
+
+struct AccessPoint {
+  char ssid[33]{};
+  uint8_t bssid[6]{};
+  int16_t rssi = 0;
+  uint8_t channel = 0;
+  bool secure = false;
+};
+
+struct Snapshot {
+  bool ready = false;
+  bool scanning = false;
+  bool sound_enabled = false;
+  bool visualizer_available = false;
+  char message[48]{};
+  AccessPoint access_points[kAccessPointCapacity]{};
+  uint8_t access_point_count = 0;
+  uint32_t revision = 0;
+};
+
+enum class ActionKind : uint8_t {
+  none,
+  close,
+  rescan,
+  open_settings,
+  toggle_mute,
+  open_visualizer,
+};
+struct Action { ActionKind kind = ActionKind::none; };
+
+void enter(const Snapshot& snapshot);
+void update(const Snapshot& snapshot);
+void update_header(const Snapshot& snapshot);
+void leave();
+bool active();
+Action handle_touch(int32_t x, int32_t y, const Snapshot& snapshot);
+bool self_check();
+
+}  // namespace orcsdr::rf24

--- a/apps/orcsdr-tab5/ui/screen_controller.cpp
+++ b/apps/orcsdr-tab5/ui/screen_controller.cpp
@@ -57,6 +57,7 @@ const char* name(Id id) {
     case Id::radio: return "radio";
     case Id::visualizer: return "visualizer";
     case Id::rf_lab: return "rf_lab";
+    case Id::wifi_analysis: return "wifi_analysis";
     case Id::settings: return "settings";
     case Id::documentation: return "documentation";
     default: return "none";
@@ -73,7 +74,7 @@ bool self_check() {
   const bool home_owns = owns(Id::home) && may_draw(Id::home);
   bool settings_return = true;
   uint32_t now = 20;
-  for (const Id screen : {Id::home, Id::fm, Id::p25, Id::adsb, Id::lora}) {
+  for (const Id screen : {Id::home, Id::fm, Id::p25, Id::adsb, Id::lora, Id::wifi_analysis}) {
     begin_transition(screen, now++, false);
     finish_transition();
     begin_transition(Id::settings, now++, true);
@@ -94,7 +95,7 @@ bool self_check() {
   begin_transition(Id::rf_lab, now++, false);
   finish_transition();
   const bool rf_lab_owns = owns(Id::rf_lab);
-  const bool restored = g_status.transitions == 20;
+  const bool restored = g_status.transitions == 23;
   g_status = saved;
   g_transitioning = saved_transitioning;
   return entering_blocks_draw && home_owns && settings_return && documentation_owns &&

--- a/apps/orcsdr-tab5/ui/screen_controller.hpp
+++ b/apps/orcsdr-tab5/ui/screen_controller.hpp
@@ -7,7 +7,7 @@ namespace orcsdr::screens {
 // Exactly one surface may own the framebuffer.  Radio/decoder work is not a
 // surface and continues independently of this state.
 enum class Id : uint8_t {
-  none, home, fm, p25, adsb, lora, radio, visualizer, rf_lab, settings, documentation
+  none, home, fm, p25, adsb, lora, radio, visualizer, rf_lab, wifi_analysis, settings, documentation
 };
 
 struct Status {

--- a/apps/orcsdr-tab5/ui/wifi_service.cpp
+++ b/apps/orcsdr-tab5/ui/wifi_service.cpp
@@ -36,6 +36,7 @@ void on_wifi_event(void*, esp_event_base_t base, int32_t id, void* data) {
   }
   if (base == WIFI_EVENT && id == WIFI_EVENT_SCAN_DONE) {
     g_scan_done.store(true, std::memory_order_release);
+    ESP_LOGI("orcsdr_wifi", "scan done event");
   }
 }
 
@@ -106,7 +107,10 @@ void stop() { if (g_started) { esp_wifi_disconnect(); esp_wifi_stop(); } g_start
 bool begin_scan() {
   if (!g_started) return false;
   g_scan_done.store(false, std::memory_order_release);
-  return esp_wifi_scan_start(nullptr, false) == ESP_OK;
+  const esp_err_t result = esp_wifi_scan_start(nullptr, false);
+  if (result == ESP_OK) return true;
+  ESP_LOGE("orcsdr_wifi", "scan start failed: %s", esp_err_to_name(result));
+  return false;
 }
 int scan_results(ScanResult* results, size_t capacity) {
   uint16_t count = 0;
@@ -120,7 +124,10 @@ int scan_results(ScanResult* results, size_t capacity) {
   g_scan_done.store(false, std::memory_order_release);
   for (uint16_t i = 0; i < received; ++i) {
     strlcpy(results[i].ssid, reinterpret_cast<const char*>(records[i].ssid), sizeof(results[i].ssid));
-    results[i].rssi = records[i].rssi; results[i].secure = records[i].authmode != WIFI_AUTH_OPEN;
+    memcpy(results[i].bssid, records[i].bssid, sizeof(results[i].bssid));
+    results[i].rssi = records[i].rssi;
+    results[i].channel = records[i].primary;
+    results[i].secure = records[i].authmode != WIFI_AUTH_OPEN;
   }
   return received;
 }

--- a/apps/orcsdr-tab5/ui/wifi_service.hpp
+++ b/apps/orcsdr-tab5/ui/wifi_service.hpp
@@ -7,7 +7,9 @@ namespace orcsdr::wifi {
 
 struct ScanResult {
   char ssid[33]{};
+  uint8_t bssid[6]{};
   int16_t rssi = 0;
+  uint8_t channel = 0;
   bool secure = false;
 };
 

--- a/docs/API_SERIAL_CLI.md
+++ b/docs/API_SERIAL_CLI.md
@@ -348,7 +348,8 @@ RTL_UI ACTION LORA VIEW 3
 RTL_UI ACTION FM TUNE 101900000
 ```
 
-`RTL_UI OPEN` accepts `HOME`, `FM`, `P25`, `ADSB`, `LORA`, or `SETTINGS`.
+`RTL_UI OPEN` accepts `HOME`, `FM`, `P25`, `ADSB`, `LORA`, `RF_LAB`,
+`WIFI_ANALYSIS`, or `SETTINGS`.
 `RTL_UI ACTION` accepts a domain and one of its visible touch actions:
 
 - `FM`: `TUNE`, `DOWN`, `UP`, `SEEK_DOWN`, `SEEK_UP`, `SAVE`, `STEP`,
@@ -359,7 +360,7 @@ RTL_UI ACTION FM TUNE 101900000
   `VOL_DOWN`, `VOL_UP`, `SETTINGS`, `HOME`.
 - `LORA`: `VIEW <0-5>`, `NODE <index>`, `FAVORITE`, `FILTER`, `SCAN`, `IQ`,
   `LOG`, `CLEAR`, `EXPORT`, `FOLLOW`, `CHANNELS`, `SETTINGS`, `HOME`.
-- `SETTINGS`: `WIFI_POWER <0|1>`, `ANTENNA <0|1>`, `SCAN`,
+- `SETTINGS`: `WIFI_POWER <0|1>`, `WIFI_BOOT <0|1>`, `ANTENNA <0|1>`, `SCAN`,
   `CONNECT_SAVED <index>`, `FORGET <index>`, `MOVE_UP <index>`,
   `MOVE_DOWN <index>`, `RANGE <nm>`, `BRIGHTNESS <0-255>`, `ROTATION <1|3>`,
   `TIMEOUT <seconds>`, `VOLUME <0-255>`, `SOUND <0|1>`, `AUTO_START <0|1>`,
@@ -368,6 +369,36 @@ RTL_UI ACTION FM TUNE 101900000
 
 Each succeeds with `RTL_UI_ACTION_OK`. Inputs are intentionally routed through
 the existing dashboard handlers rather than duplicating touch-only state.
+
+## Wi-Fi automation
+
+Wi-Fi automation uses the same bounded scan snapshot and Settings handlers as
+the display. SSIDs are returned as hexadecimal bytes so arbitrary SSID text
+cannot forge serial records. Passwords are never returned.
+
+| Command | Auth | Reply / behavior |
+|---|---|---|
+| `RTL_WIFI_STATUS` | no | Station/Hosted state, scan/connect state, profile/AP counts, power, auto-connect, and antenna. |
+| `RTL_WIFI_SCAN` | no | Queues one scan; wait for `RTL_WIFI_SCAN_RESULTS count=N` and `RTL_WIFI_COEX event=scan_complete`. |
+| `RTL_WIFI_RESULTS` | no | Bounded `RTL_WIFI_AP` rows with `ssid_hex`, BSSID, RSSI, channel, and security flag. |
+| `RTL_WIFI_PROFILES` | no | Priority-ordered SSID-only profile list; never returns passwords. |
+| `RTL_WIFI_CONNECT_SAVED` | no | Compatibility shortcut for saved profile 0. Indexed connection uses `RTL_UI ACTION SETTINGS CONNECT_SAVED <index>`. |
+| `RTL_WIFI_DISCONNECT` | yes | Disconnects Wi-Fi and restores the paused radio/audio path. |
+| `SET_WIFI <ssid_hex> <pass_hex> <hmac>` | yes + signed payload | Provisions slot 0 and attempts connection without echoing credentials. |
+
+Power, auto-connect, antenna selection, scan, indexed connection, forget, and
+priority moves use authenticated `RTL_UI ACTION SETTINGS ...` commands listed
+above. Invalid boolean values and profile indices return
+`RTL_UI_ACTION_INVALID` instead of a false success.
+
+Run the complete non-destructive hardware surface with:
+
+```powershell
+apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1 -WifiOnly -PairingKeyPath <key-file>
+```
+
+Add `-RequireWifiConnection` when a real saved profile must associate for the
+test to pass.
 
 The regression command checks the shared radio-control geometry and screen
 ownership self-checks without changing receiver state or NVS. `RUN` also


### PR DESCRIPTION
## Summary
- add the Tab5 RF24 2.4 GHz analyzer dashboard
- expose bounded Wi-Fi scan/profile/status controls over the serial CLI
- add automated Wi-Fi CLI regression coverage and lifecycle fixes

## Verification
- native ESP-IDF build passed
- firmware flash completed with verified hashes
- automatic and manual scans each returned 8 real APs
- saved-profile disconnect/reconnect passed and acquired 192.168.1.75
- device health and UI state restoration passed