### PR TITLE
fix(tab5): tolerate M5GFX line endings

### DIFF
--- a/apps/orcsdr-tab5/tools/apply-m5gfx-tab5-pageflip.ps1
+++ b/apps/orcsdr-tab5/tools/apply-m5gfx-tab5-pageflip.ps1
@@ -4,14 +4,14 @@ $patch = Join-Path $PSScriptRoot 'patches\m5gfx-tab5-pageflip.patch'
 $repoRoot = (& git -C $appRoot rev-parse --show-toplevel).Trim()
 $appRelative = [IO.Path]::GetRelativePath($repoRoot, $appRoot).Replace('\', '/')
 
-& git -C $repoRoot apply --check --directory=$appRelative -- $patch 2>$null
+& git -C $repoRoot apply --check --ignore-space-change --directory=$appRelative -- $patch 2>$null
 if ($LASTEXITCODE -eq 0) {
-  & git -C $repoRoot apply --directory=$appRelative -- $patch
+  & git -C $repoRoot apply --ignore-space-change --directory=$appRelative -- $patch
   if ($LASTEXITCODE -ne 0) { throw 'Unable to apply the M5GFX Tab5 page-flip patch.' }
   exit 0
 }
 
-& git -C $repoRoot apply --reverse --check --directory=$appRelative -- $patch 2>$null
+& git -C $repoRoot apply --reverse --check --ignore-space-change --directory=$appRelative -- $patch 2>$null
 if ($LASTEXITCODE -ne 0) {
   throw 'The installed M5GFX component does not match the Tab5 page-flip patch.'
 }


### PR DESCRIPTION
## Summary
Restore whitespace-only tolerance when applying the contextual M5GFX page-flip patch on Windows. The patch remains context-validated and no longer uses zero-context application.

## Verification
- fresh established native ESP-IDF build completed
- produced orcsdr_tab5.elf and orcsdr_tab5.bin`n- verified against the freshly resolved managed M5GFX component