### PR TITLE
docs: de-specialize COM17 in ENVIRONMENT.md

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -48,13 +48,16 @@ fully fetched, then apply the patch
 ### Flash
 
 ```powershell
-idf.py -p COM17 flash
+idf.py -p <PORT> flash
 ```
 
-Only after explicit hardware authorization. `COM17` is the current bench
-assignment for the Tab5's native USB Serial/JTAG connection — always pass
-it explicitly; do not rely on port auto-detection, which can select a
-different attached device. See
+Only after explicit hardware authorization. `<PORT>` is whatever serial
+port the Tab5's native USB Serial/JTAG connection enumerates as on your
+machine (e.g. `COM17` on Windows, `/dev/ttyACM0` on Linux) — it's
+machine-specific, not a fixed value, and can change if other USB serial
+devices are plugged in. Always pass it explicitly; do not rely on port
+auto-detection, which can select a different attached device if more than
+one is present. See
 [`apps/orcsdr-tab5/README.md`](apps/orcsdr-tab5/README.md) for file-transfer
 and splash-asset details.
 

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -57,7 +57,13 @@ machine (e.g. `COM17` on Windows, `/dev/ttyACM0` on Linux) — it's
 machine-specific, not a fixed value, and can change if other USB serial
 devices are plugged in. Always pass it explicitly; do not rely on port
 auto-detection, which can select a different attached device if more than
-one is present. See
+one is present.
+
+If you keep a fixed bench assignment, record it in a local, gitignored
+file (e.g. `.local/dev-environment.local.md`, under the existing
+`.local/` gitignore rule) rather than here — this file is read by
+contributors and coding agents on every machine, so it must stay
+machine-agnostic. See
 [`apps/orcsdr-tab5/README.md`](apps/orcsdr-tab5/README.md) for file-transfer
 and splash-asset details.
 

--- a/apps/orcsdr-tab5/README.md
+++ b/apps/orcsdr-tab5/README.md
@@ -55,7 +55,7 @@ from UI features alone.
 cd apps/orcsdr-tab5
 .\tools\build-tab5-idf.ps1
 # After explicit hardware authorization:
-idf.py -p COM17 flash
+idf.py -p <PORT> flash
 ```
 
 This is a native ESP-IDF 5.5.4 build. M5Unified 0.2.20 and M5GFX 0.2.27 are


### PR DESCRIPTION
## Summary
- `ENVIRONMENT.md`'s flash instructions hardcoded `COM17`, which is a bench-specific serial port assignment, not a general fact about the Tab5. Replaced with a `<PORT>` placeholder and a note on how the actual port varies by machine/OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated flashing instructions to use a machine-independent serial port placeholder.
  * Added examples for Windows and Linux port formats.
  * Clarified that port assignments may change and should be recorded in local, ignored documentation rather than shared project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->