### PR TITLE
fix(tab5): ADS-B interpolation window off-by-one and NVS write guard

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -1,0 +1,78 @@
+# Development environment
+
+Reproducible setup notes for building and flashing OrcSDR firmware. This
+documents what a machine needs beyond what's tracked in the repo (Python
+`requirements*.txt` files only cover standalone tool scripts, not the
+firmware toolchain itself).
+
+## Tab5 firmware (apps/orcsdr-tab5)
+
+Native ESP-IDF build; PlatformIO is not a supported build or flash path.
+
+| Requirement | Version / path | Notes |
+|---|---|---|
+| ESP-IDF | 5.5.4 | Installed via Espressif's standard installer to `C:\Espressif\frameworks\esp-idf-v5.5.4` (Windows path shown; adjust for other OSes). Do not substitute a different ESP-IDF version — component pins in `apps/orcsdr-tab5/dependencies.lock` target 5.5.4. |
+| IDF Python env | `C:\Espressif\python_env\idf5.5_py3.14_env` | Created by the ESP-IDF installer alongside the framework; not a project-level virtualenv. |
+| Target toolchain | ESP32-P4 (riscv32-esp-elf), installed by the ESP-IDF installer | Do not override the platform toolchain. |
+| M5Unified / M5GFX | 0.2.20 / 0.2.27 | Pulled as ESP-IDF managed components (`managed_components/`), pinned by `apps/orcsdr-tab5/main/idf_component.yml` and `dependencies.lock`. |
+
+### Build
+
+```powershell
+cd apps/orcsdr-tab5
+.\tools\build-tab5-idf.ps1
+```
+
+This script activates the pinned ESP-IDF environment, applies the local
+M5GFX Tab5 page-flip patch, regenerates the per-build sdkconfig from
+`sdkconfig.defaults`, and runs `idf.py build`.
+
+**Known gotcha — first build in a fresh checkout/worktree:** the script
+applies `tools/patches/m5gfx-tab5-pageflip.patch` to `managed_components/`
+*before* running `idf.py reconfigure`. On a machine (or worktree) that has
+never fetched `managed_components/` yet, the patch step has nothing to
+patch and fails outright. Even if you pre-populate `managed_components/`
+(e.g. copied from another checkout) so the patch step succeeds, the
+subsequent `idf.py reconfigure` component-manager step can still
+re-resolve/overwrite `managed_components/m5stack__m5gfx` and silently drop
+the applied patch, producing build errors like `'struct
+lgfx::v1::Panel_DSI' has no member named 'getPanelHandle'`.
+
+Workaround until the script is fixed: run `idf.py reconfigure` once first
+(via `. tools\build-tab5-idf.ps1`'s underlying `idf.py` invocation, or
+manually after activating the IDF environment) so `managed_components/` is
+fully fetched, then apply the patch
+(`tools\apply-m5gfx-tab5-pageflip.ps1`), then build with `idf.py build`
+(skip `reconfigure` on that run so the patched files aren't re-fetched).
+
+### Flash
+
+```powershell
+idf.py -p COM17 flash
+```
+
+Only after explicit hardware authorization. `COM17` is the current bench
+assignment for the Tab5's native USB Serial/JTAG connection — always pass
+it explicitly; do not rely on port auto-detection, which can select a
+different attached device. See
+[`apps/orcsdr-tab5/README.md`](apps/orcsdr-tab5/README.md) for file-transfer
+and splash-asset details.
+
+## Standalone Python tools
+
+Install into any Python 3.10+ environment as needed per script:
+
+| File | Used by |
+|---|---|
+| `requirements.txt` (repo root) | `install-orcsdr.ps1` people-installer (talks to the Tab5 over serial after flash) |
+| `tools/requirements-docs.txt` | Documentation build tooling |
+| `tools/requirements-help-media.txt` | Help-media generation scripts |
+| `tools/requirements-lora.txt` | LoRa capture/decode tooling under `.local/lora-*` |
+
+## PR workflow
+
+- Open PRs from a branch created off `origin/main`, in its own git worktree.
+- CodeRabbit does not auto-review repos with fewer than 10 stars; trigger
+  it manually by commenting `@coderabbitai review` on the PR. It reviews
+  each pushed commit only once — comment `@coderabbitai review` again
+  after pushing any follow-up commit to get it re-reviewed.

--- a/apps/orcsdr-tab5/ui/adsb_decoder.cpp
+++ b/apps/orcsdr-tab5/ui/adsb_decoder.cpp
@@ -163,7 +163,10 @@ void Decoder::process_cu8(const uint8_t* data, size_t bytes, FrameCallback callb
     }
   }
   constexpr size_t kFrameSamples = 246;
