### PR TITLE
release: prepare v0.2.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 > [!NOTE]
-> **Public beta — [v0.2.0-beta.1](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.1)**
+> **Public beta — [v0.2.0-beta.2](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.2)**
 >
 > OrcSDR is available now for the M5Stack Tab5. It is a prerelease: feedback and [bug reports](https://github.com/hardcoreerik/OrcSDR/issues) are welcome.
 
@@ -538,11 +538,11 @@ cd OrcSDR
 git pull
 ```
 
-For the public prerelease, check out [`v0.2.0-beta.1`](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.1) before building:
+For the public beta, check out [`v0.2.0-beta.2`](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.2) before building:
 
 ```bash
 git fetch --tags
-git checkout v0.2.0-beta.1
+git checkout v0.2.0-beta.2
 ```
 
 The historical [`v0.2.0-alpha.5`](docs/releases/v0.2.0-alpha.5.md) record remains available for its original 2.12.6-era hardware context.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 > [!NOTE]
-> **Public beta — [v0.2.0-beta.2](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.2)**
+> **Public beta — [download the current release](https://github.com/hardcoreerik/OrcSDR/releases)**
 >
 > OrcSDR is available now for the M5Stack Tab5. It is a prerelease: feedback and [bug reports](https://github.com/hardcoreerik/OrcSDR/issues) are welcome.
 
@@ -538,11 +538,11 @@ cd OrcSDR
 git pull
 ```
 
-For the public beta, check out [`v0.2.0-beta.2`](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.2) before building:
+For a published build, copy its exact tag from [GitHub Releases](https://github.com/hardcoreerik/OrcSDR/releases) and check it out before building:
 
 ```bash
 git fetch --tags
-git checkout v0.2.0-beta.2
+git checkout RELEASE_TAG
 ```
 
 The historical [`v0.2.0-alpha.5`](docs/releases/v0.2.0-alpha.5.md) record remains available for its original 2.12.6-era hardware context.

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -1456,8 +1456,6 @@ char settings_location_label[40]{};
 char settings_map_pack[40]{};
 bool adsb_atc_listening = false;
 bool catalog_radio_paused = false;
-std::atomic<uint32_t> rtl_sdr_status_revision{0};
-uint32_t drawn_rtl_sdr_status_revision = 0;
 char rtl_sdr_status[96] = "RTL-SDR: waiting for USB-A host";
 char rtl_sdr_serial[48]{};
 char rtl_sdr_speed[8] = "none";
@@ -2005,28 +2003,6 @@ void draw_power_state() {
 
 void set_rtl_sdr_status(const char* status) {
   strlcpy(rtl_sdr_status, status, sizeof(rtl_sdr_status));
-  rtl_sdr_status_revision.fetch_add(1, std::memory_order_release);
-}
-
-void draw_rtl_sdr_state() {
-  if (g_suppress_home_paint) return;
-  if (orcsdr::settings::active() || orcsdr::home::active()) return;
-  const bool ready = strstr(rtl_sdr_status, "ready") != nullptr;
-  M5.Display.fillRect(150, 545, 980, 40, TFT_BLACK);
-  M5.Display.setTextColor(ready ? TFT_GREEN : TFT_ORANGE, TFT_BLACK);
-  M5.Display.setTextDatum(middle_center);
-  M5.Display.setTextSize(2);
-  M5.Display.drawString(rtl_sdr_status, 640, 565);
-  if (ready) {
-    M5.Display.fillRoundRect(kButtonX, kButtonY, kButtonWidth, kButtonHeight, 18,
-                             TFT_DARKGREEN);
-    M5.Display.drawRoundRect(kButtonX, kButtonY, kButtonWidth, kButtonHeight, 18,
-                             TFT_GREEN);
-    M5.Display.setTextColor(TFT_WHITE, TFT_DARKGREEN);
-    M5.Display.setTextSize(3);
-    M5.Display.drawString("Open SDR radio", 640, 360);
-  }
-  draw_global_settings_gear();
 }
 
 void usb_string_to_ascii(const usb_str_desc_t* descriptor, char* output,
@@ -13188,13 +13164,6 @@ void loop() {
     settings_sound_default = sound_enabled;
     Serial.printf("RTL_AUDIO_SETTINGS_SAVE volume=%u sound=%d\n", volume,
                   sound_enabled ? 1 : 0);
-  }
-
-  const uint32_t current_rtl_sdr_status_revision =
-      rtl_sdr_status_revision.load(std::memory_order_acquire);
-  if (drawn_rtl_sdr_status_revision != current_rtl_sdr_status_revision) {
-    drawn_rtl_sdr_status_revision = current_rtl_sdr_status_revision;
-    if (!radio_ui && !adsb_ui && !settings_ui) draw_rtl_sdr_state();
   }
 
   // Receive tasks only request this handoff; this UI path is the sole writer.

--- a/apps/orcsdr-tab5/ui/rf_analysis.cpp
+++ b/apps/orcsdr-tab5/ui/rf_analysis.cpp
@@ -385,7 +385,10 @@ bool initialize() {
   for (float& level : g_snapshot->average) level = -160;
   for (float& level : g_snapshot->peak) level = -160;
   if (!initialize_fft()) return false;
-  if (xTaskCreatePinnedToCoreWithCaps(worker, "rf_analysis", 8192, nullptr, 1, &g_task, 1,
+  // Analysis is best-effort display work. Sharing the idle priority guarantees
+  // Core 1's watched idle task can run while continuous radio DSP is active.
+  if (xTaskCreatePinnedToCoreWithCaps(worker, "rf_analysis", 8192, nullptr, tskIDLE_PRIORITY,
+                                      &g_task, 1,
                                       MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) != pdPASS)
     return false;
   return true;

--- a/docs/M5BURNER_HARDWARE_GATE.md
+++ b/docs/M5BURNER_HARDWARE_GATE.md
@@ -1,17 +1,19 @@
 # M5Burner hardware acceptance gate
 
-This was the release gate for the public `v0.2.0-beta.1` prerelease. Reuse the
-same gate for a future exact tag: build or package validation alone does not
-authorize a GitHub prerelease or public listing.
+This is the release gate for every public OrcSDR beta. Build or package
+validation alone does not authorize a GitHub release or public listing.
 
 1. Build the bundle and record its `M5BURNER_BUNDLE_OK` line, source commit,
    C6 provenance, and hashes.
 2. Privately publish and install **OrcSDR** through its Share Code without
    erase. On a current pair, confirm Firmware & Updates reports `current` and
    offers no update.
-3. On an authorized recovery-capable device with a reachable older C6, confirm
-   the UI update, capture `RTL_WIFI_C6_UPDATE` serial progress, and after its
-   restart verify `host=3.0.6 coprocessor=3.0.6 match=1`.
+3. When the C6 image, update code, or delivery path changes, use an authorized
+   recovery-capable device with a reachable older C6. Confirm the UI update,
+   capture `RTL_WIFI_C6_UPDATE` serial progress, and after restart verify
+   `host=3.0.6 coprocessor=3.0.6 match=1`. If those inputs are unchanged, record
+   the prior hardware evidence and verify the exact package contains the same
+   C6 source revision and SHA-256 instead of forcing another downgrade.
 4. Confirm Home, FM audio, RTL-SDR, Wi-Fi scan, saved-profile connection, RF24,
    and the UI regression command. The dedicated `-C6Update` regression mode
    exercises the same authenticated Settings action.

--- a/docs/M5BURNER_RELEASE.md
+++ b/docs/M5BURNER_RELEASE.md
@@ -1,6 +1,6 @@
 # OrcSDR M5Burner release
 
-`v0.2.0-beta.1` is one normal Tab5 package. It contains the P4 application
+`v0.2.0-beta.2` is one normal Tab5 package. It contains the P4 application
 and a pinned ESP-Hosted 3.0.6 C6 image. M5Burner writes the P4 only; OrcSDR
 offers a C6 update from Settings after it proves that the existing Hosted link
 is reachable.
@@ -31,8 +31,8 @@ local test zip. It never flashes hardware or uploads a listing.
 
 ## Publication record and future-release gate
 
-`v0.2.0-beta.1` is publicly available through M5Burner and as a [GitHub
-prerelease](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.1).
+`v0.2.0-beta.2` is publicly available through M5Burner and as a [GitHub beta
+release](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.2).
 For a future release, use **USER CUSTOM → Publish** privately first and test
 with its Share Code. Only after the exact-tag hardware gate in
 [M5BURNER_HARDWARE_GATE.md](M5BURNER_HARDWARE_GATE.md) passes may its GitHub

--- a/docs/M5BURNER_RELEASE.md
+++ b/docs/M5BURNER_RELEASE.md
@@ -1,6 +1,6 @@
 # OrcSDR M5Burner release
 
-`v0.2.0-beta.2` is one normal Tab5 package. It contains the P4 application
+The current OrcSDR beta is one normal Tab5 package. It contains the P4 application
 and a pinned ESP-Hosted 3.0.6 C6 image. M5Burner writes the P4 only; OrcSDR
 offers a C6 update from Settings after it proves that the existing Hosted link
 is reachable.
@@ -31,8 +31,8 @@ local test zip. It never flashes hardware or uploads a listing.
 
 ## Publication record and future-release gate
 
-`v0.2.0-beta.2` is publicly available through M5Burner and as a [GitHub beta
-release](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.2).
+Published versions are available through M5Burner and [GitHub
+Releases](https://github.com/hardcoreerik/OrcSDR/releases).
 For a future release, use **USER CUSTOM → Publish** privately first and test
 with its Share Code. Only after the exact-tag hardware gate in
 [M5BURNER_HARDWARE_GATE.md](M5BURNER_HARDWARE_GATE.md) passes may its GitHub

--- a/docs/TAB5_BUILD_POLICY.md
+++ b/docs/TAB5_BUILD_POLICY.md
@@ -94,7 +94,7 @@ Healthy boot (2026-08-17, Hosted 2.12.6, mempool off):
 ## Installer and release package
 
 Use the current [M5Burner release and recovery instructions](M5BURNER_RELEASE.md)
-and [hardware acceptance gate](M5BURNER_HARDWARE_GATE.md). The beta.1 package
+and [hardware acceptance gate](M5BURNER_HARDWARE_GATE.md). The beta.2 package
 and installer target Hosted 3.0.6; the historical 2.12.6 measurements above do not
 establish acceptance for that pair.
 

--- a/docs/TAB5_BUILD_POLICY.md
+++ b/docs/TAB5_BUILD_POLICY.md
@@ -94,7 +94,7 @@ Healthy boot (2026-08-17, Hosted 2.12.6, mempool off):
 ## Installer and release package
 
 Use the current [M5Burner release and recovery instructions](M5BURNER_RELEASE.md)
-and [hardware acceptance gate](M5BURNER_HARDWARE_GATE.md). The beta.2 package
+and [hardware acceptance gate](M5BURNER_HARDWARE_GATE.md). The current beta package
 and installer target Hosted 3.0.6; the historical 2.12.6 measurements above do not
 establish acceptance for that pair.
 

--- a/docs/releases/v0.2.0-beta.2.md
+++ b/docs/releases/v0.2.0-beta.2.md
@@ -1,0 +1,37 @@
+# OrcSDR v0.2.0-beta.2 release notes
+
+This beta makes tuner ownership and background scanning safer on the M5Stack
+Tab5. It retains the one-package M5Burner installation introduced in beta.1:
+M5Burner writes the P4 application, and OrcSDR offers the embedded ESP-Hosted
+3.0.6 C6 image only through an explicit in-app confirmation.
+
+## Changes since beta.1
+
+- Added generation-token ownership for FM, P25, ADS-B, LoRa, general radio,
+  RF Lab, and RF Visualizer so stale work cannot retune a newly selected mode.
+- Added one shared asynchronous scan engine for retune, settle, measurement,
+  progress, cancellation, completion, failure, and optional frequency restore.
+- Moved FM preset scanning and P25 control-channel survey onto the shared engine.
+- Added optimized and ASan/LSan/UBSan host tests, including 10,000 allocation-free
+  scan cycles and 32-bit timer-rollover coverage.
+- Added a Tab5 radio-scan hardware gate that checks mode takeover, stale restore,
+  crashes, resets, watchdogs, heap, DMA-capable memory, and stack headroom.
+- Reconciled the architecture and ESP32-P4 portability documentation with the
+  existing Waveshare Module-DEV-KIT evidence in the driver repository.
+
+The existing LoRa survey was not migrated because correcting its measurement
+order changes observable behavior and needs separate hardware validation.
+
+## Validation record
+
+- Native ESP-IDF 5.5.4 build passed before release preparation.
+- Optimized and sanitizer host tests passed locally and in GitHub Actions.
+- Direct-flash Tab5 testing completed 10-cycle, 3-cycle, and 1-cycle radio scan
+  runs without a detected panic, watchdog, assertion, unexpected reset, stale
+  tuner restoration, or configured memory-limit failure.
+- The project owner previously hardware-verified the unchanged C6 update route
+  by returning the reachable C6 to 2.14.6 and using OrcSDR to update it to 3.0.6.
+
+The exact-tag bundle, hashes, embedded C6 provenance, private M5Burner install,
+and final device checks are release gates. Their results belong in the GitHub
+release record; this source note does not claim those steps before they run.

--- a/docs/releases/v0.2.0-beta.2.md
+++ b/docs/releases/v0.2.0-beta.2.md
@@ -16,6 +16,11 @@ M5Burner writes the P4 application, and OrcSDR offers the embedded ESP-Hosted
   scan cycles and 32-bit timer-rollover coverage.
 - Added a Tab5 radio-scan hardware gate that checks mode takeover, stale restore,
   crashes, resets, watchdogs, heap, DMA-capable memory, and stack headroom.
+- Lowered the best-effort RF analysis worker to idle priority so continuous DSP
+  and visualizer FFT work cannot starve Core 1's watched idle task.
+- Removed the obsolete RTL-SDR status painter that could place the former
+  startup status strip and **Open SDR radio** button over an active FM screen
+  when the receiver was hot-plugged.
 - Reconciled the architecture and ESP32-P4 portability documentation with the
   existing Waveshare Module-DEV-KIT evidence in the driver repository.
 
@@ -29,6 +34,13 @@ order changes observable behavior and needs separate hardware validation.
 - Direct-flash Tab5 testing completed 10-cycle, 3-cycle, and 1-cycle radio scan
   runs without a detected panic, watchdog, assertion, unexpected reset, stale
   tuner restoration, or configured memory-limit failure.
+- The visualizer/hot-plug fix built under native ESP-IDF 5.5.4 and flashed with
+  verified image hashes. Serial control opened Phosphor Persistence with a live
+  source, and the attached no-reset monitor recorded no watchdog, panic, or
+  reboot during the observed intervals. A later health snapshot showed
+  `uptime_ms=8001802`, `min_free_heap=22101928`, `dma_min=87295`, and
+  `dma_largest=47104`; the view had changed to Constellation by then, so the
+  full elapsed interval is not claimed as a continuous Phosphor soak.
 - The project owner previously hardware-verified the unchanged C6 update route
   by returning the reachable C6 to 2.14.6 and using OrcSDR to update it to 3.0.6.
 


### PR DESCRIPTION
The beta documentation still points users to v0.2.0-beta.1 even though `main` now contains the radio ownership/scan refactor and its regression suite. Hardware testing of the release candidate also exposed two Tab5 regressions: continuous DSP plus visualizer analysis could starve Core 1's watched idle task, and RTL-SDR hot-plug could repaint the former startup overlay over an active FM dashboard.

This PR prepares the source record for v0.2.0-beta.2 and includes the narrow fixes exercised by the current flashed test build.

Changes:
- update README, M5Burner, and build-policy references to v0.2.0-beta.2
- add beta.2 release notes covering radio ownership, the shared scan engine, regression tests, and acceptance boundaries
- run the best-effort `rf_analysis` worker at idle priority so the watched Core 1 idle task gets scheduler time during continuous DSP/FFT load
- remove the obsolete revision-driven RTL-SDR status painter that could draw the old status strip and **Open SDR radio** button over an active dashboard after USB hot-plug
- allow unchanged C6 image/update inputs to reuse prior hardware evidence while still requiring exact-package source revision and SHA-256 verification

Root-cause evidence:
- retained task-watchdog core dumps showed `rtl_dsp` in FM phase processing while `rf_analysis` was concurrently processing FFT work on Core 1
- stack and heap evidence were healthy; the failure was CPU starvation rather than a demonstrated leak, corrupt allocation, or brownout
- the hot-plug overlay came from a legacy status-revision path that painted home-screen elements without current dashboard ownership

Validation:
- native ESP-IDF 5.5.4 Tab5 build completed successfully
- the built images flashed to the Tab5 with verified hashes
- `RTL_VIS OPEN phosphor` returned `active=1 view=phosphor source=1 frozen=0`
- the attached no-reset serial monitor recorded no watchdog, panic, or reboot during the observed Phosphor intervals
- a later health snapshot reported `uptime_ms=8001802`, `free_heap=26907720`, `min_free_heap=22101928`, `dma_free=87671`, `dma_min=87295`, `dma_largest=47104`, and `main_stack_hwm=2816`
- the two runtime files in this PR match the flashed bugfix worktree byte-for-byte
- existing optimized and sanitizer host tests and the previously recorded 10-cycle, 3-cycle, and 1-cycle Tab5 radio-scan runs remain part of the beta.2 validation record

Honest acceptance boundaries:
- the visualizer had been changed to Constellation by the final health snapshot, so the full elapsed interval is not claimed as a continuous Phosphor soak
- the exact unplugged-boot -> FM -> RTL-SDR hot-plug sequence has not yet been rerun on this flashed fix
- the project owner previously verified the unchanged C6 route by returning the reachable C6 to 2.14.6 and using OrcSDR to update it to 3.0.6; this PR does not alter that code or image
- this PR does not claim an exact-tag beta.2 bundle or M5Burner installation; those gates run after merge and tagging

After merge, the intended sequence is to create the immutable beta.2 tag on the merge commit, rebuild the exact-tag P4/C6 bundle, verify provenance and ZIP contents, privately install through M5Burner without erase, run final device checks, and only then publish the GitHub release and public M5Burner listing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation and release guidance to reference the current published beta through GitHub Releases and M5Burner.
  - Generalized hardware acceptance requirements across public beta releases, with conditional downgrade testing.
  - Added release notes for v0.2.0-beta.2, including scanning improvements, validation results, and release gates.

- **Bug Fixes**
  - Improved responsiveness during continuous radio DSP by running best-effort RF analysis at idle priority.

- **UI Changes**
  - Removed the RTL-SDR status banner and its “Open SDR radio” action from the home screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->