### PR TITLE
fix(tab5): resolve confirmed Qodo findings

### DIFF
--- a/apps/orcsdr-tab5/tools/apply-m5gfx-tab5-pageflip.ps1
+++ b/apps/orcsdr-tab5/tools/apply-m5gfx-tab5-pageflip.ps1
@@ -4,14 +4,14 @@ $patch = Join-Path $PSScriptRoot 'patches\m5gfx-tab5-pageflip.patch'
 $repoRoot = (& git -C $appRoot rev-parse --show-toplevel).Trim()
 $appRelative = [IO.Path]::GetRelativePath($repoRoot, $appRoot).Replace('\', '/')
 
-& git -C $repoRoot apply --check --ignore-space-change --unidiff-zero --directory=$appRelative -- $patch 2>$null
+& git -C $repoRoot apply --check --directory=$appRelative -- $patch 2>$null
 if ($LASTEXITCODE -eq 0) {
-  & git -C $repoRoot apply --ignore-space-change --unidiff-zero --whitespace=nowarn --directory=$appRelative -- $patch
+  & git -C $repoRoot apply --directory=$appRelative -- $patch
   if ($LASTEXITCODE -ne 0) { throw 'Unable to apply the M5GFX Tab5 page-flip patch.' }
   exit 0
 }
 
-& git -C $repoRoot apply --reverse --check --ignore-space-change --unidiff-zero --directory=$appRelative -- $patch 2>$null
+& git -C $repoRoot apply --reverse --check --directory=$appRelative -- $patch 2>$null
 if ($LASTEXITCODE -ne 0) {
   throw 'The installed M5GFX component does not match the Tab5 page-flip patch.'
 }

--- a/apps/orcsdr-tab5/tools/patches/m5gfx-tab5-pageflip.patch
+++ b/apps/orcsdr-tab5/tools/patches/m5gfx-tab5-pageflip.patch
@@ -1,21 +1,43 @@
 diff --git a/managed_components/m5stack__m5gfx/src/lgfx/v1/platforms/esp32p4/Panel_DSI.hpp b/managed_components/m5stack__m5gfx/src/lgfx/v1/platforms/esp32p4/Panel_DSI.hpp
 --- a/managed_components/m5stack__m5gfx/src/lgfx/v1/platforms/esp32p4/Panel_DSI.hpp
 +++ b/managed_components/m5stack__m5gfx/src/lgfx/v1/platforms/esp32p4/Panel_DSI.hpp
-@@ -60,2 +60,4 @@
+@@ -58,7 +58,9 @@
+     color_depth_t setColorDepth(color_depth_t depth) override;
+ 
      const config_detail_t& config_detail(void) const { return _config_detail; }
      void config_detail(const config_detail_t& config_detail) { _config_detail = config_detail; };
 +    esp_lcd_panel_handle_t getPanelHandle(void) const { return _disp_panel_handle; }
 +    void* getFrameBuffer(size_t index) const { return index < 2 ? _frame_buffers[index] : nullptr; }
-@@ -98 +100,2 @@
+ 
+     void setInvert(bool invert) override;
+     void setSleep(bool flg_sleep) override;
+@@ -94,5 +96,6 @@
+ 
+     config_detail_t _config_detail;
+ 
      esp_lcd_panel_handle_t _disp_panel_handle = nullptr;
 +    void* _frame_buffers[2] = {};
+   };
 diff --git a/managed_components/m5stack__m5gfx/src/lgfx/v1/platforms/esp32p4/Panel_DSI.cpp b/managed_components/m5stack__m5gfx/src/lgfx/v1/platforms/esp32p4/Panel_DSI.cpp
 --- a/managed_components/m5stack__m5gfx/src/lgfx/v1/platforms/esp32p4/Panel_DSI.cpp
 +++ b/managed_components/m5stack__m5gfx/src/lgfx/v1/platforms/esp32p4/Panel_DSI.cpp
-@@ -85 +85 @@
+@@ -79,7 +79,7 @@
+   #else
+     dpi_config.pixel_format = LCD_COLOR_PIXEL_FORMAT_RGB565;
+   #endif
 -    dpi_config.num_fbs = 1;
 +    dpi_config.num_fbs = 2;
