### PR TITLE
docs: polish OrcSDR public beta onboarding and discoverability

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a reproducible OrcSDR problem
+title: "bug: "
+labels: bug
+---
+
+## Environment
+
+- OrcSDR version:
+- Tab5 hardware:
+- RTL-SDR hardware:
+- P4 ESP-Hosted version:
+- C6 ESP-Hosted version:
+- Dashboard or mode:
+- Frequency, if relevant:
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+## Actual behavior
+
+## Evidence
+
+Attach non-sensitive screenshots or logs if they help. Please do not include Wi-Fi passwords, private network details, or location information you do not want to share.

--- a/README.md
+++ b/README.md
@@ -538,7 +538,14 @@ cd OrcSDR
 git pull
 ```
 
-For the public prerelease, use [`v0.2.0-beta.1`](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.1). The historical [`v0.2.0-alpha.5`](docs/releases/v0.2.0-alpha.5.md) record remains available for its original 2.12.6-era hardware context.
+For the public prerelease, check out [`v0.2.0-beta.1`](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.1) before building:
+
+```bash
+git fetch --tags
+git checkout v0.2.0-beta.1
+```
+
+The historical [`v0.2.0-alpha.5`](docs/releases/v0.2.0-alpha.5.md) record remains available for its original 2.12.6-era hardware context.
 
 ### 2. Find the Tab5 port
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <strong>RTL-SDR Blog V4 → USB High-Speed → ESP32-P4 → DSP + Touch UI + Audio</strong>
 </p>
 
-**OrcSDR is a self-contained radio you hold in your hands.** Plug an RTL-SDR Blog V4 into a M5Stack Tab5, flash this firmware, and the tablet becomes the radio: live spectrum, waterfall, speaker audio, FM with RDS, P25 trunking, ADS-B, and a passive LoRa mesh monitor. There is no Raspberry Pi in the bag, no laptop running SDR#, and no desktop app you have to keep open.
+**OrcSDR is a self-contained radio you hold in your hands.** Plug an RTL-SDR Blog V4 into a M5Stack Tab5, flash this firmware, and the tablet becomes the radio: live spectrum, waterfall, speaker audio, FM with RDS, P25 trunking, ADS-B, passive LoRa mesh monitoring, RF Lab tools, and 2.4 GHz Wi-Fi Analysis. There is no Raspberry Pi in the bag, no laptop running SDR#, and no desktop app you have to keep open.
 
 <p align="center">
   <img src="docs/images/OrcSDR-Main.png"
@@ -16,10 +16,31 @@
        width="100%">
 </p>
 
+> [!NOTE]
+> **Public beta — [v0.2.0-beta.1](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.1)**
+>
+> OrcSDR is available now for the M5Stack Tab5. It is a prerelease: feedback and [bug reports](https://github.com/hardcoreerik/OrcSDR/issues) are welcome.
+
+<a id="install"></a>
+
+## 🔥 Easiest Install — M5Burner
+
+**Minimum hardware:** an **M5Stack Tab5** and an **RTL-SDR Blog V4**. An antenna is needed for the signals you want to receive; an SD card is optional.
+
+1. Open **M5Burner** and search for **OrcSDR**.
+2. Flash **OrcSDR** to the Tab5 without erase.
+3. Boot OrcSDR, then open **Settings → Firmware & Updates**.
+4. If the reachable internal C6 Wi-Fi coprocessor differs from ESP-Hosted 3.0.6, explicitly confirm the offered C6 update.
+5. After restart, verify that the P4 host and C6 coprocessor both report 3.0.6.
+
+M5Burner writes the Tab5 P4 application. OrcSDR performs the separate, explicit in-app C6 update only after it can reach the Hosted transport. Normal upgrades preserve OrcSDR settings and saved Wi-Fi profiles. If the C6 is unreachable, do not keep retrying the in-app updater; use the [documented recovery path](docs/M5BURNER_RELEASE.md).
+
+For developer/source installation, use **native ESP-IDF 5.5.4**. The source-build path remains below and is not the normal user install path.
+
 You power it on, wait for the splash to finish loading Wi-Fi and the dongle, tap **OrcSDR**, and land on Home. Home remembers the last radio you used. The spectrum and waterfall keep drawing while you listen. From there you open a dedicated dashboard for the kind of signal you actually care about, instead of one crowded “everything radio” screen.
 
 <p align="center">
-  <a href="#-flash-orcsdr-to-the-m5stack-tab5"><strong>Flash it</strong></a>
+  <a href="#install"><strong>Install</strong></a>
   &nbsp;•&nbsp;
   <a href="#the-dashboards"><strong>Dashboards</strong></a>
   &nbsp;•&nbsp;
@@ -27,11 +48,6 @@ You power it on, wait for the splash to finish loading Wi-Fi and the dongle, tap
   &nbsp;•&nbsp;
   <a href="#the-orc-ecosystem"><strong>Orc ecosystem</strong></a>
 </p>
-
-> [!IMPORTANT]
-> **Have a M5Stack Tab5 and an RTL-SDR Blog V4?**
->
-> Jump to **[Flash OrcSDR to the M5Stack Tab5](#-flash-orcsdr-to-the-m5stack-tab5)** and run it on hardware. The screenshots on this page are from that firmware.
 
 > [!NOTE]
 > **Project status:** OrcSDR is under active development. The Tab5 app is the reference radio and builds with **native ESP-IDF 5.5.4**. M5Unified and M5GFX are ESP-IDF components only; PlatformIO is not a supported build or flash path. See [the Tab5 ESP-Hosted migration record](docs/user-guide/tab5-esp-hosted-3-migration.md) and the [reusable Tab5 Wi-Fi guide](docs/user-guide/wifi-tab5.md) for the P4/C6 pairing, pins, and acceptance status.
@@ -91,6 +107,8 @@ Quick map:
 | **[P25 Trunking](#p25-trunking)** | Follow a programmed P25 system on a single tuner |
 | **[ADS-B](#ads-b)** | 1090 MHz aircraft radar, list, and target detail |
 | **[LoRa Mesh](#lora-mesh)** | Passive Meshtastic receive monitor |
+| **[RF Lab](#rf-lab)** | Live receiver test bench, measurements, and session records |
+| **[2.4 GHz Analyzer](#24-ghz-analyzer)** | Nearby Wi-Fi access-point survey using the Tab5 internal C6 |
 | **[Settings](#settings)** | Wi-Fi, location, display, radio defaults, storage, companion |
 
 ---
@@ -377,6 +395,20 @@ LoRa health shows frequency, region (US 902–928), whether the monitor is runni
 
 ---
 
+### RF Lab
+
+RF Lab is the live receiver test bench. Its **Live** page shows the shared receiver spectrum and waterfall; **Controls** exposes supported receiver settings such as retuning, sample rate, PPM correction, gain, AGC, and bias-tee state; **Measurements** can capture snapshots or timed runs; and **Records** lists completed sessions saved to SD storage. It reports capability limits rather than pretending unsupported hardware controls are available.
+
+---
+
+### 2.4 GHz Analyzer
+
+The **2.4 GHz Analyzer** uses the Tab5's internal ESP32-C6 through ESP-Hosted 3.0.6 to survey nearby Wi-Fi access points. Start or manually repeat a scan to view observed SSIDs, shortened BSSIDs, primary channel, RSSI, security, PHY/width, and scan age. The channel view draws scan-derived AP channel footprints: it is not an RF-power, airtime, packet-rate, or occupancy measurement.
+
+The Devices page means **observed access points**, not clients or stations. CSI is explicitly unavailable in this release; no motion, presence, room-radar, or CSI measurements are claimed. Wi-Fi power, saved profiles, and antenna selection remain in **Settings → Connectivity**.
+
+---
+
 ### Settings
 
 Settings is the device, not a radio. Open it from Home when you want Wi-Fi, a receiver location, brightness, or to see whether the SD card is healthy. Radio audio keeps going while you are in here.
@@ -392,6 +424,10 @@ The Settings captures below were taken in a sanitized **DEMO** profile (placehol
 </p>
 
 This is how the Tab5 gets on a network. Scan, add a hidden SSID, power the radio off, pick the Wi-Fi antenna (external MMCX on the Tab5), and manage a priority list of saved networks. OrcSDR does not need Wi-Fi to listen to FM. Wi-Fi is for maps packs, companion pages, and anything that talks to the LAN.
+
+#### Firmware & Updates
+
+This page shows the P4 host version, reachable C6 version, and embedded ESP-Hosted target. It offers a C6 update only when the Hosted transport is reachable and the versions differ; the update always requires confirmation. See [the M5Burner release guide](docs/M5BURNER_RELEASE.md) for normal installation and recovery boundaries.
 
 #### Location & ADS-B
 
@@ -465,24 +501,23 @@ Battery rail and charge, USB / VBUS, build identity, uptime, network, SD. Reboot
 
 <p align="center">
   <strong>Ready to run this on a Tab5?</strong><br>
-  <a href="#-flash-orcsdr-to-the-m5stack-tab5">Flash OrcSDR →</a>
+  <a href="#install">Install OrcSDR →</a>
 </p>
 
 ---
 
-# 🚀 Flash OrcSDR to the M5Stack Tab5
+# 🛠️ Developer/source installation
 
 > [!IMPORTANT]
-> **Fastest path to running OrcSDR on real hardware**
+> **Normal users should use M5Burner above.**
 >
-> Reference hardware: **M5Stack Tab5 + RTL-SDR Blog V4**
+> This section is for native ESP-IDF source builds on the reference hardware: **M5Stack Tab5 + RTL-SDR Blog V4**.
 
 ### Requirements
 
 - **M5Stack Tab5**
 - **RTL-SDR Blog V4**
 - **Espressif ESP-IDF 5.5.4 for Windows**
-- **ESP-Hosted 3.0.6 C6 firmware** for the Tab5 C6
 - USB cable for flashing the Tab5
 - USB connection from the Tab5 USB Host port to the RTL-SDR
 - Antenna appropriate for what you want to receive
@@ -503,7 +538,7 @@ cd OrcSDR
 git pull
 ```
 