-  for (size_t pos = 0; pos + kFrameSamples <= count; ++pos) {
+  // Bit interpolation for the last data bit reads one sample past the
+  // kFrameSamples preamble window (see interpolate()), so require that
+  // extra sample to be part of this call's freshly-filled data.
+  for (size_t pos = 0; pos + kFrameSamples + 1 <= count; ++pos) {
     const uint16_t* sample = magnitudes_ + pos;
     if (sample[0] <= sample[1] || sample[2] <= sample[1] || sample[2] <= sample[3] ||
         sample[7] <= sample[6] || sample[7] <= sample[8] || sample[9] <= sample[8] ||
@@ -206,7 +209,9 @@ void Decoder::process_cu8(const uint8_t* data, size_t bytes, FrameCallback callb
     if (callback) callback(decoded, context);
     pos += (valid_bits == 56 ? 131 : kFrameSamples) - 1;
   }
-  overlap_ = std::min(count, kFrameSamples - 1);
+  // Retain kFrameSamples samples (not kFrameSamples - 1) so the extra
+  // lookahead sample the interpolator needs is available on the next call.
+  overlap_ = std::min(count, kFrameSamples);
   std::memmove(magnitudes_, magnitudes_ + count - overlap_, overlap_ * sizeof(uint16_t));
 }
 

--- a/apps/orcsdr-tab5/ui/adsb_decoder.cpp
+++ b/apps/orcsdr-tab5/ui/adsb_decoder.cpp
@@ -265,7 +265,9 @@ bool Decoder::self_check() {
          short_reply.icao == 0x4840d6))
     return false;
 
-  uint8_t cu8[246 * 2]{};
+  // process_cu8's frame-search loop needs kFrameSamples + 1 (247) samples
+  // to run a single pass; 246 would leave the buffer one sample short.
+  uint8_t cu8[247 * 2]{};
   for (size_t i = 0; i < sizeof(cu8); i += 2) cu8[i] = cu8[i + 1] = 127;
   for (const size_t index : {size_t{0}, size_t{2}, size_t{7}, size_t{9}})
     cu8[index * 2] = 220;

--- a/apps/orcsdr-tab5/ui/nvs_store.cpp
+++ b/apps/orcsdr-tab5/ui/nvs_store.cpp
@@ -63,13 +63,13 @@ int32_t NvsStore::get_i32(const char* key, int32_t fallback) const { int32_t val
 bool NvsStore::get_bool(const char* key, bool fallback) const { return get_u8(key, fallback ? 1 : 0) != 0; }
 
 bool NvsStore::commit(esp_err_t result) { return open_ && result == ESP_OK && nvs_commit(handle_) == ESP_OK; }
-bool NvsStore::put_bytes(const char* key, const void* value, size_t size) { return key && value && commit(nvs_set_blob(handle_, key, value, size)); }
-bool NvsStore::put_string(const char* key, const char* value) { return key && value && commit(nvs_set_str(handle_, key, value)); }
-bool NvsStore::put_u8(const char* key, uint8_t value) { return key && commit(nvs_set_u8(handle_, key, value)); }
-bool NvsStore::put_u16(const char* key, uint16_t value) { return key && commit(nvs_set_u16(handle_, key, value)); }
-bool NvsStore::put_u32(const char* key, uint32_t value) { return key && commit(nvs_set_u32(handle_, key, value)); }
-bool NvsStore::put_i32(const char* key, int32_t value) { return key && commit(nvs_set_i32(handle_, key, value)); }
+bool NvsStore::put_bytes(const char* key, const void* value, size_t size) { return open_ && key && value && commit(nvs_set_blob(handle_, key, value, size)); }
+bool NvsStore::put_string(const char* key, const char* value) { return open_ && key && value && commit(nvs_set_str(handle_, key, value)); }
+bool NvsStore::put_u8(const char* key, uint8_t value) { return open_ && key && commit(nvs_set_u8(handle_, key, value)); }
+bool NvsStore::put_u16(const char* key, uint16_t value) { return open_ && key && commit(nvs_set_u16(handle_, key, value)); }
+bool NvsStore::put_u32(const char* key, uint32_t value) { return open_ && key && commit(nvs_set_u32(handle_, key, value)); }
+bool NvsStore::put_i32(const char* key, int32_t value) { return open_ && key && commit(nvs_set_i32(handle_, key, value)); }
 bool NvsStore::put_bool(const char* key, bool value) { return put_u8(key, value ? 1 : 0); }
-bool NvsStore::remove(const char* key) { return key && commit(nvs_erase_key(handle_, key)); }
+bool NvsStore::remove(const char* key) { return open_ && key && commit(nvs_erase_key(handle_, key)); }
 
 }  // namespace orcsdr


### PR DESCRIPTION
## Summary
- Fixes an off-by-one in `Decoder::process_cu8` (ADS-B decoder): the frame-search loop bound didn't account for the interpolator's one-sample lookahead, so the last decoded bit near a 32KB IQ block boundary could read stale data from the previous batch instead of fresh samples, silently corrupting/rejecting valid DF17/DF11 frames.
- Guards `NvsStore`'s `put_*`/`remove` helpers on `open_` before issuing `nvs_set_*`/`nvs_erase_key`, matching the getters, so writes through an unopened store consistently no-op instead of calling into an invalid handle.

Found during a full-codebase correctness/security audit of `main` (two multi-agent passes: memory-safety/correctness over `apps/orcsdr-tab5/ui`, and a security review over the tab5 app, c6-bridge, and components). No other issues found — signature verification, HMAC auth, and bounds-checking elsewhere in the decoder/parser paths were confirmed correctly implemented.

## Test plan
- [ ] Build `apps/orcsdr-tab5` firmware and confirm no compile errors
- [ ] Exercise ADS-B decode path (live or recorded IQ capture spanning multiple 32KB blocks) and confirm frame decode rate is unaffected or improved
- [ ] Exercise NVS-backed settings (e.g. Wi-Fi credentials, pairing key) save/load to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ADS-B frame processing to prevent reads beyond available sample data, supporting more reliable decoding across consecutive frames.
  - Added validation to prevent NVS values from being written when the storage handle is not open, avoiding invalid or failed storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->