### PR TITLE
fix(tab5): apply M5GFX page-flip patch after reconfigure

### DIFF
--- a/apps/orcsdr-tab5/tools/build-tab5-idf.ps1
+++ b/apps/orcsdr-tab5/tools/build-tab5-idf.ps1
@@ -8,7 +8,6 @@ $env:PYTHONIOENCODING = 'utf-8'
 $env:IDF_PYTHON_ENV_PATH = 'C:\Espressif\python_env\idf5.5_py3.14_env'
 $env:PATH = "$env:IDF_PYTHON_ENV_PATH\Scripts;$env:PATH"
 . (Join-Path $IdfPath 'export.ps1')
-& (Join-Path $PSScriptRoot 'apply-m5gfx-tab5-pageflip.ps1')
 Set-Location (Join-Path $PSScriptRoot '..')
 $buildDir = 'build-native-hosted3'
 
@@ -19,6 +18,12 @@ Copy-Item -LiteralPath 'sdkconfig.defaults' -Destination (Join-Path $buildDir 's
 idf.py -B $buildDir -D "SDKCONFIG=$buildDir/sdkconfig" `
     -D 'SDKCONFIG_DEFAULTS=sdkconfig.defaults' reconfigure
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+# The component-manager step above fetches (or re-resolves) managed_components/,
+# which can overwrite an already-patched M5GFX checkout. Apply the patch after
+# reconfigure, not before, so a fresh checkout/worktree has something to patch
+# and a stale patch can't be silently dropped by re-resolution.
+& (Join-Path $PSScriptRoot 'apply-m5gfx-tab5-pageflip.ps1')
 
 $required = @(
   'CONFIG_ESP32P4_TAB5_C6_BOARD=y',


### PR DESCRIPTION
## Summary
- `build-tab5-idf.ps1` applied the M5GFX Tab5 page-flip patch *before* `idf.py reconfigure`, so a fresh checkout/worktree with no `managed_components/` yet fails the patch step outright, and even a pre-populated `managed_components/` can be silently overwritten (dropping the patch) by the component-manager reconfigure step that follows.
- Moves the patch application to after `reconfigure`, before `build`, so `managed_components/m5stack__m5gfx` is guaranteed fetched/resolved first.
- Found this while validating the fixes from [PR #37](https://github.com/hardcoreerik/OrcSDR/pull/37) in a brand-new worktree — build failed with `'struct lgfx::v1::Panel_DSI' has no member named 'getPanelHandle'` until this ordering was corrected.

## Test plan
- [x] Clean build (`.\tools\build-tab5-idf.ps1`) from a brand-new git worktree with no pre-existing `managed_components/` — succeeded, patch present in `managed_components/m5stack__m5gfx/.../Panel_DSI.hpp` (`getPanelHandle`/`getFrameBuffer` methods), `orcsdr_tab5.bin` produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the build process so the M5GFX page-flip patch is preserved after project reconfiguration.
  * Prevented component resolution from overwriting the applied display patch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->