### PR TITLE
Fix Tab5 data catalog sync and location lookup

### DIFF
--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -19,6 +19,9 @@ param(
   [switch]$SelfCheck,
   [switch]$Driver079,
   [switch]$WifiOnly,
+  [switch]$DataOnly,
+  [switch]$InstallLaneMap,
+  [string]$LocationQuery = '97401',
   [switch]$RequireWifiConnection,
   [switch]$TestBiasTee
 )
@@ -306,8 +309,7 @@ function Assert-WifiLists([int]$ExpectedAccessPoints) {
   return $profileCount
 }
 
-function Assert-WifiCli {
-  $initialUi = Get-UiState
+function Assert-WifiCli($initialUi) {
   $initial = Get-WifiStatus
   try {
     [void](Send-And-Wait 'SET_WIFI 00 00 00' '^WIFI_INVALID$')
@@ -349,6 +351,8 @@ function Assert-WifiCli {
       Write-SoakLine 'RTL_WIFI_CLI_CONNECT skipped=no_saved_profile'
     }
     Assert-Health
+    Connect-Authenticated
+    [void](Open-Ui 'HOME' $initialUi.Band)
     Write-SoakLine "RTL_WIFI_CLI_RESULT pass=1 auto_aps=$autoCount manual_aps=$manualCount profiles=$profileCount connected=$([int]($profileCount -gt 0))"
   } finally {
     try {
@@ -359,6 +363,69 @@ function Assert-WifiCli {
       [void](Send-And-Wait "RTL_UI OPEN $($initialUi.Screen)" '^RTL_UI_OPEN_(?:OK|INVALID)')
     } catch { Write-Warning "Could not restore initial Wi-Fi/UI state: $($_.Exception.Message)" }
   }
+}
+
+function Wait-CatalogIdle([int]$Seconds) {
+  $deadline = [DateTime]::UtcNow.AddSeconds($Seconds)
+  do {
+    Start-Sleep -Seconds 1
+    $status = Send-And-Wait 'RTL_CATALOG_STATUS' '^RTL_CATALOG_STATUS ' 10
+    if ($status -match 'busy=0') { return $status }
+  } while ([DateTime]::UtcNow -lt $deadline)
+  throw "Catalog operation timed out: $status"
+}
+
+function Assert-DataServices {
+  $wifi = Get-WifiStatus
+  if ($wifi.Power -eq 0) {
+    [void](Send-And-Wait 'RTL_UI ACTION SETTINGS WIFI_POWER 1' '^RTL_UI_ACTION_OK$' 20)
+    $wifi = Get-WifiStatus
+  }
+  if ($wifi.Connected -eq 0) {
+    if ($wifi.Profiles -eq 0) { throw 'Data service test requires a saved Wi-Fi profile.' }
+    for ($attempt = 1; $attempt -le 3; $attempt++) {
+      Connect-Authenticated
+      [void](Send-And-Wait 'RTL_UI ACTION SETTINGS CONNECT_SAVED 0' '^RTL_UI_ACTION_OK$')
+      $event = Read-MatchingLine '^RTL_WIFI_COEX event=connect_(?:complete|failed) ' 45
+      if ($event -match 'event=connect_complete') { break }
+    }
+  }
+  if ((Get-WifiStatus).Connected -ne 1) { throw 'Data service test could not connect Wi-Fi.' }
+
+  [void](Send-And-Wait 'RTL_CATALOG_CHECK' '^RTL_CATALOG_CHECK_QUEUED$')
+  $catalog = Wait-CatalogIdle 60
+  if ($catalog -notmatch 'ready=1 .*message="Catalog verified"') {
+    throw "Catalog verification failed: $catalog"
+  }
+  if ($InstallLaneMap) {
+    Connect-Authenticated
+    [void](Send-And-Wait 'RTL_CATALOG_INSTALL lane_county_map' '^RTL_CATALOG_INSTALL_QUEUED$')
+    $catalog = Wait-CatalogIdle 180
+    if ($catalog -notmatch 'message="Pack installed and verified"') {
+      throw "Lane County map install failed: $catalog"
+    }
+    $pack = Read-MatchingLine '^RTL_CATALOG_PACK id=lane_county_map ' 10
+    if ($pack -notmatch 'installed=1 update=0 status="INSTALLED"') {
+      throw "Lane County map was not activated: $pack"
+    }
+  }
+
+  if ($LocationQuery -notmatch '^[\x20-\x7E]{1,63}$') {
+    throw 'LocationQuery must contain 1-63 printable ASCII characters.'
+  }
+  Connect-Authenticated
+  [void](Send-And-Wait "RTL_LOCATION LOOKUP $LocationQuery" '^RTL_LOCATION_LOOKUP_QUEUED$')
+  $deadline = [DateTime]::UtcNow.AddSeconds(30)
+  do {
+    Start-Sleep -Seconds 1
+    $location = Send-And-Wait 'RTL_LOCATION STATUS' '^RTL_LOCATION_STATUS ' 10
+    if ($location -match 'busy=0') { break }
+  } while ([DateTime]::UtcNow -lt $deadline)
+  if ($location -notmatch 'busy=0 ready=1 latitude_e7=-?\d+ longitude_e7=-?\d+ message="Address found; confirm to save"') {
+    throw "Location lookup failed: $location"
+  }
+  Assert-Health
+  Write-SoakLine "RTL_DATA_SERVICES_RESULT pass=1 catalog=verified lane_map_installed=$([int][bool]$InstallLaneMap) location_query=$LocationQuery"
 }
 
 function Capture-ResetEvidence {
@@ -408,8 +475,8 @@ function Invoke-SelfCheck {
 }
 
 if ($SelfCheck) { Invoke-SelfCheck; exit 0 }
-if (@($Run, $Soak, $Driver079, $WifiOnly).Where({ $_ }).Count -gt 1) {
-  throw 'Choose only one of -Run, -Soak, -Driver079, or -WifiOnly.'
+if (@($Run, $Soak, $Driver079, $WifiOnly, $DataOnly).Where({ $_ }).Count -gt 1) {
+  throw 'Choose only one of -Run, -Soak, -Driver079, -WifiOnly, or -DataOnly.'
 }
 
 function Get-DriverStatus {
@@ -506,8 +573,15 @@ try {
   if ($Driver079) { Invoke-Driver079Test; exit 0 }
   if ($WifiOnly) {
     Wait-DeviceReady 60 11000
+    $initialUi = Get-UiState
     Connect-Authenticated
-    Assert-WifiCli
+    Assert-WifiCli $initialUi
+    exit 0
+  }
+  if ($DataOnly) {
+    Wait-DeviceReady 60 11000
+    Connect-Authenticated
+    Assert-DataServices
     exit 0
   }
 

--- a/apps/orcsdr-tab5/ui/catalog_sync.cpp
+++ b/apps/orcsdr-tab5/ui/catalog_sync.cpp
@@ -30,6 +30,7 @@ constexpr size_t kChunkBytes = 4096;
 constexpr size_t kWriteBatchBytes = kChunkBytes;
 constexpr size_t kYieldBytes = 64 * 1024;
 constexpr uint8_t kMaxRedirects = 4;
+constexpr char kUserAgent[] = "OrcSDR/0.2 (+https://github.com/hardcoreerik/OrcSDR)";
 
 extern const uint8_t catalog_public_key_pem_start[] asm("_binary_catalog_public_key_pem_start");
 extern const uint8_t catalog_public_key_pem_end[] asm("_binary_catalog_public_key_pem_end");
@@ -200,13 +201,14 @@ bool http_read_all(const char* url, uint8_t* output, size_t capacity, size_t* re
   config.buffer_size_tx = 2048;
   config.crt_bundle_attach = esp_crt_bundle_attach;
   config.keep_alive_enable = true;
+  config.user_agent = kUserAgent;
   esp_http_client_handle_t client = esp_http_client_init(&config);
   if (!client) return false;
   esp_err_t open_result = ESP_FAIL;
   int64_t declared = -1;
   int status = -1;
   bool ok = open_get(client, &declared, &status, &open_result);
-  if (!ok || declared < 0 || static_cast<uint64_t>(declared) > capacity) {
+  if (!ok || (declared > 0 && static_cast<uint64_t>(declared) > capacity)) {
     esp_http_client_cleanup(client);
     return false;
   }
@@ -218,13 +220,15 @@ bool http_read_all(const char* url, uint8_t* output, size_t capacity, size_t* re
     if (got == 0) break;
     total += static_cast<size_t>(got);
   }
+  const bool complete = esp_http_client_is_complete_data_received(client);
   esp_http_client_close(client);
   esp_http_client_cleanup(client);
   *received = total;
   ESP_LOGI(kTag, "fetch open=%s status=%d declared=%lld received=%u",
            esp_err_to_name(open_result), status, static_cast<long long>(declared),
            static_cast<unsigned>(total));
-  return ok && status == 200 && total > 0 && (declared == 0 || total == static_cast<size_t>(declared));
+  return ok && complete && status == 200 && total > 0 &&
+         (declared <= 0 || total == static_cast<size_t>(declared));
 }
 
 bool verify_signature(const uint8_t* manifest, size_t manifest_size,
@@ -351,12 +355,13 @@ bool download_artifact(const Artifact& artifact, uint8_t pack_index,
   config.timeout_ms = 20000;
   config.buffer_size_tx = 2048;
   config.crt_bundle_attach = esp_crt_bundle_attach;
+  config.user_agent = kUserAgent;
   esp_http_client_handle_t client = esp_http_client_init(&config);
   esp_err_t open_result = ESP_FAIL;
   int64_t declared = -1;
   int status = -1;
   bool ok = client && open_get(client, &declared, &status, &open_result);
-  if (!ok || declared != artifact.bytes || status != 200) ok = false;
+  if (!ok || (declared > 0 && declared != artifact.bytes) || status != 200) ok = false;
   ESP_LOGI(kTag, "download stage=http_open ok=%d status=%d declared=%lld", ok ? 1 : 0,
            status, static_cast<long long>(declared));
   uint8_t* write_batch = static_cast<uint8_t*>(heap_caps_malloc(kWriteBatchBytes, MALLOC_CAP_SPIRAM));
@@ -583,7 +588,9 @@ bool request(Operation operation, uint8_t pack_index, bool needs_wifi) {
   g_requested_pack = pack_index;
   set_busy(operation, 0);
   set_message(operation == Operation::check ? "Catalog check queued" : "Data operation queued");
-  if (xTaskCreatePinnedToCore(worker, "catalog_sync", 12288, nullptr, 3, &g_worker, 1) != pdPASS) {
+  if (xTaskCreatePinnedToCoreWithCaps(worker, "catalog_sync", 12288, nullptr, 3,
+                                      &g_worker, 1,
+                                      MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) != pdPASS) {
     g_requested = Operation::none;
     set_busy(Operation::none, 0);
     set_message("Catalog worker creation failed");

--- a/apps/orcsdr-tab5/ui/location_estimate.cpp
+++ b/apps/orcsdr-tab5/ui/location_estimate.cpp
@@ -5,19 +5,49 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <atomic>
+#include <cctype>
 #include <cmath>
 #include <cstring>
 namespace orcsdr::location_estimate { namespace {
 State g_state{}; portMUX_TYPE g_lock=portMUX_INITIALIZER_UNLOCKED; std::atomic_bool g_busy{false};
+char g_query[64]{};
+char g_last_query[64]{};
 void set(const State& value) { portENTER_CRITICAL(&g_lock); g_state=value; portEXIT_CRITICAL(&g_lock); }
-void worker(void*) { State next{}; next.busy=true; strlcpy(next.message,"Looking up IP area",sizeof(next.message)); set(next);
-  char body[1024]{}; esp_http_client_config_t cfg{}; cfg.url="https://ipwho.is/"; cfg.timeout_ms=12000; cfg.crt_bundle_attach=esp_crt_bundle_attach;
-  esp_http_client_handle_t http=esp_http_client_init(&cfg); bool ok=http && esp_http_client_open(http,0)==ESP_OK;
+bool encode_query(const char* input, char* output, size_t capacity) {
+  if (!input || !input[0] || !output || capacity == 0) return false;
+  static constexpr char hex[] = "0123456789ABCDEF";
+  size_t used = 0;
+  for (const uint8_t* p = reinterpret_cast<const uint8_t*>(input); *p; ++p) {
+    if (*p < 32 || *p == 127) return false;
+    const bool plain = std::isalnum(*p) || *p == '-' || *p == '_' || *p == '.' || *p == '~';
+    const size_t needed = plain ? 1 : 3;
+    if (used + needed >= capacity) return false;
+    if (plain) output[used++] = static_cast<char>(*p);
+    else { output[used++] = '%'; output[used++] = hex[*p >> 4]; output[used++] = hex[*p & 15]; }
+  }
+  output[used] = '\0';
+  return used != 0;
+}
+void worker(void*) { const bool address = g_query[0] != '\0'; State next{}; next.busy=true; strlcpy(next.message,address ? "Looking up address" : "Looking up IP area",sizeof(next.message)); set(next);
+  char encoded[192]{}, url[320]{};
+  bool ok = !address || encode_query(g_query, encoded, sizeof(encoded));
+  if (address) snprintf(url, sizeof(url), "https://nominatim.openstreetmap.org/search?q=%s&format=jsonv2&limit=1", encoded);
+  else strlcpy(url, "https://ipwho.is/", sizeof(url));
+  char body[2048]{}; esp_http_client_config_t cfg{}; cfg.url=url; cfg.timeout_ms=12000; cfg.crt_bundle_attach=esp_crt_bundle_attach; cfg.user_agent="OrcSDR/0.2 (+https://github.com/hardcoreerik/OrcSDR)";
+  esp_http_client_handle_t http=ok?esp_http_client_init(&cfg):nullptr; ok=ok && http && esp_http_client_open(http,0)==ESP_OK;
   if (ok) { const int64_t size=esp_http_client_fetch_headers(http); ok=size>=0 && (size==0 || size < (int64_t)sizeof(body)); size_t used=0; while(ok && used<sizeof(body)-1) { const int got=esp_http_client_read(http,body+used,sizeof(body)-1-used); if(got<0){ok=false;break;} if(got==0){ok=esp_http_client_is_complete_data_received(http);break;} used+=static_cast<size_t>(got); if(size>0 && used==static_cast<size_t>(size)) break; } body[used]='\0'; ok=ok && (size==0 ? esp_http_client_is_complete_data_received(http) : used==static_cast<size_t>(size)) && esp_http_client_get_status_code(http)==200; }
   if(http){esp_http_client_close(http);esp_http_client_cleanup(http);} next={};
-  cJSON* root=ok?cJSON_Parse(body):nullptr; const cJSON* lat=root?cJSON_GetObjectItem(root,"latitude"):nullptr; const cJSON* lon=root?cJSON_GetObjectItem(root,"longitude"):nullptr; const cJSON* city=root?cJSON_GetObjectItem(root,"city"):nullptr;
-  if(root && cJSON_IsNumber(lat) && cJSON_IsNumber(lon) && fabs(lat->valuedouble)<=90 && fabs(lon->valuedouble)<=180) { next.ready=true; next.latitude_e7=(int32_t)llround(lat->valuedouble*10000000.0); next.longitude_e7=(int32_t)llround(lon->valuedouble*10000000.0); snprintf(next.label,sizeof(next.label),"IP AREA: %s",cJSON_IsString(city)?city->valuestring:"UNKNOWN"); strlcpy(next.message,"Approximate IP area; confirm to save",sizeof(next.message)); } else strlcpy(next.message,"IP area lookup failed",sizeof(next.message)); if(root)cJSON_Delete(root); set(next); g_busy.store(false,std::memory_order_release); vTaskDelete(nullptr); }
+  cJSON* root=ok?cJSON_Parse(body):nullptr;
+  const cJSON* result=address && cJSON_IsArray(root)?cJSON_GetArrayItem(root,0):root;
+  const cJSON* lat=result?cJSON_GetObjectItem(result,address?"lat":"latitude"):nullptr;
+  const cJSON* lon=result?cJSON_GetObjectItem(result,address?"lon":"longitude"):nullptr;
+  const double latitude=address && cJSON_IsString(lat)?strtod(lat->valuestring,nullptr):cJSON_IsNumber(lat)?lat->valuedouble:NAN;
+  const double longitude=address && cJSON_IsString(lon)?strtod(lon->valuestring,nullptr):cJSON_IsNumber(lon)?lon->valuedouble:NAN;
+  const cJSON* label=result?cJSON_GetObjectItem(result,address?"display_name":"city"):nullptr;
+  if(result && std::isfinite(latitude) && std::isfinite(longitude) && fabs(latitude)<=90 && fabs(longitude)<=180) { next.ready=true; next.latitude_e7=(int32_t)llround(latitude*10000000.0); next.longitude_e7=(int32_t)llround(longitude*10000000.0); snprintf(next.label,sizeof(next.label),"%s: %s",address?"SEARCH":"IP AREA",cJSON_IsString(label)?label->valuestring:"UNKNOWN"); strlcpy(next.message,address?"Address found; confirm to save":"Approximate IP area; confirm to save",sizeof(next.message)); if(address)strlcpy(g_last_query,g_query,sizeof(g_last_query)); } else strlcpy(next.message,address?"Address not found":"IP area lookup failed",sizeof(next.message)); if(root)cJSON_Delete(root); set(next); g_busy.store(false,std::memory_order_release); vTaskDelete(nullptr); }
 }
-bool request(bool wifi_connected) { if(!wifi_connected)return false; bool expected=false; if(!g_busy.compare_exchange_strong(expected,true,std::memory_order_acq_rel))return false; State pending{}; pending.busy=true; strlcpy(pending.message,"IP area lookup queued",sizeof(pending.message)); set(pending); if(xTaskCreatePinnedToCore(worker,"ip_location",8192,nullptr,3,nullptr,1)==pdPASS)return true; g_busy.store(false,std::memory_order_release); pending.busy=false; strlcpy(pending.message,"IP area lookup unavailable",sizeof(pending.message)); set(pending); return false; }
+bool request(bool wifi_connected) { return request(nullptr, wifi_connected); }
+bool request(const char* query, bool wifi_connected) { if(!wifi_connected){State error{};strlcpy(error.message,"Connect Wi-Fi before lookup",sizeof(error.message));set(error);return false;} if(query && query[0] && strcmp(query,g_last_query)==0 && state().ready)return true; bool expected=false; if(!g_busy.compare_exchange_strong(expected,true,std::memory_order_acq_rel))return false; strlcpy(g_query,query?query:"",sizeof(g_query)); State pending{}; pending.busy=true; strlcpy(pending.message,g_query[0]?"Address lookup queued":"IP area lookup queued",sizeof(pending.message)); set(pending); if(xTaskCreatePinnedToCoreWithCaps(worker,"location_lookup",8192,nullptr,3,nullptr,1,MALLOC_CAP_SPIRAM|MALLOC_CAP_8BIT)==pdPASS)return true; g_busy.store(false,std::memory_order_release); pending.busy=false; strlcpy(pending.message,"Location lookup unavailable",sizeof(pending.message)); set(pending); return false; }
 State state(){State copy{};portENTER_CRITICAL(&g_lock);copy=g_state;portEXIT_CRITICAL(&g_lock);return copy;}
+bool self_check(){char encoded[64]{};return encode_query("97401 Main St",encoded,sizeof(encoded))&&strcmp(encoded,"97401%20Main%20St")==0&&!encode_query("bad\nquery",encoded,sizeof(encoded));}
 }

--- a/apps/orcsdr-tab5/ui/location_estimate.hpp
+++ b/apps/orcsdr-tab5/ui/location_estimate.hpp
@@ -3,5 +3,7 @@
 namespace orcsdr::location_estimate {
 struct State { bool busy=false; bool ready=false; int32_t latitude_e7=0; int32_t longitude_e7=0; char label[40]{}; char message[48]{}; };
 bool request(bool wifi_connected);
+bool request(const char* query, bool wifi_connected);
 State state();
+bool self_check();
 }

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -5233,6 +5233,7 @@ void draw_sdr_screen(RtlBand band, uint32_t frequency_hz, uint8_t volume) {
   const auto screen = screen_for_band(band);
   orcsdr::screens::begin_transition(screen, millis());
   orcsdr::home::leave();
+  orcsdr::rf24::leave();
   orcsdr::settings::leave();
   if (band != RtlBand::fm) orcsdr::fm::leave();
   if (band != RtlBand::p25) orcsdr::p25::leave();
@@ -8759,10 +8760,7 @@ void open_rf24_dashboard() {
 }
 
 void close_rf24_dashboard() {
-  orcsdr::rf24::leave();
-  orcsdr::screens::begin_transition(orcsdr::screens::Id::home, millis());
-  orcsdr::home::draw();
-  orcsdr::screens::finish_transition();
+  show_home();
 }
 
 void open_dashboard(orcsdr::dashboards::Id id) {
@@ -8770,6 +8768,7 @@ void open_dashboard(orcsdr::dashboards::Id id) {
   if (id != Id::settings && orcsdr::settings::active()) close_global_settings();
   if (id == Id::rf_lab) {
     persist_dashboard_open(id);
+    orcsdr::rf24::leave();
     open_rf_lab();
     return;
   }
@@ -8971,12 +8970,21 @@ void handle_global_settings_action(const orcsdr::settings::Action& action) {
       (void)orcsdr::location_estimate::request(wifi_connected);
       update_global_settings();
       break;
+    case orcsdr::settings::ActionKind::location_query_lookup: {
+      char query[64]{};
+      if (orcsdr::settings::take_location_query(query, sizeof(query)))
+        (void)orcsdr::location_estimate::request(query, wifi_connected);
+      update_global_settings();
+      break;
+    }
     case orcsdr::settings::ActionKind::location_ip_confirm: {
-      const auto& state = orcsdr::settings::state();
-      adsb_settings.location_configured = state.location_configured;
-      adsb_settings.latitude_e7 = state.latitude_e7; adsb_settings.longitude_e7 = state.longitude_e7;
+      const auto location = orcsdr::location_estimate::state();
+      if (!location.ready) break;
+      adsb_settings.location_configured = true;
+      adsb_settings.latitude_e7 = location.latitude_e7;
+      adsb_settings.longitude_e7 = location.longitude_e7;
       refresh_adsb_atc_preset();
-      strlcpy(settings_location_label, state.location_label, sizeof(settings_location_label));
+      strlcpy(settings_location_label, location.label, sizeof(settings_location_label));
       adsb_settings_persist_pending.store(true, std::memory_order_release);
       break;
     }
@@ -11278,6 +11286,7 @@ void process_command(char* command) {
   }
   if (strcmp(command, "RTL_CATALOG_CHECK") == 0 ||
       strcmp(command, "RTL_CATALOG_FETCH") == 0) {
+    if (!authenticated) { Serial.println("RTL_CATALOG_ERROR auth_required"); return; }
     const bool fetch = strcmp(command, "RTL_CATALOG_FETCH") == 0;
     handle_global_settings_action({orcsdr::settings::ActionKind::catalog_check, 0});
     Serial.printf("RTL_CATALOG_%s_%s\n", fetch ? "FETCH" : "CHECK",
@@ -11286,6 +11295,7 @@ void process_command(char* command) {
   }
   if (strncmp(command, "RTL_CATALOG_INSTALL ", 20) == 0 ||
       strncmp(command, "RTL_CATALOG_REMOVE ", 19) == 0) {
+    if (!authenticated) { Serial.println("RTL_CATALOG_ERROR auth_required"); return; }
     const bool remove = strncmp(command, "RTL_CATALOG_REMOVE ", 19) == 0;
     const char* argument = command + (remove ? 19 : 20);
     char id[20]{};
@@ -11311,6 +11321,36 @@ void process_command(char* command) {
                                    index});
     Serial.printf("RTL_CATALOG_%s_%s\n", remove ? "REMOVE" : "INSTALL",
                   orcsdr::catalog::state().busy ? "QUEUED" : "REJECTED");
+    return;
+  }
+  if (strcmp(command, "RTL_LOCATION STATUS") == 0) {
+    const auto location = orcsdr::location_estimate::state();
+    Serial.printf("RTL_LOCATION_STATUS busy=%d ready=%d latitude_e7=%ld longitude_e7=%ld message=\"%s\"\n",
+                  location.busy ? 1 : 0, location.ready ? 1 : 0,
+                  static_cast<long>(location.latitude_e7),
+                  static_cast<long>(location.longitude_e7), location.message);
+    return;
+  }
+  if (strcmp(command, "RTL_LOCATION IP") == 0 ||
+      strncmp(command, "RTL_LOCATION LOOKUP ", 20) == 0 ||
+      strcmp(command, "RTL_LOCATION CONFIRM") == 0) {
+    if (!authenticated) { Serial.println("RTL_LOCATION_ERROR auth_required"); return; }
+    if (strcmp(command, "RTL_LOCATION CONFIRM") == 0) {
+      handle_global_settings_action({orcsdr::settings::ActionKind::location_ip_confirm, 0});
+      Serial.printf("RTL_LOCATION_CONFIRM_%s\n",
+                    orcsdr::location_estimate::state().ready ? "OK" : "REJECTED");
+      return;
+    }
+    const char* query = strncmp(command, "RTL_LOCATION LOOKUP ", 20) == 0
+                            ? command + 20 : nullptr;
+    if (query && (!query[0] || strlen(query) >= 64)) {
+      Serial.println("RTL_LOCATION_ERROR query_length");
+      return;
+    }
+    const bool queued = query ? orcsdr::location_estimate::request(query, wifi_connected)
+                              : orcsdr::location_estimate::request(wifi_connected);
+    Serial.printf("RTL_LOCATION_%s_%s\n", query ? "LOOKUP" : "IP",
+                  queued ? "QUEUED" : "REJECTED");
     return;
   }
   if (strncmp(command, "RTL_ADSB_LOCATION ", 18) == 0) {
@@ -11768,6 +11808,7 @@ void process_command(char* command) {
     Serial.println("RTL_CATALOG_INSTALL <id>       - fetch+verify+activate data/map pack");
     Serial.println("RTL_CATALOG_REMOVE <id> CONFIRM - remove installed pack (SD only)");
     Serial.println("RTL_CATALOG packs: faa_aircraft|faa_aviation|noaa_weather|fcc_broadcast|lane_county_map");
+    Serial.println("RTL_LOCATION STATUS|IP|LOOKUP <zip/address>|CONFIRM - resolve and save receiver location");
     Serial.println("SD_LIST/SD_GET_*/SD_PUT_*      - SD card file transfer (see copy_to_tab5_sd.ps1)");
     Serial.println("RTL_HELP_END");
     return;
@@ -12481,6 +12522,11 @@ void setup() {
     abort();
   }
   Serial.println("ORC_SETTINGS_SELF_CHECK_OK");
+  if (!orcsdr::location_estimate::self_check()) {
+    Serial.println("ORC_LOCATION_SELF_CHECK_FAIL");
+    abort();
+  }
+  Serial.println("ORC_LOCATION_SELF_CHECK_OK");
   if (!orcsdr::screens::self_check()) {
     Serial.println("ORC_SCREEN_CONTROLLER_SELF_CHECK_FAIL");
     abort();

--- a/apps/orcsdr-tab5/ui/navigation_service.cpp
+++ b/apps/orcsdr-tab5/ui/navigation_service.cpp
@@ -9,6 +9,7 @@
 #include "fm_dashboard.hpp"
 #include "lora_dashboard.hpp"
 #include "p25_dashboard.hpp"
+#include "rf24_dashboard.hpp"
 
 namespace orcsdr::navigation {
 namespace {
@@ -32,6 +33,7 @@ void show_home(bool demo) {
   p25::leave();
   adsb::leave();
   lora::leave();
+  rf24::leave();
   settings::leave();
   g_hooks.close_overlays();
   g_hooks.sync_audio();

--- a/apps/orcsdr-tab5/ui/settings_app.cpp
+++ b/apps/orcsdr-tab5/ui/settings_app.cpp
@@ -53,6 +53,9 @@ char g_wifi_edit_password[64]{};
 char g_wifi_request_ssid[33]{};
 char g_wifi_request_password[64]{};
 bool g_wifi_request_pending = false;
+bool g_location_edit = false;
+bool g_location_request_pending = false;
+char g_location_query[64]{};
 int8_t g_catalog_remove_armed = -1;
 
 bool hit(int x, int y, int bx, int by, int bw, int bh) {
@@ -206,12 +209,14 @@ void draw_location() {
   button(value, 820, 344, 398, 54, TFT_DARKCYAN);
   value_row("MAP PACK", g_state.map_pack[0] ? g_state.map_pack : "NOT INSTALLED", 445);
   value_row("RF GAIN", "AUTO (READ ONLY)", 495, kMuted);
-  text("Phone GPS proposals require confirmation on this screen.", 330, 565,
-       TFT_LIGHTGREY, 2);
-  button(g_state.ip_location_busy ? "LOOKING UP IP AREA" : "LOOK UP IP AREA", 330, 610, 260, 46,
+  text("INTERNET LOCATION LOOKUP", 330, 550, kBlue, 2);
+  button(g_state.ip_location_busy ? "LOOKING UP..." : "ZIP / ADDRESS", 330, 575, 250, 46,
          g_state.ip_location_busy ? TFT_DARKGREY : TFT_DARKCYAN);
-  if (g_state.ip_location_ready) button("CONFIRM IP AREA", 900, 610, 290, 46, TFT_DARKGREEN);
-  if (g_state.ip_location_message[0]) text(g_state.ip_location_message, 330, 676, kMuted, 2, middle_left);
+  button("IP AREA", 600, 575, 180, 46,
+         g_state.ip_location_busy ? TFT_DARKGREY : TFT_NAVY);
+  if (g_state.ip_location_ready) button("USE RESULT", 800, 575, 240, 46, TFT_DARKGREEN);
+  if (g_state.ip_location_message[0]) text(g_state.ip_location_message, 330, 645, kMuted, 2, middle_left);
+  text("Address search data (c) OpenStreetMap contributors", 330, 682, kMuted, 1);
 }
 
 void draw_data_maps() {
@@ -465,6 +470,21 @@ Action handle_wifi_keyboard(int x, int y) {
   return {};
 }
 
+Action handle_location_keyboard(int x, int y) {
+  const auto result = text_editor::handle_touch(x, y);
+  strlcpy(g_location_query, text_editor::value(), sizeof(g_location_query));
+  if (result == text_editor::Result::cancelled) {
+    g_location_edit = false;
+    draw_content();
+  } else if (result == text_editor::Result::accepted && g_location_query[0]) {
+    g_location_edit = false;
+    g_location_request_pending = true;
+    draw_content();
+    return {ActionKind::location_query_lookup, 0};
+  }
+  return {};
+}
+
 bool valid_coordinate(EditField field, double value) {
   return std::isfinite(value) &&
          (field == EditField::latitude ? value >= -90.0 && value <= 90.0
@@ -528,6 +548,7 @@ void enter(const State& state_value, Section section) {
   g_section = section;
   g_edit = EditField::none;
   g_wifi_edit = WifiEdit::none;
+  g_location_edit = false;
   g_catalog_remove_armed = -1;
   g_active = true;
   g_latitude_set = state_value.location_configured;
@@ -539,6 +560,7 @@ void leave() {
   g_active = false;
   g_edit = EditField::none;
   g_wifi_edit = WifiEdit::none;
+  g_location_edit = false;
 }
 
 void draw() {
@@ -603,13 +625,13 @@ void update(const State& state_value) {
        strcmp(g_state.web_console_url, state_value.web_console_url) != 0);
   g_state = state_value;
   if (header_changed) draw_header();
-  if (page_changed && g_edit == EditField::none && g_wifi_edit == WifiEdit::none)
+  if (page_changed && g_edit == EditField::none && g_wifi_edit == WifiEdit::none && !g_location_edit)
     draw_content();
   if (power_changed && g_edit == EditField::none && g_wifi_edit == WifiEdit::none)
     draw_system_power();
   if (catalog_changed && g_edit == EditField::none && g_wifi_edit == WifiEdit::none)
     draw_content();
-  if (location_changed && g_edit == EditField::none && g_wifi_edit == WifiEdit::none)
+  if (location_changed && g_edit == EditField::none && g_wifi_edit == WifiEdit::none && !g_location_edit)
     draw_content();
   if (companion_changed && g_edit == EditField::none && g_wifi_edit == WifiEdit::none)
     draw_content();
@@ -617,6 +639,7 @@ void update(const State& state_value) {
 
 Action handle_touch(int32_t x, int32_t y) {
   if (!g_active) return {};
+  if (g_location_edit) return handle_location_keyboard(x, y);
   if (g_wifi_edit != WifiEdit::none) return handle_wifi_keyboard(x, y);
   if (g_edit != EditField::none) return handle_keypad(x, y);
   if (audio_header::mute_hit(x, y))
@@ -685,8 +708,16 @@ Action handle_touch(int32_t x, int32_t y) {
       draw_content();
       return {ActionKind::range_changed, g_state.radar_range_nm};
     }
-    if (hit(x, y, 330, 610, 260, 46) && !g_state.ip_location_busy) return {ActionKind::location_ip_lookup, 0};
-    if (g_state.ip_location_ready && hit(x, y, 900, 610, 290, 46)) {
+    if (hit(x, y, 330, 575, 250, 46) && !g_state.ip_location_busy) {
+      g_location_edit = true;
+      text_editor::begin("ZIP CODE OR ADDRESS", g_location_query,
+                         sizeof(g_location_query) - 1, false, "LOOK UP");
+      text_editor::draw();
+      return {};
+    }
+    if (hit(x, y, 600, 575, 180, 46) && !g_state.ip_location_busy)
+      return {ActionKind::location_ip_lookup, 0};
+    if (g_state.ip_location_ready && hit(x, y, 800, 575, 240, 46)) {
       g_state.latitude_e7 = g_state.ip_latitude_e7; g_state.longitude_e7 = g_state.ip_longitude_e7;
       strlcpy(g_state.location_label, g_state.ip_location_label, sizeof(g_state.location_label));
       g_state.location_configured = true; g_latitude_set = g_longitude_set = true;
@@ -766,6 +797,7 @@ void show_documentation_section(Section section, const State& state_value,
   g_section = section;
   g_edit = EditField::none;
   g_wifi_edit = WifiEdit::none;
+  g_location_edit = false;
   g_active = true;
   if (show_wifi_keyboard) {
     begin_wifi_edit(WifiEdit::password, "Demo Network");
@@ -786,6 +818,13 @@ bool take_wifi_credentials(char* ssid, size_t ssid_size,
   g_wifi_request_ssid[0] = '\0';
   g_wifi_request_pending = false;
   return true;
+}
+
+bool take_location_query(char* query, size_t query_size) {
+  if (!g_location_request_pending || !query || query_size == 0) return false;
+  strlcpy(query, g_location_query, query_size);
+  g_location_request_pending = false;
+  return query[0] != '\0';
 }
 
 bool self_check() {
@@ -812,7 +851,12 @@ bool self_check() {
                               strcmp(password, "not-a-real-password") == 0 &&
                               g_wifi_request_password[0] == '\0';
   memset(password, 0, sizeof(password));
-  if (!symbols_ok || !credentials_ok) return false;
+  strlcpy(g_location_query, "97401", sizeof(g_location_query));
+  g_location_request_pending = true;
+  char query[64]{};
+  const bool location_ok = take_location_query(query, sizeof(query)) &&
+                           strcmp(query, "97401") == 0;
+  if (!symbols_ok || !credentials_ok || !location_ok) return false;
   return true;
 }
 

--- a/apps/orcsdr-tab5/ui/settings_app.hpp
+++ b/apps/orcsdr-tab5/ui/settings_app.hpp
@@ -121,6 +121,7 @@ enum class ActionKind : uint8_t {
   move_wifi_down,
   location_changed,
   location_ip_lookup,
+  location_query_lookup,
   location_ip_confirm,
   range_changed,
   brightness_changed,
@@ -153,6 +154,7 @@ void show_documentation_section(Section section, const State& state,
                                 bool show_wifi_keyboard = false);
 bool take_wifi_credentials(char* ssid, size_t ssid_size,
                            char* password, size_t password_size);
+bool take_location_query(char* query, size_t query_size);
 bool self_check();
 
 }  // namespace orcsdr::settings


### PR DESCRIPTION
## Summary
- fix catalog and location workers under fragmented internal RAM
- support ZIP/address lookup with explicit confirmation
- add automated catalog, map-install, and location checks
- preserve RF24 dashboard transition cleanup

## Verification
- un-tab5-ui-regression.ps1 -SelfCheck
- authorized Tab5 hardware run: signed catalog verification, Lane County map install, and ZIP 97401 lookup

No merge is included in this PR.