### PR TITLE
test(tab5): automate radio scan regressions

### DIFF
--- a/.github/workflows/radio-scan-tests.yml
+++ b/.github/workflows/radio-scan-tests.yml
@@ -1,0 +1,32 @@
+name: Radio scan core
+
+on:
+  pull_request:
+    paths:
+      - apps/orcsdr-tab5/ui/radio_session.*
+      - apps/orcsdr-tab5/ui/scan_engine.*
+      - tests/radio_scan_tests.cpp
+      - tools/test-radio-scan.ps1
+      - tools/test-radio-scan.sh
+      - .github/workflows/radio-scan-tests.yml
+  push:
+    branches: [main]
+    paths:
+      - apps/orcsdr-tab5/ui/radio_session.*
+      - apps/orcsdr-tab5/ui/scan_engine.*
+      - tests/radio_scan_tests.cpp
+      - tools/test-radio-scan.ps1
+      - tools/test-radio-scan.sh
+      - .github/workflows/radio-scan-tests.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Optimized and sanitizer tests
+        run: bash tools/test-radio-scan.sh

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,5 @@ site/
 artifacts/help-media/
 artifacts/data-source-cache/
 artifacts/data-catalog-v1*/
+artifacts/radio-scan-soak/
 docs/user-guide/assets/screenshots/raw/

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -30,6 +30,23 @@ required sdkconfig values, and runs `idf.py build`. This order supports a fresh
 checkout or worktree and prevents component resolution from overwriting the
 patch before compilation.
 
