### PR TITLE
docs: reconcile architecture and board validation records

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,8 +1,12 @@
 # OrcSDR project status
 
-Snapshot date: **2026-08-27**
-Source branch: **`codex/esp-rtl-sdr-v0.7.9`**
-Mainline baseline: **`origin/main` at `fc30c1030f26c8dd034d65917ec50e6880b7a871`**
+Hardware snapshot date: **2026-08-27**
+Historical snapshot branch: **`codex/esp-rtl-sdr-v0.7.9`**
+Historical mainline baseline: **`fc30c1030f26c8dd034d65917ec50e6880b7a871`**
+Documentation/source review: **2026-09-03**, against `main` at **`3eb67fb`**.
+
+This review reconciles driver/board provenance and current source boundaries;
+it does not rerun hardware acceptance or refresh every historical measurement.
 
 This is the authoritative current-status and roadmap index. Historical design,
 research, and validation documents remain useful evidence, but do not override
@@ -15,6 +19,7 @@ this file when their paths, versions, or completion claims differ.
 | **Hardware-verified** | Observed on the named physical device and recorded |
 | **Build-verified** | Compiled or validated from repository artifacts, without a hardware claim |
 | **Implemented** | Present in source; current hardware acceptance may still be pending |
+| **Recorded upstream** | Prior operation documented in the driver repository; not a new local hardware run or proof of every later release gate |
 | **Planned** | Accepted roadmap work, not implemented |
 | **Deferred** | Intentionally outside the current milestone |
 
@@ -31,7 +36,7 @@ this file when their paths, versions, or completion claims differ.
 | Tab5 radio shell | **Implemented** | FM/AM/WX/CB/LoRa, radio/scope/capture tabs, sound/GFX toggles |
 | Screen ownership controller | **Hardware-verified** | `ScreenController` is the sole display-route owner for Home, FM, P25, ADS-B, LoRa, generic Radio/Scope/Capture, Settings, and documentation mode. The Tab5 transition check passed after the final UI-loop handoff; documentation capture now claims and restores its controller identity. |
 | CB channel dashboard | **Flashed; operator acceptance pending** | 40-channel AM/USB/LSB plan, 2/3 scope, touch channel dial, clarifier, squelch, live S/RF bar |
-| LoRa/Meshtastic receive path | **Flashed; live RF acceptance pending** | 250 ms pre-roll, adaptive 9 dB energy trigger, verified SD bridge, and dashboard message return; synthetic full-chain and COM17 protocol checks pass |
+| LoRa/Meshtastic receive path | **Native implementation present; historical hardware evidence not refreshed here** | `lora_native_decoder` performs capture decoding and feeds the dashboard; the serial `LORA_PACKET` bridge remains separate. The earlier snapshot recorded flashed 250 ms pre-roll, adaptive 9 dB energy capture, SD bridge, and synthetic/COM17 checks, with live-RF acceptance pending. Source review does not refresh that hardware verdict. |
 | SDR navigation | **Implemented; Home-first migration in progress** | Full 24–1766 MHz tune range, US band/use guide, direct entry, pinch, peak find, and FM auto tune. The legacy Browse surface is retired from user navigation; Home is the interim workspace for bands without a dedicated dashboard. |
 | Browse demodulation | **Partial** | NFM spectrum/listen path; AM/SSB/digital mode selection and sub-24 MHz direct sampling remain open |
 | Variant-4 splash | **Implemented on this branch** | Looping SD asset playback and static ready/button overlay |
@@ -45,7 +50,7 @@ this file when their paths, versions, or completion claims differ.
 | Live speaker versus recorded PCM | **Open performance gate** | Recorder taps PCM immediately before `playRaw`; clean WAVs plus poor live sound isolate the remaining fault to speaker queue/DMA/output after the DSP tap |
 | Paired FM IQ/WAV DSP lab | **Planned** | Buffer synchronized raw CU8 IQ, post-DSP PCM, and metadata in PSRAM; write after capture and evaluate filter variants offline |
 | AM/HF fidelity | **Experimental** | Do not claim calibrated HF/direct-sampling support |