-A tagged hardware-testing snapshot lives at `v0.2.0-alpha.5` if you want a known cut instead of `main`. See [`docs/releases/v0.2.0-alpha.5.md`](docs/releases/v0.2.0-alpha.5.md).
+For the public prerelease, use [`v0.2.0-beta.1`](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.1). The historical [`v0.2.0-alpha.5`](docs/releases/v0.2.0-alpha.5.md) record remains available for its original 2.12.6-era hardware context.
 
 ### 2. Find the Tab5 port
 
@@ -727,6 +762,8 @@ Each project is useful on its own. The larger direction is devices that can comm
 ## Contributing
 
 Contributions are welcome in USB Host, DSP, spectrum/waterfall, radio UI, hardware testing, USB traces, V4 behavior documentation, radio modes, test tooling, and docs.
+
+**Found a bug?** OrcSDR is a public beta. Please [open an issue](https://github.com/hardcoreerik/OrcSDR/issues/new?template=bug_report.md) with the OrcSDR version, P4/C6 ESP-Hosted versions, Tab5 and RTL-SDR hardware, dashboard or mode, frequency when relevant, steps to reproduce, and any non-sensitive screenshots or logs.
 
 When contributing to the RTL-SDR V4 driver, preserve the clean-room rules and document the source of any device behavior or measurements.
 

--- a/docs/M5BURNER_HARDWARE_GATE.md
+++ b/docs/M5BURNER_HARDWARE_GATE.md
@@ -1,7 +1,8 @@
 # M5Burner hardware acceptance gate
 
-This is the release gate for an exact `v0.2.0-beta.1` tag. Build or package
-validation alone does not authorize a GitHub prerelease or public listing.
+This was the release gate for the public `v0.2.0-beta.1` prerelease. Reuse the
+same gate for a future exact tag: build or package validation alone does not
+authorize a GitHub prerelease or public listing.
 
 1. Build the bundle and record its `M5BURNER_BUNDLE_OK` line, source commit,
    C6 provenance, and hashes.
@@ -19,5 +20,5 @@ validation alone does not authorize a GitHub prerelease or public listing.
    recovery guidance when Hosted cannot form a link.
 
 Attach photos/screenshots and serial evidence to the tag record. Only then
-attach the verified artifacts to the GitHub prerelease and change the M5Burner
-listing from private to public.
+attach the verified artifacts to that GitHub prerelease and change its
+M5Burner listing from private to public.

--- a/docs/M5BURNER_HARDWARE_GATE.md
+++ b/docs/M5BURNER_HARDWARE_GATE.md
@@ -20,5 +20,5 @@ authorize a GitHub prerelease or public listing.
    recovery guidance when Hosted cannot form a link.
 
 Attach photos/screenshots and serial evidence to the tag record. Only then
-attach the verified artifacts to that GitHub prerelease and change its
+create the GitHub prerelease with the verified artifacts and change its
 M5Burner listing from private to public.

--- a/docs/M5BURNER_RELEASE.md
+++ b/docs/M5BURNER_RELEASE.md
@@ -29,10 +29,12 @@ The build pins the Espressif ESP-Hosted 3.0.6 source revision, emits C6
 provenance and SHA-256, and produces the one M5Burner upload bundle plus a
 local test zip. It never flashes hardware or uploads a listing.
 
-## Publication gate
+## Publication record and future-release gate
 
-Use **USER CUSTOM → Publish** for the one package, keep the listing private,
-and test using its Share Code. Only after the exact-tag hardware gate in
-[M5BURNER_HARDWARE_GATE.md](M5BURNER_HARDWARE_GATE.md) passes may the GitHub
-prerelease be created and the listing made public. M5Burner publishing
-details are in the [official guide](https://docs.m5stack.com/en/uiflow/m5burner/publish).
+`v0.2.0-beta.1` is publicly available through M5Burner and as a [GitHub
+prerelease](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.1).
+For a future release, use **USER CUSTOM → Publish** privately first and test
+with its Share Code. Only after the exact-tag hardware gate in
+[M5BURNER_HARDWARE_GATE.md](M5BURNER_HARDWARE_GATE.md) passes may its GitHub
+prerelease be created and its listing made public. M5Burner publishing details
+are in the [official guide](https://docs.m5stack.com/en/uiflow/m5burner/publish).

--- a/docs/releases/v0.2.0-beta.1.md
+++ b/docs/releases/v0.2.0-beta.1.md
@@ -5,6 +5,7 @@ application and a pinned C6 Hosted 3.0.6 image. When a reachable C6 is older,
 Firmware & Updates presents an explicit in-app confirmation; normal upgrades
 do not erase P4 NVS.
 
-The public release is blocked until private M5Burner hardware acceptance has
-recorded exact-tag P4/C6 match, Home/FM/RTL-SDR/Wi-Fi/RF24 behavior, and the
-Windows installer safeguards.
+This public prerelease was published after private M5Burner hardware acceptance
+of the exact-tag P4/C6 match, Home/FM/RTL-SDR/Wi-Fi/RF24 behavior, and the
+Windows installer safeguards. The detailed, reusable gate remains in
+[M5BURNER_HARDWARE_GATE.md](../M5BURNER_HARDWARE_GATE.md).


### PR DESCRIPTION
## Summary
- promotes M5Burner as the normal Tab5 installation path and adds the public `v0.2.0-beta.1` callout
- updates the current dashboard map and documents shipped RF Lab and 2.4 GHz Analyzer capabilities conservatively
- clarifies minimum hardware, the developer/source-build path, and public-beta feedback reporting
- updates M5Burner gate/release docs to reflect the public beta and adds a focused bug-report template
- refreshes repository description and topics (outside this Git diff)

## Validation
- `python tools/validate-help-docs.py`
- focused Markdown local-link check for every changed Markdown file
- `git diff --cached --check`

No firmware, version, tag, ESP-Hosted architecture, or M5GFX/M5Unified/ESP-IDF configuration changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated release documentation for v0.2.0-beta.1, including public availability through M5Burner and GitHub.
  - Added installation guidance, including M5Burner setup and C6 firmware update instructions.
  - Expanded product navigation and quick-reference content with RF Lab tools and 2.4 GHz Wi‑Fi Analysis.
  - Added Firmware & Updates guidance and updated developer installation instructions.
  - Documented the reusable hardware acceptance and future-release publishing process.

- **Chores**
  - Added a structured bug report template to help collect environment details, reproduction steps, expected and actual behavior, and supporting evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->