+### Radio session and scan tests
+
+Run the portable state-machine tests from the repository root. The runner uses
+WSL `g++` and executes both an optimized build and an ASan/LSan/UBSan build.
+
+```powershell
+.\tools\test-radio-scan.ps1
+```
+
+The same test runs in GitHub Actions. Hardware scan-takeover testing remains a
+separate, explicitly invoked Tab5 gate:
+
+```powershell
+cd apps\orcsdr-tab5
+.\tools\run-tab5-ui-regression.ps1 -RadioScan -Cycles 10 -Port COM17
+```
+
 ### Flash
 
 ```powershell

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -283,6 +283,11 @@ function Get-HealthStatus {
   return ConvertFrom-HealthStatus (Send-And-Wait 'RTL_HEALTH' '^RTL_HEALTH_STATUS ')
 }
 
+function Test-UptimeAdvanced([uint64]$Previous, [uint64]$Current) {
+  $elapsed = ($Current + 0x100000000L - $Previous) % 0x100000000L
+  return $elapsed -gt 0 -and $elapsed -lt 0x80000000L
+}
+
 function Assert-HealthStatus($Health) {
   if ($Health.FreeHeap -eq 0 -or $Health.DmaFree -eq 0 -or
       $Health.DmaLargest -eq 0 -or $Health.Tasks -eq 0 -or $Health.MainStackHwm -eq 0) {
@@ -711,6 +716,11 @@ function Invoke-SelfCheck {
   if ($health.UptimeMs -ne 123 -or $health.DmaLargest -ne 200 -or $health.MainStackHwm -ne 2048) {
     throw 'Health parser failed.'
   }
+  if (!(Test-UptimeAdvanced 4294967290 5) -or
+      (Test-UptimeAdvanced 5000 100) -or
+      (Test-UptimeAdvanced 100 100)) {
+    throw 'Uptime rollover check failed.'
+  }
   $frequency = ConvertFrom-RadioFrequencyStatus 'RTL_FREQ_STATUS band=P25 frequency_hz=453925000 mode=P25 C4FM'
   if ($frequency.Band -ne 'P25' -or $frequency.Frequency -ne 453925000 -or
       $frequency.Mode -ne 'P25 C4FM') {
@@ -869,7 +879,7 @@ function Invoke-RadioScanTest {
 
       $health = Get-HealthStatus
       Assert-HealthStatus $health
-      if ($previousUptime -ne 0 -and $health.UptimeMs -le $previousUptime) {
+      if ($previousUptime -ne 0 -and !(Test-UptimeAdvanced $previousUptime $health.UptimeMs)) {
         throw "Device uptime did not advance; reset suspected: $($health.Line)"
       }
       $previousUptime = $health.UptimeMs

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -24,6 +24,7 @@ param(
   [switch]$WifiCoexistenceDiagnostic,
   [switch]$DataOnly,
   [switch]$C6Update,
+  [switch]$RadioScan,
   [switch]$InstallLaneMap,
   [string]$LocationQuery = '97401',
   [switch]$RequireWifiConnection,
@@ -45,6 +46,14 @@ if ($Profile) {
     $artifactDir = Join-Path $PSScriptRoot '..\..\..\artifacts\ui-soak'
     $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
     $LogPath = Join-Path $artifactDir "$timestamp-$($Profile.ToLowerInvariant())-seed$Seed.log"
+  }
+}
+if ($RadioScan) {
+  if ($Cycles -eq 0) { $Cycles = 10 }
+  if (!$LogPath) {
+    $artifactDir = Join-Path $PSScriptRoot '..\..\..\artifacts\radio-scan-soak'
+    $timestamp = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $LogPath = Join-Path $artifactDir "$timestamp-cycles$Cycles.log"
   }
 }
 if ($LogPath) {
@@ -252,14 +261,53 @@ function Assert-FmAudioProgress {
   throw "FM audio did not recover: enabled=$($next.speaker_enabled) running=$($next.speaker_running) chunks_before=$($first.audio_chunks) chunks_after=$($next.audio_chunks)"
 }
 
+function ConvertFrom-HealthStatus([string]$Line) {
+  if ($Line -notmatch '^RTL_HEALTH_STATUS uptime_ms=(\d+) free_heap=(\d+) min_free_heap=(\d+) dma_free=(\d+) dma_min=(\d+) dma_largest=(\d+) tasks=(\d+) main_stack_hwm=(\d+) reset_reason=(\d+)$') {
+    throw "Malformed health status: $Line"
+  }
+  return [pscustomobject]@{
+    Line = $Line
+    UptimeMs = [uint64]$Matches[1]
+    FreeHeap = [uint64]$Matches[2]
+    MinFreeHeap = [uint64]$Matches[3]
+    DmaFree = [uint64]$Matches[4]
+    DmaMin = [uint64]$Matches[5]
+    DmaLargest = [uint64]$Matches[6]
+    Tasks = [uint32]$Matches[7]
+    MainStackHwm = [uint32]$Matches[8]
+    ResetReason = [uint32]$Matches[9]
+  }
+}
+
+function Get-HealthStatus {
+  return ConvertFrom-HealthStatus (Send-And-Wait 'RTL_HEALTH' '^RTL_HEALTH_STATUS ')
+}
+
+function Assert-HealthStatus($Health) {
+  if ($Health.FreeHeap -eq 0 -or $Health.DmaFree -eq 0 -or
+      $Health.DmaLargest -eq 0 -or $Health.Tasks -eq 0 -or $Health.MainStackHwm -eq 0) {
+    throw "Device reported exhausted memory or stack: $($Health.Line)"
+  }
+}
+
 function Assert-Health {
-  $line = Send-And-Wait 'RTL_HEALTH' '^RTL_HEALTH_STATUS '
-  if ($line -notmatch 'free_heap=(\d+) min_free_heap=(\d+) dma_free=(\d+) dma_min=(\d+) dma_largest=(\d+)') {
-    throw "Malformed health status: $line"
+  $health = Get-HealthStatus
+  Assert-HealthStatus $health
+}
+
+function ConvertFrom-RadioFrequencyStatus([string]$Line) {
+  if ($Line -notmatch '^RTL_FREQ_STATUS band=(\S+) frequency_hz=(\d+) mode=(.+)$') {
+    throw "Malformed frequency status: $Line"
   }
-  if ([uint64]$Matches[1] -eq 0 -or [uint64]$Matches[3] -eq 0 -or [uint64]$Matches[5] -eq 0) {
-    throw "Device reported exhausted heap: $line"
+  return [pscustomobject]@{
+    Band = $Matches[1].ToUpperInvariant()
+    Frequency = [uint32]$Matches[2]
+    Mode = $Matches[3]
   }
+}
+
+function Get-RadioFrequency {
+  return ConvertFrom-RadioFrequencyStatus (Send-And-Wait 'RTL_FREQ' '^RTL_FREQ_STATUS ')
 }
 
 function Assert-SoundCycle {
@@ -658,12 +706,22 @@ function Invoke-SelfCheck {
   if (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,1,1,0,0,1) }) 'WIFI_ANALYSIS') {
     throw 'RF24 overlay check accepted an active P25 dashboard.'
   }
+  $health = ConvertFrom-HealthStatus 'RTL_HEALTH_STATUS uptime_ms=123 free_heap=456 min_free_heap=400 dma_free=300 dma_min=250 dma_largest=200 tasks=12 main_stack_hwm=2048 reset_reason=1'
+  Assert-HealthStatus $health
+  if ($health.UptimeMs -ne 123 -or $health.DmaLargest -ne 200 -or $health.MainStackHwm -ne 2048) {
+    throw 'Health parser failed.'
+  }
+  $frequency = ConvertFrom-RadioFrequencyStatus 'RTL_FREQ_STATUS band=P25 frequency_hz=453925000 mode=P25 C4FM'
+  if ($frequency.Band -ne 'P25' -or $frequency.Frequency -ne 453925000 -or
+      $frequency.Mode -ne 'P25 C4FM') {
+    throw 'Radio frequency parser failed.'
+  }
   Write-SoakLine 'RTL_UI_SOAK_SELF_CHECK pass=1'
 }
 
 if ($SelfCheck) { Invoke-SelfCheck; exit 0 }
-if (@($Run, $Soak, $Driver079, $WifiOnly, $WifiCoexistence, $WifiCoexistenceDiagnostic, $DataOnly, $C6Update).Where({ $_ }).Count -gt 1) {
-  throw 'Choose only one of -Run, -Soak, -Driver079, -WifiOnly, -WifiCoexistence, -WifiCoexistenceDiagnostic, -DataOnly, or -C6Update.'
+if (@($Run, $Soak, $Driver079, $WifiOnly, $WifiCoexistence, $WifiCoexistenceDiagnostic, $DataOnly, $C6Update, $RadioScan).Where({ $_ }).Count -gt 1) {
+  throw 'Choose only one of -Run, -Soak, -Driver079, -WifiOnly, -WifiCoexistence, -WifiCoexistenceDiagnostic, -DataOnly, -C6Update, or -RadioScan.'
 }
 
 function Get-C6UpdateStatus {
@@ -778,6 +836,68 @@ function Invoke-Driver079Test {
   }
 }
 
+function Invoke-RadioScanTest {
+  Wait-DeviceReady 60 11000
+  Connect-Authenticated
+  $rtlDeadline = [DateTime]::UtcNow.AddSeconds(30)
+  do {
+    $rtlStatus = Send-And-Wait 'RTL_STATUS' '^RTL_SDR_STATUS ' 20
+    if ($rtlStatus -match 'connected=true ') { break }
+    Start-Sleep -Milliseconds 500
+  } while ([DateTime]::UtcNow -lt $rtlDeadline)
+  if ($rtlStatus -notmatch 'connected=true ') { throw "RTL-SDR did not enumerate: $rtlStatus" }
+
+  $initial = Get-UiState
+  $baseline = $null
+  $previousUptime = [uint64]0
+  try {
+    for ($cycle = 0; $cycle -le $Cycles; $cycle++) {
+      [void](Open-Ui 'FM' 'FM')
+      [void](Send-And-Wait 'RTL_PRESET_SCAN' '^RTL_PRESET_SCAN_QUEUED$')
+      [void](Read-MatchingLine '^RTL_PRESET_SCAN start$' 20)
+
+      [void](Open-Ui 'P25' 'P25')
+      $p25 = Get-RadioFrequency
+      if ($p25.Band -ne 'P25') { throw "FM scan restored stale state after takeover: band=$($p25.Band)" }
+
+      $script:serial.WriteLine('RTL_P25_SCAN')
+      [void](Read-MatchingLine '^RTL_P25_SURVEY start candidates=\d+ dwell_ms=1500$' 30)
+      [void](Open-Ui 'LORA' 'LORA')
+      Start-Sleep -Seconds $DwellSeconds
+      $lora = Get-RadioFrequency
+      if ($lora.Band -ne 'LORA') { throw "P25 survey restored stale state after takeover: band=$($lora.Band)" }
+
+      $health = Get-HealthStatus
+      Assert-HealthStatus $health
+      if ($previousUptime -ne 0 -and $health.UptimeMs -le $previousUptime) {
+        throw "Device uptime did not advance; reset suspected: $($health.Line)"
+      }
+      $previousUptime = $health.UptimeMs
+      if ($cycle -eq 0) {
+        $baseline = $health
+        Write-SoakLine "RTL_RADIO_SCAN_WARMUP pass=1 free_heap=$($health.FreeHeap) dma_free=$($health.DmaFree) dma_largest=$($health.DmaLargest) stack_hwm=$($health.MainStackHwm)"
+      } else {
+        $heapDelta = [int64]$health.FreeHeap - [int64]$baseline.FreeHeap
+        $dmaDelta = [int64]$health.DmaFree - [int64]$baseline.DmaFree
+        if ($heapDelta -lt -4096 -or $dmaDelta -lt -2048 -or $health.DmaLargest -lt 20480) {
+          throw "Radio scan memory regression: heap_delta=$heapDelta dma_delta=$dmaDelta dma_largest=$($health.DmaLargest)"
+        }
+        Write-SoakLine "RTL_RADIO_SCAN_CYCLE cycle=$cycle pass=1 heap_delta=$heapDelta dma_delta=$dmaDelta free_heap=$($health.FreeHeap) dma_largest=$($health.DmaLargest) stack_hwm=$($health.MainStackHwm)"
+      }
+    }
+    Write-SoakLine "RTL_RADIO_SCAN_RESULT pass=1 cycles=$Cycles lines=$script:linesSeen"
+  } finally {
+    try {
+      if ($initial.Band -in @('FM','AM','WX','CB','LORA','BROWSE','ADSB','P25')) {
+        [void](Send-And-Wait "RTL_TUNE $($initial.Band) $($initial.Frequency)" '^RTL_TUNE_(?:OK|UNAVAILABLE|INVALID)')
+      }
+      [void](Send-And-Wait "RTL_UI OPEN $($initial.Screen)" '^RTL_UI_OPEN_(?:OK|INVALID)')
+    } catch {
+      Write-Warning "Could not restore initial device state: $($_.Exception.Message)"
+    }
+  }
+}
+
 $script:serial = [System.IO.Ports.SerialPort]::new($Port, 115200, 'None', 8, 'One')
 $script:serial.NewLine = "`n"
 $script:serial.ReadTimeout = 250