-| Second ESP32-P4 board | **Planned** | No second-board hardware evidence yet |
+| Second ESP32-P4 board | **Recorded upstream** | Waveshare Module-DEV-KIT operation under OrcSDR is documented by the driver project; [PORTING.md](docs/PORTING.md#existing-implementation-and-evidence) links the provenance and FM application notes. Exact-version soak/recovery acceptance remains separate. |
 | rtl_tcp over Ethernet | **Planned** | App does not exist yet |
 | ADS-B 1090 | **Flashed — live pipeline implemented; acceptance pending** | COM17 upload hash-verified. Five-minute 1090 MHz run sustained 2,047,654 S/s (99.98% of 2.048 MS/s) with five startup drops and none afterward. A live RF trace reconstructed to CRC-valid DF17 `8DA2955158B505036BFB54BC90AC` (ICAO `A29551`, 35,000 ft), matching ASA1310's simultaneous independent track; the same captured magnitude waveform now passes the on-device fractional-sample replay check. The bounded aircraft table and revisioned dashboard snapshot are flashed. Dynamic updates no longer clear the full screen each second. A 315,547-record FAA index and the complete supplied FAA archive are SD hash-verified; live ICAO `A31111` resolved to `N297SF`. The UI honestly remains `DEMO` until a new on-device live frame passes CRC; physical view/touch acceptance remains open. |
 | User guide and media pipeline | **Build-verified** | Native build plus 44-screen manifest, capture tooling, strict MkDocs site, and local narrated-video scripts. Hardware captures, privacy review, voice approval, and rendered media remain pending. |
@@ -91,12 +96,15 @@ paired IQ/WAV dataset that can drive FM filter decisions without tuning by ear.
       zero fatal USB errors.
 - [ ] Unplug/replug during streaming and recover to Ready without reboot.
 - [ ] Record retune settle time and recovery behavior after a failed retune.
-- [x] Remove the legacy in-app USB path after the v0.7.9 integration soak passed.
+- [x] Retire the legacy in-app USB path: enabling it is a compile-time error; `esp_rtl_sdr` is the only live implementation.
+- [ ] Delete the remaining disabled legacy source blocks in a separate code change.
 - [x] Move standalone smoke ownership to the `esp-rtl-sdr` repository.
-- [ ] Repeat the driver gate on one other ESP32-P4 board.
+- [x] Record existing Waveshare second-board operation with upstream provenance.
+- [ ] Attach exact-version sustained-rate and unplug/replug evidence for the boards covered by a release; prior operation alone does not close these gates.
 
-Exit: portable driver behavior is measured on two P4 boards and the Tab5 app has
-no duplicate USB implementation.
+Exit: release-specific driver acceptance is recorded for both P4 boards and
+the Tab5 app has no remaining duplicate USB implementation. Prior Waveshare
+operation is already recorded; disabled legacy code still needs deletion.
 
 ### P2 — network transport
 
@@ -206,7 +214,7 @@ Set-Location F:\Ai\OrcSDR\apps\orcsdr-tab5
 Required runtime lines for the next performance record:
 
 ```text
-RTL_INSTALL ok v0.4.1 ...
+RTL_INSTALL ok v0.7.9 ...
 RTL_CORE_SPLIT usb=core0 iq_demod+ui=core1 ...
 RTL_SPECTRUM_FPS fps=... audio_dropped=... audio_chunks=...
                     dsp_load_pct=... dsp_blocks=... dsp_block_us_max=...
@@ -221,11 +229,11 @@ SPLASH_FPS ...
 | `architecture.md` | Implemented runtime ownership, ScreenController contract, and dashboard drawing boundary |
 | `docs/IMPLEMENTATION_FROM_PEER_RESEARCH.md` | Detailed workstreams and design rationale |
 | `docs/PORTING.md` | Driver extraction and target gates |
-| `docs/API_RTL_SDR_V4_ESP.md` | Public API contract |
+| `docs/API_ESP_RTL_SDR.md` | Pinned driver integration contract; complete public API maintained upstream |
 | `docs/API_SERIAL_CLI.md` | Tab5 serial CLI — tuning, telemetry, RDS status, presets, file transfer |
 | `docs/M5TAB5_VALIDATION_REPORT.md` | Historical hardware evidence |
 | `docs/GATE2_IMPLEMENTATION_LOCK.md` | Historical Gate-2 handoff snapshot |
 | `docs/OrcSDR_Splash_README.md` | Splash asset and playback contract |
 | `docs/cb/README.md` | CB channel, sideband, clarifier, squelch, and asset controls |
-| `docs/lora/README.md` | LoRa IQ capture and Meshtastic host-decoder workflow |
+| `docs/lora/README.md` | Native LoRa capture/decoder boundary and serial regression bridge |
 | `docs/FM_DSP_CAPTURE_LAB.md` | Measured FM WAV evidence and paired IQ/WAV DSP-lab implementation plan |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You power it on, wait for the splash to finish loading Wi-Fi and the dongle, tap
   &nbsp;•&nbsp;
   <a href="#the-dashboards"><strong>Dashboards</strong></a>
   &nbsp;•&nbsp;
-  <a href="#rtl-sdrv4-esp"><strong>RTL-SDRv4-ESP driver</strong></a>
+  <a href="#esp_rtl_sdr"><strong>esp_rtl_sdr driver</strong></a>
   &nbsp;•&nbsp;
   <a href="#the-orc-ecosystem"><strong>Orc ecosystem</strong></a>
 </p>
@@ -713,7 +713,7 @@ Product:      Blog V4
                 │                       │
                 └───────────┬───────────┘
                             │
-                     RTL-SDRv4-ESP
+                      esp_rtl_sdr
                             │
                      ESP-IDF USB Host
                             │
@@ -726,6 +726,12 @@ Product:      Blog V4
 
 ---
 
+The USB/tuner driver is already standalone. Several decoder modules are
+separate, while DSP/session coordination and Tab5 audio integration remain
+in the application. This diagram shows responsibilities, not a completed
+portable DSP engine. See [architecture.md](architecture.md) for the implemented
+boundaries and [PORTING.md](docs/PORTING.md) for existing Waveshare validation.
+
 ## Development Roadmap
 
 OrcSDR is moving from a working reference radio toward a more reusable embedded SDR platform. Current work includes:
@@ -734,8 +740,8 @@ OrcSDR is moving from a working reference radio toward a more reusable embedded 
 - Improve FM audio quality and RDS lock time on weak stations
 - Finish remaining radio shells (AM, WX, CB, wide browse) to the same dashboard quality as FM / P25 / LoRa
 - Keep separating radio logic from the Tab5 UI
-- Validate additional ESP32-P4 USB Host boards
-- Build reusable examples around `RTL-SDRv4-ESP`
+- Extend board/version validation from the existing Tab5 and Waveshare P4 work
+- Reuse the upstream `esp_rtl_sdr` P4 serial example; assess existing consumer code before adding further examples
 
 Engineering notes:
 

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -9,7 +9,7 @@ point at `phasing.md` for how each item gets implemented.
 ## Evidence labels
 
 Same convention as `PROJECT_STATUS.md`: **Hardware-verified**,
-**Build-verified**, **Implemented**, **Planned**, **Deferred**.
+**Build-verified**, **Implemented**, **Recorded upstream**, **Planned**, **Deferred**.
 
 ## External review: Grok code review (2026-08-10)
 
@@ -31,22 +31,22 @@ entire MVC stack — model, view, controller, and service layer — into one
 class. Concretely, it already makes review diffs hard to scope (a touch-
 handler change and a DSP change land in the same file with no compiler-
 enforced boundary), and it will only get worse as more radio modes/tools are
-added (RDS decode is the next one in the queue, per `docs/lora/README.md` and
-recent stereo-decoder work).
+added. RDS decoding is now implemented in `main.cpp`; ADS-B, P25, LoRa,
+RF analysis, and several UI services already have separate modules. The
+remaining task is incremental separation of shared DSP/session state, not
+recreating those existing modules.
 
 **Status: Planned.** See `phasing.md` Phase 1.
 
 ### Gap 2 — dual USB code paths (`RTL_USE_LEGACY_USB`)
 
-`PROJECT_STATUS.md` already tracks this correctly under P1 ("Remove the
-legacy in-app USB path only after a soak build passes") — the review confirms
-the *sequencing* is right (soak-test before removal) but flags the *cost* of
-carrying both paths in the meantime: every driver-facing change has to be
-reasoned about twice.
+`esp_rtl_sdr` is the only live USB implementation. `main.cpp` forces
+`RTL_USE_LEGACY_USB=0` and rejects attempts to enable it, but disabled legacy
+implementation blocks remain in the source.
 
-**Status: Resolved.** The legacy implementation and duplicate EP0 tables were
-removed after the v0.7.9 integration soak. `esp_rtl_sdr` is the only live USB
-implementation.
+**Status: Runtime duplication resolved; source cleanup remains.** Track the
+remaining deletion under `PROJECT_STATUS.md` P1, separately from driver or
+DSP behavior changes.
 
 ### Gap 3 — no CI
 
@@ -62,9 +62,11 @@ planned. See `phasing.md` Phase 2.
 The review independently re-derived the same P0 gates already open in
 `PROJECT_STATUS.md`: graphics+audio simultaneous FPS/drop-rate measurement,
 the live-speaker-vs-recorded-PCM discrepancy, and hot-plug/second-board
-validation. This is a **confirmation**, not a new finding — it's listed here
-only so the review is fully accounted for; the tracked item and its evidence
-boundary remain in `PROJECT_STATUS.md` P0/P1 unchanged.
+validation. Waveshare operation has since been recorded upstream; see
+[PORTING.md](docs/PORTING.md). Exact-version sustained-rate and recovery gates
+remain distinct from that completed board milestone. Historical performance
+observations require their own measured acceptance, not a blanket reset to
+"not started."
 
 **Status: Already tracked** — `PROJECT_STATUS.md` P0/P1. No duplicate entry.
 
@@ -168,8 +170,11 @@ authorized-key decryption, bounded queue/error handling, then an authorized
 Heltec network comparison. The 902–928 MHz survey is an explicit occupancy
 tool that restores the monitor; it is not a packet-capture substitute.
 
-**Status: UI/config foundation in progress; no native PHY or live-air claim
-until replay and hardware gates pass.**
+**Status: Native decoder and five-panel UI implemented.** Source includes
+capture decoding, initialization/self-checks, and packet publication. Keep
+recorded-IQ and live-air acceptance tied to named evidence; this documentation
+review does not establish a new hardware pass. The serial regression bridge
+is not the native decoding implementation.
 
 ## Summary table
 

--- a/apps/orcsdr-tab5/README.md
+++ b/apps/orcsdr-tab5/README.md
@@ -55,18 +55,18 @@ from UI features alone.
 cd apps/orcsdr-tab5
 .\tools\build-tab5-idf.ps1
 # After explicit hardware authorization:
-idf.py -p <PORT> flash
+idf.py -B build-native-hosted3 -p <PORT> flash
 ```
 
 This is a native ESP-IDF 5.5.4 build. M5Unified 0.2.20 and M5GFX 0.2.27 are
 ESP-IDF components; PlatformIO is not a supported OrcSDR build or flash path.
 The current ESP-Hosted 3.0.6 Tab5 migration, pins, and honest hardware status
-are defined in [`docs/TAB5_ESP_HOSTED_3_MIGRATION.md`](../../docs/TAB5_ESP_HOSTED_3_MIGRATION.md).
+are defined in the [Tab5 ESP-Hosted 3 migration](../../docs/user-guide/tab5-esp-hosted-3-migration.md).
 
-`m5tab5_ui` is the complete firmware: regular splash/home flow, NAV band
-selection, and the LoRa dashboard/PSRAM decoder capture path. The optional
-`m5tab5_lora_test` environment uses the same radio features but skips directly
-to LoRa for bench testing.
+The native application includes the regular splash/home flow, band selection,
+and the LoRa dashboard/decoder capture path. `m5tab5_ui` and
+`m5tab5_lora_test` are historical PlatformIO environment names, not supported
+native build targets.
 
 Do not override the platform ESP-P4 toolchain. After flash, power-cycle if the
 device stays in download mode.

--- a/architecture.md
+++ b/architecture.md
@@ -7,6 +7,25 @@ application. It is an architecture reference, not a release-acceptance record.
 [`PROJECT_STATUS.md`](PROJECT_STATUS.md) remains the authoritative project-truth
 document for build, flash, and hardware evidence.
 
+## Driver, DSP, and board boundaries
+
+OrcSDR consumes the standalone `esp_rtl_sdr` v0.7.9 component through its C
+API. The driver owns USB/tuner control and IQ delivery; its implementation,
+tests, and P4 serial example live upstream. The Tab5 app selects callback-only
+IQ delivery and owns the downstream DSP queues, radio sessions, and outputs.
+See the [driver integration contract](docs/API_ESP_RTL_SDR.md).
+
+ADS-B, P25, LoRa, and RF analysis already have separate modules and interfaces.
+They still compile into the Tab5 application component. `ui/main.cpp` retains
+FM/AM processing, RDS, radio/session coordination, and speaker integration;
+`rf_analysis.cpp` still depends on M5Unified timing. File/module separation
+does not yet establish a board-independent OrcSDR engine or display/audio HAL.
+
+Tab5 display, touch, speaker, and USB power setup remain application concerns.
+The task/screen boundaries below describe runtime ownership, not independently
+linkable portable components. Prior Waveshare operation and the evidence needed
+to assess shared DSP reuse are documented in [PORTING.md](docs/PORTING.md).
+
 ## Runtime ownership
 
 The native ESP-IDF application separates deterministic radio work from display

--- a/docs/ESP32_RTL_SDR_DRIVER_PLAN.md
+++ b/docs/ESP32_RTL_SDR_DRIVER_PLAN.md
@@ -1,5 +1,12 @@
 # ESP32 RTL-SDR Driver Plan
 
+> **Historical design, superseded as an execution plan.** The standalone
+> `esp_rtl_sdr` driver and Waveshare board operation now exist. The proposed
+> paths, API restrictions, and pending milestones below describe the original
+> plan, not current capability. Use [PORTING.md](PORTING.md), the
+> [current integration contract](API_ESP_RTL_SDR.md), and
+> [project status](../PROJECT_STATUS.md) before scheduling work.
+
 ## Goal
 
 Extract the physically verified RTL-SDR.COM V4 USB path from the M5Tab5

--- a/docs/IMPLEMENTATION_FROM_PEER_RESEARCH.md
+++ b/docs/IMPLEMENTATION_FROM_PEER_RESEARCH.md
@@ -1,5 +1,11 @@
 # Implementation plan — close OrcSDR gaps from peer research
 
+> **Historical workstream design.** In-tree driver paths and extraction tasks
+> below describe the 2026-08-06/08 baseline. The standalone driver and
+> second-board operation now exist; use [PORTING.md](PORTING.md) and
+> [project status](../PROJECT_STATUS.md) to distinguish completed work from
+> remaining validation before implementing this plan.
+
 Date: 2026-08-06  
 Depends on: `COMPETITIVE_ANALYSIS_ESP32_RTLSDR.md`, `PORTING.md`, clean-room spec.
 

--- a/docs/M5TAB5_INTEGRATION.md
+++ b/docs/M5TAB5_INTEGRATION.md
@@ -1,5 +1,12 @@
 # M5Tab5 Integration
 
+> **Historical OrcLink platform-integration record.** The provisioning,
+> toolchain, and acceptance statements below belong to that earlier proof.
+> They are not current OrcSDR build instructions or its full feature status.
+> See [project status](../PROJECT_STATUS.md), the
+> [native build policy](TAB5_BUILD_POLICY.md), and
+> [Tab5 Wi-Fi guide](user-guide/wifi-tab5.md) for current operation.
+
 ## Truth status
 
 **Decision:** M5Tab5 is first-class in OrcLink as both an edge node/gateway and a portable operator console.

--- a/docs/M5TAB5_RTL_RADIO_NEXT_STEPS.md
+++ b/docs/M5TAB5_RTL_RADIO_NEXT_STEPS.md
@@ -1,10 +1,15 @@
 # M5Tab5 RTL radio next steps
 
+> **Historical execution checklist (2026-08-08).** The versions, PlatformIO
+> commands, and pending gates below are retained as history, not current
+> instructions. Use the [native build policy](TAB5_BUILD_POLICY.md),
+> [current project status](../PROJECT_STATUS.md), and
+> [porting evidence](PORTING.md) for new work.
+
 Updated: **2026-08-08**
 Authority: [`../PROJECT_STATUS.md`](../PROJECT_STATUS.md)
 
-This document is the Tab5 execution checklist. It intentionally contains no
-future feature inventory; the project roadmap owns that scope.
+This document was the Tab5 execution checklist at the date above.
 
 ## Current measured target
 

--- a/docs/PEER_USB_PIPELINE_DEEP_DIVE.md
+++ b/docs/PEER_USB_PIPELINE_DEEP_DIVE.md
@@ -1,5 +1,12 @@
 # Peer USB pipeline deep-dive (for RTL-SDRv4-ESP Gate 2)
 
+> **Historical research snapshot (2026-08-07).** The proposed in-tree driver
+> paths and implementation steps below are not the current architecture.
+> Use the [driver integration contract](API_ESP_RTL_SDR.md),
+> [porting evidence](PORTING.md), and [architecture](../architecture.md)
+> before applying these recommendations. Preserve the original research and
+> clean-room boundary as historical context.
+
 **Date:** 2026-08-07  
 **Sources reviewed (source-level):**
 

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -6,18 +6,44 @@
 2. **OrcSDR app** (`apps/orcsdr-tab5`) consumes the component for radio UX.
 3. **OrcLink** remains the control-plane project; it does not own this driver.
 
+## Existing implementation and evidence
+
+The standalone driver extraction is complete. OrcSDR pins `esp_rtl_sdr`
+v0.7.9; its public C API, USB/tuner implementation, tests, and
+[`p4_serial_smoke` example](https://github.com/hardcoreerik/esp-rtl-sdr/tree/v0.7.9/examples/p4_serial_smoke)
+live in the driver repository. See the [integration contract](API_ESP_RTL_SDR.md).
+
+Waveshare second-board work has already been performed under OrcSDR. The
+driver's [validation provenance](https://github.com/hardcoreerik/esp-rtl-sdr/blob/9bd59129622e0b978b6a4b1fe748cf37fcc2bc37/docs/AI_DEVELOPMENT_DISCLOSURE.md#provenance-honesty-orcsdr--this-repo)
+records the same tables working unmodified on Waveshare, and its
+[lab inventory](https://github.com/hardcoreerik/esp-rtl-sdr/blob/9bd59129622e0b978b6a4b1fe748cf37fcc2bc37/docs/TESTING.md#hosts-sdr-under-test)
+identifies the ESP32-P4 Module-DEV-KIT. Its
+[FM application notes](https://github.com/hardcoreerik/esp-rtl-sdr/blob/9bd59129622e0b978b6a4b1fe748cf37fcc2bc37/docs/DRIVER_GAPS_VS_DESKTOP.md)
+also describe on-device demodulation and web PCM output.
+
+These records establish prior second-board operation, not completion of every
+later release's soak/recovery gates. The Waveshare application source and raw
+logs are not included in this checkout. Whether it shares the Tab5 DSP
+implementation must be established from that source before planning a new
+extraction or duplicate example.
+
 ## Target matrix
 
 | Target | USB host | Status |
 |---|---|---|
-| ESP32-P4 (Tab5, Waveshare P4 kits) | High-Speed | **Measured** reference |
-| ESP32-S3 | Full-Speed OTG | Build-only until measured |
-| ESP32-S2 | Full-Speed OTG | Build-only until measured |
+| ESP32-P4 M5Stack Tab5 | High-Speed | Reference consumer; see [project status](../PROJECT_STATUS.md) for version-specific evidence |
+| ESP32-P4 Waveshare Module-DEV-KIT | High-Speed | Prior OrcSDR operation recorded upstream; see evidence above |
+| ESP32-S3 | Full-Speed OTG | Streaming support not claimed; requires target-specific build and hardware evidence |
+| ESP32-S2 | Full-Speed OTG | Streaming support not claimed; requires target-specific build and hardware evidence |
 | Classic ESP32 | No native HS host | **Out of scope** |
 
 Never claim a target without device identity, procedure, and observed result.
 
-## Extraction gates
+## Extraction milestones and remaining validation
+
+The milestones below originated in the in-tree driver plan. Driver extraction
+and board operation are distinct from extracting a reusable OrcSDR DSP engine;
+see [architecture](../architecture.md#driver-dsp-and-board-boundaries).
 
 ### Gate 1 — Component skeleton (**complete**)
 
@@ -26,9 +52,9 @@ Never claim a target without device identity, procedure, and observed result.
 - [x] Private clean-room transfer tables
 - [x] install/uninstall lifecycle
 
-### Gate 2 — Behavior parity with Tab5 radio (**implemented; soak pending**)
+### Gate 2 — USB/tuner extraction (**implemented**)
 
-Move from `apps/orcsdr-tab5/ui/main.cpp` into the component **without** UI/audio:
+The standalone component implements these responsibilities without UI/audio:
 
 1. [x] V4 identity filter and hot-plug events
 2. [x] Interface claim / release
@@ -38,19 +64,23 @@ Move from `apps/orcsdr-tab5/ui/main.cpp` into the component **without** UI/audio
 6. [x] Bulk IN pipeline, stop, cleanup
 7. [x] Metrics (bytes, min/max/mean, effective sps)
 
-**Remaining pass evidence:** five-minute serial smoke outside M5Unified at at
-least 95% effective sample rate, zero fatal USB errors, and bounded drop counts.
+**Separate acceptance gate:** record the exact driver version, board, and
+configuration for a five-minute serial smoke outside M5Unified at at least
+95% effective sample rate, zero fatal USB errors, and bounded drop counts.
+Prior board operation does not automatically close this version-specific gate.
 
 ### Gate 3 — Dual-core friendly IQ delivery (**implemented; recovery pending**)
 
 - [x] USB owner task only talks to USB Host API
-- [x] FreeRTOS queue of IQ blocks to consumers
+- [x] Driver supports IQ delivery; Tab5 selects callback-only delivery and copies borrowed data into its app-owned queue
 - [x] Retune drains bulk before EP0
 - [ ] Unplug/replug recovery without reboot on Tab5 and a second P4 board
 
-### Gate 4 — Second board (**not started**)
+### Gate 4 — Second-board operation (**recorded upstream**)
 
-Repeat Gate 2 on Waveshare ESP32-P4 (or other measured P4) with board BSP for VBUS only.
+Waveshare Module-DEV-KIT operation is recorded above. Preserve that milestone;
+track sustained-rate, unplug/replug, and release-specific regression results
+separately instead of restarting board bring-up as unimplemented work.
 
 ## Board BSP boundary
 

--- a/docs/TAB5_BUILD_POLICY.md
+++ b/docs/TAB5_BUILD_POLICY.md
@@ -1,7 +1,7 @@
 # Tab5 build and ESP-Hosted policy
 
 > Current migration details, exact pins, and acceptance status live in
-> [`TAB5_ESP_HOSTED_3_MIGRATION.md`](TAB5_ESP_HOSTED_3_MIGRATION.md).
+> [Tab5 ESP-Hosted 3 migration](user-guide/tab5-esp-hosted-3-migration.md).
 
 OrcSDR's Tab5 firmware is a native ESP-IDF project. Build and flash the P4
 with Espressif `idf.py`; do not use PlatformIO for development, release, or
@@ -15,10 +15,11 @@ not an Arduino-IDE or PlatformIO toolchain.
 The Tab5 uses two DSI framebuffers for full-frame UI rendering. The tracked
 patch at `apps/orcsdr-tab5/tools/patches/m5gfx-tab5-pageflip.patch` exposes
 the M5GFX framebuffers and configures the driver for two buffers. The native
-build entry point applies it idempotently before configuration:
+build entry point applies it idempotently after `idf.py reconfigure`, which
+may fetch or replace managed components. From `apps/orcsdr-tab5`, use:
 
 ```powershell
-.\tools\apply-m5gfx-tab5-pageflip.ps1
+.\tools\build-tab5-idf.ps1
 ```
 
 Do not make a one-off change inside ignored `managed_components`. If the
@@ -32,8 +33,12 @@ The P4 application pins `espressif/esp_hosted` to **3.0.6** in
 `apps/orcsdr-tab5/dependencies.lock` with every dependency change.
 
 The Tab5 C6 must run the matching **3.0.6** ESP-Hosted firmware. OrcSDR's
-normal P4 application image does not update the C6. Never downgrade the C6
-to accommodate an old P4 host library.
+M5Burner package embeds a matching C6 image. With reachable Hosted transport
+and an eligible older C6, Firmware & Updates offers an explicitly confirmed
+in-app update. Source builds need `-C6Firmware` to embed that image; the
+default helper invocation does not supply it. An unreachable C6 needs the
+[documented recovery path](M5BURNER_RELEASE.md), not repeated in-app retries.
+Never downgrade the C6 to accommodate an old P4 host library.
 
 At boot the P4 logs both versions. Wi-Fi is blocked unless it reports:
 
@@ -86,20 +91,18 @@ Healthy boot (2026-08-17, Hosted 2.12.6, mempool off):
 | after_usb | ~33 KiB | ~23 KiB |
 | after_speaker | ~20 KiB | ~19 KiB |
 
-## People installer
+## Installer and release package
 
-The older installer/release scripts still contain 2.12.6 checks and must not
-be used as 3.0.6 acceptance tooling. Use the explicit native 5.5.4 commands
-in the migration document until those scripts are migrated.
+Use the current [M5Burner release and recovery instructions](M5BURNER_RELEASE.md)
+and [hardware acceptance gate](M5BURNER_HARDWARE_GATE.md). The beta.1 package
+and installer target Hosted 3.0.6; the historical 2.12.6 measurements above do not
+establish acceptance for that pair.
 
 ## Native build and release gate
 
 ```powershell
 Set-Location F:\Ai\OrcSDR\apps\orcsdr-tab5
-$env:IDF_PYTHON_ENV_PATH = 'C:\Espressif\python_env\idf5.5_py3.14_env'
-. 'C:\Espressif\frameworks\esp-idf-v5.5.4\export.ps1'
-idf.py reconfigure
-idf.py build
+.\tools\build-tab5-idf.ps1
 ```
 
 After an explicitly authorized P4 flash, use the serial release test to prove

--- a/docs/lora/README.md
+++ b/docs/lora/README.md
@@ -26,10 +26,13 @@ bounded local event/log path. Existing `LORA_PACKET` serial input remains a
 regression bridge for known, externally verified Meshtastic decode records.
 It is not described as native decoding.
 
-Native LongFast work is staged as IQ -> chirp/FEC/CRC -> Meshtastic frame parse
--> authorized decryption -> bounded snapshot. Until its recorded-IQ vectors
-pass, the dashboard displays **PHY PENDING**. Unknown encrypted traffic is not
-decrypted, recovered, or attributed.
+The native LongFast decoder is implemented in `lora_native_decoder` and
+connected to the capture task: IQ -> chirp/FEC/CRC -> Meshtastic frame parse
+-> authorized decryption -> bounded snapshot. Decoder self-check and
+initialization determine readiness; the dashboard displays **PHY PENDING**
+when the native decoder is not ready. Readiness does not certify live RF or
+complete replay coverage. Unknown encrypted traffic is not decrypted,
+recovered, or attributed.
 
 ## Local data and capture
 

--- a/docs/user-guide/dashboards/lora.md
+++ b/docs/user-guide/dashboards/lora.md
@@ -2,8 +2,10 @@
 
 The LoRa dashboard is an experimental receive and analysis surface.
 
-- **Live** shows current channel settings, detector state, and the latest decoded packet.
-- **Packets** retains bounded recent metadata and SD logging status.
+- **Overview** shows channel settings, spectrum, capture controls, and recent traffic.
+- **Nodes** lists received sender records; missing fields remain unknown.
+- **Traffic** retains bounded receive events and packet details.
 - **Map** plots positions only when a packet contains usable coordinates.
+- **RF Health** reports receiver rate, drops, capture/log state, and decoder readiness.
 
 LoRa packet capture and Meshtastic interpretation depend on the selected spreading factor, bandwidth, channel, and keys. OrcSDR does not transmit from these pages.

--- a/phasing.md
+++ b/phasing.md
@@ -19,10 +19,10 @@ flashable at every step — no phase should require a multi-day broken build.
 
 ## Phase 1 — split `main.cpp` into modules
 
-Goal: break the ~266 KB single translation unit into logical modules without
-changing behavior, closing Roadmap Gap 1 and setting up Gap 2 (legacy USB
-deletion becomes a one-file diff) and Gap 5 (touch/draw abstraction has
-somewhere to live).
+Goal: continue separating DSP/session/host responsibilities from `main.cpp`
+without changing behavior. The ~266 KB size was the original review baseline.
+ADS-B, P25, LoRa, RF analysis, dashboards, and shared UI services already have
+modules; reuse them. Disabled legacy USB blocks remain a separate cleanup item.
 
 Target module boundaries (mirrors the review's suggested split):
 
@@ -65,9 +65,10 @@ tune CB, tune LoRa, confirm dashboards and touch still respond identically).
 
 Goal: catch a header/driver-example break automatically, closing Gap 3.
 
-1. [ ] Add `.github/workflows/build.yml`: on every push and PR, run
-      `pio run` for the Tab5 UI environment (`m5tab5_ui`) and the LoRa test
-      environment (`m5tab5_lora_test`).
+1. [ ] Add native ESP-IDF 5.5.4 Tab5 consumer-build CI, matching the dependency
+      pins, configuration, and post-reconfigure display patch ordering in
+      `apps/orcsdr-tab5/tools/build-tab5-idf.ps1`. Do not revive the historical
+      PlatformIO environments. The existing guide workflow is documentation CI.
 2. [x] Keep the standalone P4 smoke build and driver API contract in the
       `esp-rtl-sdr` repository; OrcSDR CI verifies only the consumer integration.
 3. [ ] No hardware-in-the-loop testing in CI at this stage — that's a much
@@ -76,7 +77,7 @@ Goal: catch a header/driver-example break automatically, closing Gap 3.
       the project reaches the point of wanting hardware regression coverage.
 
 Exit: a broken build or a broken example fails a GitHub Actions check before
-merge, instead of being caught by a human running `pio run` manually.
+merge, instead of being caught by a manual native firmware build.
 
 ## Phase 3 — tool-shell abstraction
 
@@ -476,7 +477,7 @@ for view separation. Do not copy their GPL tuner, decoder, or UI source.
 - [x] Render absent/unconfigured values as `--`; retain dBFS wording until an
       RF calibration supports dBm, and show CPU as `N/A` until measured.
 
-Exit: the targeted PlatformIO environment builds; all views, selection, lock,
+Exit: the native ESP-IDF Tab5 application builds; all views, selection, lock,
 coordinate validation/persistence, range cycling, and Exit ADS-B are accepted
 on the physical Tab5. Until that visual/touch pass occurs, evidence stops at
 Build-verified.
@@ -693,9 +694,12 @@ strict site builds, and approved audio/video outputs pass `ffprobe` checks.
 
 ## Phase 9 — native Meshtastic LongFast receive
 
-1. [ ] Keep the five-panel M5GFX LoRa shell on one bounded snapshot and reuse
-       the shared Home control; remove legacy image plates only after no code
-       references them.
+Source review (2026-09-03): the native decoder and five-panel dashboard are
+present and connected. The remaining checklist separates implementation from
+recorded-IQ and hardware acceptance; it does not schedule the decoder anew.
+
+1. [x] Keep the five-panel M5GFX LoRa shell on one bounded snapshot and reuse
+       the shared Home control. Any unused image-asset cleanup is separate.
 2. [ ] Validate `/orcsdr/lora.cfg` bounds and complete the masked Settings
        editor for authorized receive keys without exporting them.
 3. [ ] Prove recorded IQ sync, chirp/FEC/CRC, public LongFast frames,


### PR DESCRIPTION
Current documentation describes Waveshare second-board work as not started, proposes obsolete PlatformIO steps, and claims disabled legacy USB code was deleted. These contradictions can send new work back through completed driver extraction.

This documentation-only update:
- Records existing Waveshare operation with commit-pinned upstream references, keeping later release-specific soak/recovery gates separate.
- Explains the standalone driver, existing decoder modules, and remaining Tab5 DSP/session/audio dependencies without proposing a new refactor.
- Corrects native build/flash instructions, display-patch ordering, C6 in-app update guidance, migration links, and LoRa implementation/page descriptions.
- Labels superseded extraction and integration plans as historical while retaining their original evidence.

Validation:
- `python tools/validate-help-docs.py` — PASS, 46 screens.
- `git diff --check` and `git diff --cached --check` — PASS before commit.
- Read-only inline Python link/scope check — PASS: 58 Markdown files, zero missing relative file destinations, updated local heading targets present, all 15 changed files Markdown-only. External URLs and general fragment validation were outside that check.
- No firmware builds, flashing, or new hardware acceptance claims. GitHub User guide CI validates the site build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project status, architecture, roadmap, and porting guidance to distinguish current capabilities from historical plans and recorded upstream evidence.
  - Clarified standalone driver integration, supported board status, native build policy, migration paths, and recovery procedures.
  - Updated LoRa/Meshtastic documentation to reflect native decoder readiness and remaining validation requirements.
- **User Guide**
  - Reorganized the LoRa dashboard into Overview, Nodes, Traffic, and RF Health sections.
  - Added clearer decoder-readiness and receiver-health information.
- **Build & Release**
  - Refined native build, flashing, firmware update, and migration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->