-@@ -127 +127,2 @@
+     dpi_config.video_timing.h_size = _cfg.panel_width;
+     dpi_config.video_timing.v_size = _cfg.panel_height;
+     dpi_config.video_timing.hsync_back_porch  = _config_detail.hsync_back_porch;
+@@ -124,7 +124,8 @@
+     auto bus = getBusDSI();
+     if (bus == nullptr) { return false; }
+     if (init_dpi(bus) && init_panel())
+     {
 -        esp_lcd_dpi_panel_get_frame_buffer(_disp_panel_handle, 1, &(_config_detail.buffer));
 +        esp_lcd_dpi_panel_get_frame_buffer(_disp_panel_handle, 2, _frame_buffers, _frame_buffers + 1);
 +        _config_detail.buffer = _frame_buffers[0];
+     }
+ 
+     auto ptr = (uint8_t*)_config_detail.buffer;

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -3020,7 +3020,10 @@ bool lookup_adsb_metadata(uint32_t icao, AdsbIndexRecord* result) {
     if (result->icao < icao) low = middle + 1;
     else high = middle;
   }
-  const bool found = low < header.record_count && result->icao == icao;
+  const bool found = low < header.record_count &&
+                     file.seek(sizeof(header) + low * sizeof(AdsbIndexRecord)) &&
+                     file.read(reinterpret_cast<uint8_t*>(result), sizeof(*result)) == sizeof(*result) &&
+                     result->icao == icao;
   file.close();
   return found;
 }

--- a/apps/orcsdr-tab5/ui/settings_app.cpp
+++ b/apps/orcsdr-tab5/ui/settings_app.cpp
@@ -470,19 +470,28 @@ Action handle_wifi_keyboard(int x, int y) {
   return {};
 }
 
+bool accept_location_query();
+
 Action handle_location_keyboard(int x, int y) {
   const auto result = text_editor::handle_touch(x, y);
   strlcpy(g_location_query, text_editor::value(), sizeof(g_location_query));
   if (result == text_editor::Result::cancelled) {
     g_location_edit = false;
     draw_content();
-  } else if (result == text_editor::Result::accepted && g_location_query[0]) {
-    g_location_edit = false;
-    g_location_request_pending = true;
+  } else if (result == text_editor::Result::accepted) {
+    const bool queued = accept_location_query();
     draw_content();
+    if (!queued) return {};
     return {ActionKind::location_query_lookup, 0};
   }
   return {};
+}
+
+bool accept_location_query() {
+  g_location_edit = false;
+  if (!g_location_query[0]) return false;
+  g_location_request_pending = true;
+  return true;
 }
 
 bool valid_coordinate(EditField field, double value) {
@@ -851,12 +860,24 @@ bool self_check() {
                               strcmp(password, "not-a-real-password") == 0 &&
                               g_wifi_request_password[0] == '\0';
   memset(password, 0, sizeof(password));
+  const bool saved_location_edit = g_location_edit;
+  const bool saved_location_pending = g_location_request_pending;
+  char saved_location_query[sizeof(g_location_query)]{};
+  strlcpy(saved_location_query, g_location_query, sizeof(saved_location_query));
+  g_location_edit = true;
+  g_location_request_pending = false;
+  g_location_query[0] = '\0';
+  const bool empty_location_ok = !accept_location_query() && !g_location_edit &&
+                                 !g_location_request_pending;
   strlcpy(g_location_query, "97401", sizeof(g_location_query));
-  g_location_request_pending = true;
+  const bool location_queued = accept_location_query();
   char query[64]{};
-  const bool location_ok = take_location_query(query, sizeof(query)) &&
+  const bool location_ok = location_queued && take_location_query(query, sizeof(query)) &&
                            strcmp(query, "97401") == 0;
-  if (!symbols_ok || !credentials_ok || !location_ok) return false;
+  g_location_edit = saved_location_edit;
+  g_location_request_pending = saved_location_pending;
+  strlcpy(g_location_query, saved_location_query, sizeof(g_location_query));
+  if (!symbols_ok || !credentials_ok || !empty_location_ok || !location_ok) return false;
   return true;
 }
 


### PR DESCRIPTION
## Summary
- reread the final ADS-B binary-search record before comparing ICAO
- close an empty accepted location editor without queuing a lookup
- require strict contextual application of the M5GFX page-flip patch

## Verification
- established native ESP-IDF build (uild-tab5-idf.ps1) completed and produced orcsdr_tab5.elf / orcsdr_tab5.bin`n- strict reverse patch check passed against the installed M5GFX component
- focused settings self-check covers empty and populated location submission

No hardware flash or device acceptance was performed for this source/build PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved display rendering with smoother frame updates through double buffering.
  - Added more reliable location search handling, including validation of empty and non-empty queries.

- **Bug Fixes**
  - Fixed aircraft metadata lookups to verify results against the correctly matched record.
  - Improved handling of failed data reads during metadata searches.
  - Patch application now enforces stricter whitespace and context matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->