@@ -821,6 +941,7 @@ try {
     exit 0
   }
   if ($C6Update) { Invoke-C6UpdateTest; exit 0 }
+  if ($RadioScan) { Invoke-RadioScanTest; exit 0 }
 
   if ($Profile) {
     $commit = (& git -C (Join-Path $PSScriptRoot '..\..\..') rev-parse --short HEAD 2>$null)

--- a/docs/API_SERIAL_CLI.md
+++ b/docs/API_SERIAL_CLI.md
@@ -422,7 +422,15 @@ not reset the Tab5:
 .\tools\run-tab5-ui-regression.ps1 -Port COM17 -Profile Stress -Seed 12345
 .\tools\run-tab5-ui-regression.ps1 -Port COM17 -Profile Stress -Cycles 1 -WifiEvery 1
 .\tools\run-tab5-ui-regression.ps1 -Port COM17 -Profile Overnight -Cycles 500
+.\tools\run-tab5-ui-regression.ps1 -Port COM17 -RadioScan -Cycles 10
 ```
+
+`-RadioScan` repeatedly starts FM and P25 scans, transfers tuner ownership to
+another dashboard during each scan, rejects stale restoration, and records heap,
+DMA, stack, uptime, reset, watchdog, and panic evidence. The first cycle warms
+the dashboards before the memory baseline is recorded. The run fails if free
+heap falls by more than 4 KiB, DMA-capable heap falls by more than 2 KiB, or the
+largest DMA-capable block falls below 20 KiB.
 
 `-Soak` authenticates with `.orclink\ui-doc.key`, then drives every radio
 dashboard through Home and Settings. `Smoke`, `Stress`, and `Overnight` provide

--- a/tests/radio_scan_tests.cpp
+++ b/tests/radio_scan_tests.cpp
@@ -1,0 +1,263 @@
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <new>
+
+#include "radio_session.hpp"
+#include "scan_engine.hpp"
+
+namespace {
+
+std::atomic_size_t allocations{0};
+
+struct Trace {
+  std::array<uint32_t, 64> tunes{};
+  std::array<uint32_t, 64> measured_hz{};
+  std::array<size_t, 64> measured_index{};
+  size_t tune_count = 0;
+  size_t measure_count = 0;
+  size_t finish_count = 0;
+  orcsdr::scan::Finish finish = orcsdr::scan::Finish::retune_failed;
+  uint32_t fail_hz = 0;
+  orcsdr::radio::Session* session = nullptr;
+  orcsdr::radio::Token token{};
+};
+
+[[noreturn]] void fail(const char* expression, int line) {
+  std::fprintf(stderr, "FAIL line=%d check=%s\n", line, expression);
+  std::exit(1);
+}
+
+#define CHECK(expression) \
+  do {                    \
+    if (!(expression)) fail(#expression, __LINE__); \
+  } while (false)
+
+bool retune(uint32_t frequency_hz, void* context) {
+  auto& trace = *static_cast<Trace*>(context);
+  CHECK(trace.tune_count < trace.tunes.size());
+  trace.tunes[trace.tune_count++] = frequency_hz;
+  if (frequency_hz == trace.fail_hz) return false;
+  return trace.session == nullptr || trace.session->retuned(trace.token, frequency_hz);
+}
+
+void measure(size_t index, uint32_t frequency_hz, void* context) {
+  auto& trace = *static_cast<Trace*>(context);
+  CHECK(trace.measure_count < trace.measured_hz.size());
+  trace.measured_index[trace.measure_count] = index;
+  trace.measured_hz[trace.measure_count++] = frequency_hz;
+}
+
+void finished(orcsdr::scan::Finish reason, void* context) {
+  auto& trace = *static_cast<Trace*>(context);
+  trace.finish = reason;
+  ++trace.finish_count;
+}
+
+orcsdr::scan::Callbacks callbacks(Trace& trace) {
+  return {retune, measure, finished, &trace};
+}
+
+void test_radio_session() {
+  using namespace orcsdr::radio;
+  Session session;
+  CHECK(session.snapshot().owner == Owner::none);
+  CHECK(!session.owns(session.acquire(Owner::none, Band::fm, 100, 200)));
+  CHECK(session.snapshot().generation == 0);
+
+  const Token fm = session.acquire(Owner::fm, Band::fm, 96100000, 960000);
+  CHECK(session.owns(fm));
+  CHECK(session.set_state(fm, ReceiverState::running));
+  CHECK(!session.retuned(fm, 0));
+  CHECK(session.retuned(fm, 101700000));
+  const Snapshot fm_snapshot = session.snapshot();
+  CHECK(fm_snapshot.owner == Owner::fm);
+  CHECK(fm_snapshot.band == Band::fm);
+  CHECK(fm_snapshot.state == ReceiverState::running);
+  CHECK(fm_snapshot.frequency_hz == 101700000);
+  CHECK(fm_snapshot.sample_rate_sps == 960000);
+
+  const Token p25 = session.acquire(Owner::p25, Band::p25, 453812500, 960000);
+  CHECK(!session.owns(fm));
+  CHECK(!session.retuned(fm, 102300000));
+  CHECK(!session.set_state(fm, ReceiverState::failed));
+  CHECK(session.owns(p25));
+  CHECK(session.snapshot().frequency_hz == 453812500);
+
+  CHECK(owner_for_band(Band::fm) == Owner::fm);
+  CHECK(owner_for_band(Band::p25) == Owner::p25);
+  CHECK(owner_for_band(Band::adsb) == Owner::adsb);
+  CHECK(owner_for_band(Band::lora) == Owner::lora);
+  CHECK(owner_for_band(Band::am) == Owner::radio);
+  CHECK(owner_for_band(Band::wx) == Owner::radio);
+  CHECK(owner_for_band(Band::cb) == Owner::radio);
+  CHECK(owner_for_band(Band::browse) == Owner::radio);
+  CHECK(Session::self_check());
+}
+
+void test_scan_validation_and_timing() {
+  using namespace orcsdr::scan;
+  Engine engine;
+  CHECK(!engine.start({}, 0, 0));
+  CHECK(!engine.start({Mode::channel_list, nullptr, 1}, 0, 0));
+  CHECK(!engine.start({Mode::frequency_range, nullptr, 1, 0, 10}, 0, 0));
+  CHECK(!engine.start({Mode::window_sweep, nullptr, 1, 100, 0}, 0, 0));
+
+  const uint32_t channels[] = {100, 200};
+  Trace trace;
+  const auto cb = callbacks(trace);
+  constexpr uint32_t near_wrap = UINT32_MAX - 5;
+  CHECK(engine.start({Mode::channel_list, channels, 2, 0, 0, 10, true}, 50,
+                     near_wrap));
+  CHECK(!engine.start({Mode::channel_list, channels, 2}, 0, 0));
+  engine.service(near_wrap, cb);
+  CHECK(trace.tune_count == 1 && trace.tunes[0] == 100);
+  CHECK(trace.measure_count == 0);
+  engine.service(UINT32_MAX, cb);
+  engine.service(3, cb);
+  CHECK(trace.measure_count == 0);
+  engine.service(4, cb);
+  CHECK(trace.measure_count == 1 && trace.measured_index[0] == 0 &&
+        trace.measured_hz[0] == 100);
+  CHECK(engine.progress().index == 1 && engine.progress().frequency_hz == 200);
+  engine.service(4, cb);
+  engine.service(13, cb);
+  CHECK(trace.measure_count == 1);
+  engine.service(14, cb);
+  CHECK(!engine.active());
+  CHECK(trace.measure_count == 2 && trace.measured_index[1] == 1 &&
+        trace.measured_hz[1] == 200);
+  CHECK(trace.tune_count == 3 && trace.tunes[2] == 50);
+  CHECK(trace.finish_count == 1 && trace.finish == Finish::completed);
+  CHECK(!engine.progress().active && engine.progress().index == 2 &&
+        engine.progress().frequency_hz == 0);
+}
+
+void test_scan_modes_cancel_and_failures() {
+  using namespace orcsdr::scan;
+  for (const Mode mode : {Mode::frequency_range, Mode::window_sweep}) {
+    Engine engine;
+    Trace trace;
+    const auto cb = callbacks(trace);
+    CHECK(engine.start({mode, nullptr, 3, 300, 25, 0, false}, 75, 0));
+    for (size_t i = 0; i < 3; ++i) {
+      engine.service(0, cb);
+      engine.service(0, cb);
+    }
+    CHECK(!engine.active());
+    CHECK(trace.tune_count == 3 && trace.tunes[0] == 300 && trace.tunes[1] == 325 &&
+          trace.tunes[2] == 350);
+    CHECK(trace.measure_count == 3 && trace.finish == Finish::completed);
+  }
+
+  const uint32_t one[] = {400};
+  Engine engine;
+  Trace trace;
+  auto cb = callbacks(trace);
+  CHECK(engine.start({Mode::channel_list, one, 1, 0, 0, 0, true}, 80, 0));
+  engine.service(0, cb);
+  engine.cancel(true, cb);
+  CHECK(!engine.active() && trace.tune_count == 2 && trace.tunes[1] == 80 &&
+        trace.finish == Finish::cancelled);
+
+  trace = {};
+  cb = callbacks(trace);
+  CHECK(engine.start({Mode::channel_list, one, 1, 0, 0, 0, true}, 80, 0));
+  engine.service(0, cb);
+  engine.cancel(false, cb);
+  CHECK(trace.tune_count == 1 && trace.finish == Finish::cancelled);
+
+  const uint32_t two[] = {400, 500};
+  trace = {};
+  trace.fail_hz = 500;
+  cb = callbacks(trace);
+  CHECK(engine.start({Mode::channel_list, two, 2, 0, 0, 0, true}, 80, 0));
+  engine.service(0, cb);
+  engine.service(0, cb);
+  engine.service(0, cb);
+  CHECK(!engine.active() && trace.measure_count == 1 && trace.tune_count == 3 &&
+        trace.tunes[2] == 80 && trace.finish == Finish::retune_failed);
+
+  trace = {};
+  trace.fail_hz = 80;
+  cb = callbacks(trace);
+  CHECK(engine.start({Mode::channel_list, one, 1, 0, 0, 0, true}, 80, 0));
+  engine.service(0, cb);
+  engine.service(0, cb);
+  CHECK(!engine.active() && trace.measure_count == 1 &&
+        trace.finish == Finish::retune_failed);
+  CHECK(Engine::self_check());
+}
+
+void test_session_scan_ownership() {
+  using namespace orcsdr;
+  const uint32_t channels[] = {1100, 1200};
+  radio::Session session;
+  scan::Engine engine;
+  Trace trace;
+  trace.session = &session;
+  trace.token = session.acquire(radio::Owner::fm, radio::Band::fm, 1000, 960000);
+  auto cb = callbacks(trace);
+  CHECK(engine.start({scan::Mode::channel_list, channels, 2, 0, 0, 0, true}, 1000, 0));
+  engine.service(0, cb);
+  engine.service(0, cb);
+  engine.service(0, cb);
+  engine.service(0, cb);
+  CHECK(trace.finish == scan::Finish::completed);
+  CHECK(session.snapshot().frequency_hz == 1000);
+
+  trace = {};
+  trace.session = &session;
+  trace.token = session.acquire(radio::Owner::fm, radio::Band::fm, 1000, 960000);
+  cb = callbacks(trace);
+  CHECK(engine.start({scan::Mode::channel_list, channels, 2, 0, 0, 0, true}, 1000, 0));
+  engine.service(0, cb);
+  CHECK(session.snapshot().frequency_hz == 1100);
+  const auto p25 = session.acquire(radio::Owner::p25, radio::Band::p25, 453812500, 960000);
+  engine.cancel(false, cb);
+  CHECK(trace.finish == scan::Finish::cancelled && trace.tune_count == 1);
+  CHECK(session.owns(p25) && session.snapshot().frequency_hz == 453812500);
+}
+
+void test_allocation_free_stress() {
+  using namespace orcsdr::scan;
+  const uint32_t channel[] = {100};
+  Engine engine;
+  Trace trace;
+  const auto cb = callbacks(trace);
+  const size_t before = allocations.load(std::memory_order_relaxed);
+  for (size_t cycle = 0; cycle < 10000; ++cycle) {
+    trace = {};
+    CHECK(engine.start({Mode::channel_list, channel, 1, 0, 0, 0, true}, 50, 0));
+    engine.service(0, cb);
+    engine.service(0, cb);
+    CHECK(trace.finish == Finish::completed);
+  }
+  CHECK(allocations.load(std::memory_order_relaxed) == before);
+}
+
+}  // namespace
+
+void* operator new(std::size_t size) {
+  allocations.fetch_add(1, std::memory_order_relaxed);
+  if (void* memory = std::malloc(size)) return memory;
+  throw std::bad_alloc();
+}
+
+void* operator new[](std::size_t size) { return ::operator new(size); }
+void operator delete(void* memory) noexcept { std::free(memory); }
+void operator delete[](void* memory) noexcept { std::free(memory); }
+void operator delete(void* memory, std::size_t) noexcept { std::free(memory); }
+void operator delete[](void* memory, std::size_t) noexcept { std::free(memory); }
+
+int main() {
+  test_radio_session();
+  test_scan_validation_and_timing();
+  test_scan_modes_cancel_and_failures();
+  test_session_scan_ownership();
+  test_allocation_free_stress();
+  std::puts("radio_scan_tests: PASS");
+  return 0;
+}

--- a/tools/test-radio-scan.ps1
+++ b/tools/test-radio-scan.ps1
@@ -1,0 +1,7 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+& wsl.exe --cd $repoRoot bash ./tools/test-radio-scan.sh
+if ($LASTEXITCODE -ne 0) { throw "Radio scan host tests failed with exit code $LASTEXITCODE." }
+Write-Host 'Radio scan host tests passed (optimized + ASan/LSan/UBSan).'

--- a/tools/test-radio-scan.sh
+++ b/tools/test-radio-scan.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+build_dir="$(mktemp -d)"
+trap 'rm -rf "$build_dir"' EXIT
+
+sources=(tests/radio_scan_tests.cpp apps/orcsdr-tab5/ui/radio_session.cpp apps/orcsdr-tab5/ui/scan_engine.cpp)
+common=(-std=c++17 -Wall -Wextra -Werror -pedantic -Iapps/orcsdr-tab5/ui)
+
+g++ "${common[@]}" -O2 "${sources[@]}" -o "$build_dir/radio_scan_tests"
+"$build_dir/radio_scan_tests"
+
+g++ "${common[@]}" -O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer \
+  "${sources[@]}" -o "$build_dir/radio_scan_tests_sanitized"
+ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 UBSAN_OPTIONS=halt_on_error=1 \
+  "$build_dir/radio_scan_tests_sanitized"


### PR DESCRIPTION
The radio session and shared scan engine refactor had boot-time self-checks, but it lacked a repeatable regression test for ownership handoff, timer wraparound, allocation behavior, and device memory stability.

This adds a framework-free C++17 host test that runs optimized and under ASan/LSan/UBSan, a path-filtered GitHub Actions job, and a `-RadioScan` Tab5 hardware soak. The hardware gate repeatedly cancels FM and P25 scans through dashboard takeovers, rejects stale tuner restoration, watches fatal serial output and resets, and enforces calibrated heap/DMA limits after a warmup cycle.

Validation:
- `./tools/test-radio-scan.ps1` — optimized and ASan/LSan/UBSan runs passed, including 10,000 allocation-free scan cycles.
- `./apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1 -SelfCheck` — parser checks passed.
- `./apps/orcsdr-tab5/tools/build-tab5-idf.ps1` — ESP-IDF 5.5.4 build passed; application size `0x21a9c0` with 47% partition space remaining.
- Flashed and exercised on Tab5/COM17: the original 10-cycle soak passed, followed by a 3-cycle calibrated-threshold run. No panic, reset, watchdog, assertion, stale restore, or memory-limit failure occurred. Final measured heap and DMA were 132 bytes above the warmed baseline; the largest DMA block remained 47,104 bytes. The runner restored Home/FM afterward.

The documented RTL-SDR USB control-transfer STALL messages appeared during stream restarts and remained nonfatal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a radio-scan soak-test mode for Tab5 hardware, covering FM, P25, and LORA workflows with health, memory, uptime, and reset monitoring.
  - Added automated radio-scan testing for optimized and sanitized builds.
  - Added CI coverage for radio-scan tests on pull requests, main-branch updates, and manual runs.

- **Documentation**
  - Added setup and usage guidance for portable radio-session, scan, and hardware UI regression tests.
  - Documented radio-scan test behavior and pass/fail thresholds.

- **Tests**
  - Added coverage for session ownership, scan validation, cancellation, retuning failures, timing, and allocation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->