### PR TITLE
Improve Tab5 Home dashboard layout and readability

### DIFF
--- a/apps/orcsdr-tab5/ui/dashboard_audio_control.cpp
+++ b/apps/orcsdr-tab5/ui/dashboard_audio_control.cpp
@@ -30,17 +30,17 @@ constexpr int kHomeY = 8;
 constexpr int kHomeW = 58;
 constexpr int kHomeH = 58;
 constexpr int kMuteX = 1099;
-constexpr int kMuteY = 8;
-constexpr int kMuteW = 58;
-constexpr int kMuteH = 58;
+constexpr int kMuteY = 12;
+constexpr int kMuteW = 54;
+constexpr int kMuteH = 54;
 constexpr int kVisualizerX = 1158;
-constexpr int kVisualizerY = 8;
-constexpr int kVisualizerW = 58;
-constexpr int kVisualizerH = 58;
+constexpr int kVisualizerY = 12;
+constexpr int kVisualizerW = 54;
+constexpr int kVisualizerH = 54;
 constexpr int kSettingsX = 1217;
-constexpr int kSettingsY = 8;
-constexpr int kSettingsW = 55;
-constexpr int kSettingsH = 58;
+constexpr int kSettingsY = 12;
+constexpr int kSettingsW = 51;
+constexpr int kSettingsH = 54;
 constexpr uint32_t kTrayTimeoutMs = 4000;
 
 bool hit(int32_t x, int32_t y, int bx, int by, int bw, int bh) {

--- a/apps/orcsdr-tab5/ui/dashboard_registry.cpp
+++ b/apps/orcsdr-tab5/ui/dashboard_registry.cpp
@@ -18,7 +18,7 @@ constexpr Descriptor kEntries[] = {
     {Id::marine, "MARINE", "VHF marine receiver", Category::audio, true},
     {Id::satellite, "SATELLITE", "Satellite receive workspace", Category::digital, true},
     {Id::rf_lab, "RF LAB", "Live measurements and driver tests", Category::utility, true},
-    {Id::wifi_analysis, "2.4 GHz ANALYZER", "Real Wi-Fi access-point survey", Category::utility, true},
+    {Id::wifi_analysis, "2.4 GHz WIFI", "Real Wi-Fi access-point survey", Category::utility, true},
     {Id::settings, "SETTINGS", "Global device settings", Category::system, true},
 };
 

--- a/apps/orcsdr-tab5/ui/home_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/home_dashboard.cpp
@@ -149,10 +149,10 @@ void draw_header_status() {
   text(current.wifi_connected && current.wifi_ip[0] ? current.wifi_ip : "OFFLINE",
        kHeaderStatusX + 54, 66, current.wifi_connected ? kCyan : TFT_ORANGE, 1);
   M5.Display.drawFastVLine(kHeaderStatusX + 114, 30, 52, kDim);
-  draw_usb_icon(kHeaderStatusX + 135, 54, current.usb_connected ? kCyan : kDim);
-  text("USB", kHeaderStatusX + 158, 42, TFT_WHITE, 2);
-  text(current.usb_connected ? "CONNECTED" : "DISCONNECTED", kHeaderStatusX + 158, 66,
-       current.usb_connected ? kCyan : TFT_ORANGE, 1);
+  draw_usb_icon(kHeaderStatusX + 135, 54, current.driver_ready ? kCyan : kDim);
+  text("RTL-SDR", kHeaderStatusX + 148, 42, TFT_WHITE, 2);
+  text(current.driver_ready ? "READY" : "NOT READY", kHeaderStatusX + 158, 66,
+       current.driver_ready ? kCyan : TFT_ORANGE, 1);
   M5.Display.drawFastVLine(kHeaderStatusX + 238, 30, 52, kDim);
   draw_battery(kHeaderStatusX + 254, 39);
   char value[12];

--- a/apps/orcsdr-tab5/ui/home_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/home_dashboard.cpp
@@ -21,8 +21,8 @@ constexpr int kRailX = 24, kRailY = 112, kRailW = 280, kRailH = 530;
 constexpr int kMainX = 318, kMainY = 112, kMainW = 930, kMainH = 530;
 constexpr int kPlotX = 330, kPlotW = 906;
 constexpr int kSpectrumY = 144, kSpectrumH = 151;
-constexpr int kWaterfallY = 298, kWaterfallH = 148;
-constexpr int kContrastY = 452;
+constexpr int kWaterfallY = 298, kWaterfallH = 158;
+constexpr int kContrastY = 462;
 constexpr int kContrastDownX = 462;
 constexpr int kContrastUpX = 724;
 constexpr int kContrastButtonW = 36;
@@ -267,18 +267,18 @@ float home_spectrum_floor(const float* levels, size_t count, float pipeline_floo
 }
 
 void draw_frequency() {
-  M5.Display.fillRect(kPlotX, 448, 430, 88, TFT_BLACK);
-  text("FREQUENCY", kPlotX, 462, kCyan, 2);
+  M5.Display.fillRect(kPlotX, 458, 430, 88, TFT_BLACK);
+  text("FREQUENCY", kPlotX, 472, kCyan, 2);
   char value[40];
   snprintf(value, sizeof(value), current.frequency_hz >= 1000000 ? "%.3f" : "%.1f",
            current.frequency_hz >= 1000000 ? current.frequency_hz / 1000000.0
                                            : current.frequency_hz / 1000.0);
-  text(value, kPlotX + 25, 506, kGreen, 4);
-  text(current.frequency_hz >= 1000000 ? "MHz" : "kHz", kPlotX + 350, 516,
+  text(value, kPlotX + 40, 516, kGreen, 4);
+  text(current.frequency_hz >= 1000000 ? "MHz" : "kHz", kPlotX + 350, 526,
        kGreen, 2);
   if (current.requested_frequency_hz != 0 &&
       current.requested_frequency_hz != current.frequency_hz)
-    text("TUNING", kPlotX + 425, 516, TFT_YELLOW, 1, middle_right);
+    text("TUNING", kPlotX + 425, 526, TFT_YELLOW, 1, middle_right);
   draw_waterfall_controls();
 }
 
@@ -306,34 +306,34 @@ void draw_spectrum_axis() {
 }
 
 void draw_tuning_controls() {
-  M5.Display.fillRect(kPlotX, 544, 610, 84, TFT_BLACK);
-  panel(kPlotX, 544, 610, 84, kCyan, 9);
-  panel(338, 557, 60, 56, kCyan, 7); text("<", 368, 585, kGreen, 3, middle_center);
-  text("SPAN", 470, 568, kCyan, 2, middle_center);
+  M5.Display.fillRect(kPlotX, 564, 610, 62, TFT_BLACK);
+  panel(kPlotX, 564, 610, 62, kCyan, 9);
+  panel(338, 571, 60, 48, kCyan, 7); text("<", 368, 595, kGreen, 3, middle_center);
+  text("SPAN", 470, 578, kCyan, 2, middle_center);
   char value[24];
   snprintf(value, sizeof(value), "%.0f kHz", current.span_hz / 1000.0);
-  text(value, 470, 596, kGreen, 2, middle_center);
-  panel(548, 557, 60, 56, kCyan, 7); text(">", 578, 585, kGreen, 3, middle_center);
-  panel(640, 557, 60, 56, kCyan, 7); text("<", 670, 585, kGreen, 3, middle_center);
-  text("STEP", 780, 568, kCyan, 2, middle_center);
+  text(value, 470, 606, kGreen, 2, middle_center);
+  panel(548, 571, 60, 48, kCyan, 7); text(">", 578, 595, kGreen, 3, middle_center);
+  panel(640, 571, 60, 48, kCyan, 7); text("<", 670, 595, kGreen, 3, middle_center);
+  text("STEP", 780, 578, kCyan, 2, middle_center);
   snprintf(value, sizeof(value), "%.1f kHz", current.step_hz / 1000.0);
-  text(value, 780, 596, kGreen, 2, middle_center);
-  panel(864, 557, 60, 56, kCyan, 7); text(">", 894, 585, kGreen, 3, middle_center);
+  text(value, 780, 606, kGreen, 2, middle_center);
+  panel(864, 571, 60, 48, kCyan, 7); text(">", 894, 595, kGreen, 3, middle_center);
 }
 
 void draw_audio_controls() {
-  M5.Display.fillRect(998, 458, 236, 72, TFT_BLACK);
-  panel(998, 458, 70, 72, kCyan, 8);
-  text("-", 1033, 494, kGreen, 4, middle_center);
-  panel(1076, 458, 80, 72, kCyan, 8);
-  text(current.sound_enabled ? "VOL" : "MUTE", 1116, 476,
+  M5.Display.fillRect(998, 468, 236, 72, TFT_BLACK);
+  panel(998, 468, 70, 72, kCyan, 8);
+  text("-", 1033, 504, kGreen, 4, middle_center);
+  panel(1076, 468, 80, 72, kCyan, 8);
+  text(current.sound_enabled ? "VOL" : "MUTE", 1116, 486,
        current.sound_enabled ? kCyan : TFT_ORANGE, 2, middle_center);
   char value[8];
   snprintf(value, sizeof(value), "%u", current.volume);
-  text(value, 1116, 505, current.sound_enabled ? kGreen : TFT_LIGHTGREY, 2,
+  text(value, 1116, 515, current.sound_enabled ? kGreen : TFT_LIGHTGREY, 2,
        middle_center);
-  panel(1164, 458, 70, 72, kCyan, 8);
-  text("+", 1199, 494, kGreen, 4, middle_center);
+  panel(1164, 468, 70, 72, kCyan, 8);
+  text("+", 1199, 504, kGreen, 4, middle_center);
 }
 
 void footer_text(const char* value, int x, uint16_t color) {
@@ -403,23 +403,23 @@ void draw_receiver_chrome() {
   M5.Display.fillRect(kPlotX, kWaterfallY, kPlotW, kWaterfallH, TFT_BLACK);
   M5.Display.drawRect(kPlotX, kWaterfallY, kPlotW, kWaterfallH, kDim);
   draw_frequency();
-  panel(770, 458, 92, 72, kCyan, 8);
-  text("MODE", 816, 474, kCyan, 2, middle_center);
-  text(current.mode[0] ? current.mode : "--", 816, 506, kGreen, 2, middle_center);
-  panel(874, 458, 112, 72, kCyan, 8);
-  text("STEP", 930, 474, kCyan, 2, middle_center);
+  panel(770, 468, 92, 72, kCyan, 8);
+  text("MODE", 816, 484, kCyan, 2, middle_center);
+  text(current.mode[0] ? current.mode : "--", 816, 516, kGreen, 2, middle_center);
+  panel(874, 468, 112, 72, kCyan, 8);
+  text("STEP", 930, 484, kCyan, 2, middle_center);
   char value[24]; snprintf(value, sizeof(value), "%.1f kHz", current.step_hz / 1000.0);
-  text(value, 930, 506, kGreen, 2, middle_center);
+  text(value, 930, 516, kGreen, 2, middle_center);
   draw_audio_controls();
   draw_tuning_controls();
-  panel(950, 557, 128, 56, kCyan, 7);
-  text("FILTER", 1014, 572, kCyan, 2, middle_center);
+  panel(950, 564, 128, 62, kCyan, 7);
+  text("FILTER", 1014, 582, kCyan, 2, middle_center);
   snprintf(value, sizeof(value), "%lu kHz", static_cast<unsigned long>(current.filter_bandwidth_hz / 1000u));
-  text(current.filter_bandwidth_hz ? value : "AUTO", 1014, 598, kGreen, 2, middle_center);
-  panel(1090, 557, 144, 56, kCyan, 7);
-  text("SIGNAL", 1162, 572, kCyan, 2, middle_center);
+  text(current.filter_bandwidth_hz ? value : "AUTO", 1014, 608, kGreen, 2, middle_center);
+  panel(1090, 564, 144, 62, kCyan, 7);
+  text("SIGNAL", 1162, 582, kCyan, 2, middle_center);
   snprintf(value, sizeof(value), "%.1f dBFS", static_cast<double>(current.relative_dbfs));
-  text(value, 1162, 598, kGreen, 2, middle_center);
+  text(value, 1162, 608, kGreen, 2, middle_center);
 }
 
 void draw_browser() {
@@ -481,7 +481,8 @@ Action tap_action(int32_t x, int32_t y) {
       return {ActionKind::open_dashboard, dashboards::recent(index - 1)};
     return {};
   }
-  if (inside(x, y, kPlotX, kSpectrumY, kPlotW, kSpectrumH + kWaterfallH)) {
+  if (inside(x, y, kPlotX, kSpectrumY, kPlotW,
+             kWaterfallY + kWaterfallH - kSpectrumY)) {
     const int64_t offset = (static_cast<int64_t>(x - kPlotX) * current.span_hz) /
                                kPlotW -
                            static_cast<int64_t>(current.span_hz / 2);
@@ -489,13 +490,13 @@ Action tap_action(int32_t x, int32_t y) {
     return {ActionKind::tune_frequency, dashboards::Id::count,
             requested > 0 ? static_cast<uint32_t>(requested) : 0};
   }
-  if (inside(x, y, 338, 557, 60, 56)) return {ActionKind::span_down};
-  if (inside(x, y, 548, 557, 60, 56)) return {ActionKind::span_up};
-  if (inside(x, y, 640, 557, 60, 56)) return {ActionKind::step_down};
-  if (inside(x, y, 864, 557, 60, 56)) return {ActionKind::step_up};
-  if (inside(x, y, 998, 458, 70, 72)) return {ActionKind::volume_down};
-  if (inside(x, y, 1076, 458, 80, 72)) return {ActionKind::sound_toggle};
-  if (inside(x, y, 1164, 458, 70, 72)) return {ActionKind::volume_up};
+  if (inside(x, y, 338, 571, 60, 48)) return {ActionKind::span_down};
+  if (inside(x, y, 548, 571, 60, 48)) return {ActionKind::span_up};
+  if (inside(x, y, 640, 571, 60, 48)) return {ActionKind::step_down};
+  if (inside(x, y, 864, 571, 60, 48)) return {ActionKind::step_up};
+  if (inside(x, y, 998, 468, 70, 72)) return {ActionKind::volume_down};
+  if (inside(x, y, 1076, 468, 80, 72)) return {ActionKind::sound_toggle};
+  if (inside(x, y, 1164, 468, 70, 72)) return {ActionKind::volume_up};
   return {};
 }
 
@@ -536,14 +537,14 @@ void update(const Snapshot& snapshot) {
   M5.Display.startWrite();
   if (tuner_changed) {
     draw_frequency();
-    M5.Display.fillRect(770, 458, 216, 72, TFT_BLACK);
-    panel(770, 458, 92, 72, kCyan, 8);
-    text("MODE", 816, 474, kCyan, 2, middle_center);
-    text(current.mode, 816, 506, kGreen, 2, middle_center);
-    panel(874, 458, 112, 72, kCyan, 8);
+    M5.Display.fillRect(770, 468, 216, 72, TFT_BLACK);
+    panel(770, 468, 92, 72, kCyan, 8);
+    text("MODE", 816, 484, kCyan, 2, middle_center);
+    text(current.mode, 816, 516, kGreen, 2, middle_center);
+    panel(874, 468, 112, 72, kCyan, 8);
     char value[24]; snprintf(value, sizeof(value), "%.1f kHz", current.step_hz / 1000.0);
-    text("STEP", 930, 474, kCyan, 2, middle_center);
-    text(value, 930, 506, kGreen, 2, middle_center);
+    text("STEP", 930, 484, kCyan, 2, middle_center);
+    text(value, 930, 516, kGreen, 2, middle_center);
   }
   if (audio_changed) draw_audio_controls();
   if (tuning_controls_changed) draw_tuning_controls();
@@ -669,6 +670,9 @@ bool self_check() {
              ActionKind::waterfall_contrast_down &&
          tap_action(kContrastUpX + 1, kContrastY + 1).kind ==
              ActionKind::waterfall_contrast_up &&
+         tap_action(339, 572).kind == ActionKind::span_down &&
+         tap_action(865, 572).kind == ActionKind::step_up &&
+         tap_action(999, 469).kind == ActionKind::volume_down &&
          tap_action(1223, 13).kind == ActionKind::open_device_settings &&
          tap_action(1100, 13).kind == ActionKind::sound_toggle &&
          std::abs(home_spectrum_floor(levels, std::size(levels), 10.0f) - 62.0f) < 0.01f;

--- a/apps/orcsdr-tab5/ui/home_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/home_dashboard.cpp
@@ -20,15 +20,20 @@ constexpr uint16_t kPanel = 0x0021;
 constexpr int kRailX = 24, kRailY = 112, kRailW = 280, kRailH = 530;
 constexpr int kMainX = 318, kMainY = 112, kMainW = 930, kMainH = 530;
 constexpr int kPlotX = 330, kPlotW = 906;
-constexpr int kSpectrumY = 150, kSpectrumH = 145;
+constexpr int kSpectrumY = 144, kSpectrumH = 151;
 constexpr int kWaterfallY = 298, kWaterfallH = 148;
-constexpr int kListX = 30, kListY = 158, kListW = 242, kListH = 360;
+constexpr int kContrastY = 452;
+constexpr int kContrastDownX = 462;
+constexpr int kContrastUpX = 724;
+constexpr int kContrastButtonW = 36;
+constexpr int kContrastButtonH = 28;
+constexpr int kListX = 30, kListY = 158, kListW = 242, kListH = 420;
 constexpr int kRowH = 52, kRowGap = 8, kRowPitch = kRowH + kRowGap;
-constexpr int kVisibleRows = 6;
+constexpr int kVisibleRows = 7;
 constexpr int kAllY = 590;
 constexpr int kTapDragThreshold = 10;
-constexpr int kHeaderStatusX = 620;
-constexpr int kHeaderStatusW = 480;
+constexpr int kHeaderStatusX = 595;
+constexpr int kHeaderStatusW = 474;
 
 Snapshot current{};
 bool shown = false;
@@ -154,9 +159,9 @@ void draw_header_status() {
   snprintf(value, sizeof(value), "%ld%%", static_cast<long>(current.battery_percent));
   text(current.battery_percent >= 0 ? value : "--", kHeaderStatusX + 322, 54, TFT_WHITE, 2);
   M5.Display.drawFastVLine(kHeaderStatusX + 352, 30, 52, kDim);
-  text(current.clock[0] ? current.clock : "--:--", kHeaderStatusX + 464, 42, TFT_WHITE, 2,
+  text(current.clock[0] ? current.clock : "--:--", kHeaderStatusX + kHeaderStatusW - 12, 42, TFT_WHITE, 2,
        middle_right);
-  text(current.date[0] ? current.date : "UPTIME", kHeaderStatusX + 464, 68, kCyan, 1,
+  text(current.date[0] ? current.date : "UPTIME", kHeaderStatusX + kHeaderStatusW - 12, 68, kCyan, 2,
        middle_right);
 }
 
@@ -243,14 +248,16 @@ uint8_t waterfall_range_db(uint8_t contrast) {
 }
 
 void draw_waterfall_controls() {
-  M5.Display.fillRect(1004, kWaterfallY + 2, 230, 27, TFT_BLACK);
-  panel(1004, kWaterfallY + 2, 36, 27, kCyan, 5);
-  text("<", 1022, kWaterfallY + 15, kGreen, 2, middle_center);
+  M5.Display.fillRect(kContrastDownX, kContrastY, 298, kContrastButtonH, TFT_BLACK);
+  panel(kContrastDownX, kContrastY, kContrastButtonW, kContrastButtonH, kCyan, 5);
+  text("<", kContrastDownX + kContrastButtonW / 2, kContrastY + 14, kGreen, 2,
+       middle_center);
   char value[24];
   snprintf(value, sizeof(value), "WF CONTRAST %u", waterfall_contrast);
-  text(value, 1118, kWaterfallY + 15, kCyan, 1, middle_center);
-  panel(1200, kWaterfallY + 2, 34, 27, kCyan, 5);
-  text(">", 1217, kWaterfallY + 15, kGreen, 2, middle_center);
+  text(value, 615, kContrastY + 14, kCyan, 2, middle_center);
+  panel(kContrastUpX, kContrastY, kContrastButtonW, kContrastButtonH, kCyan, 5);
+  text(">", kContrastUpX + kContrastButtonW / 2, kContrastY + 14, kGreen, 2,
+       middle_center);
 }
 
 float home_spectrum_floor(const float* levels, size_t count, float pipeline_floor) {
@@ -271,7 +278,8 @@ void draw_frequency() {
        kGreen, 2);
   if (current.requested_frequency_hz != 0 &&
       current.requested_frequency_hz != current.frequency_hz)
-    text("TUNING", kPlotX + 405, 472, TFT_YELLOW, 1, middle_right);
+    text("TUNING", kPlotX + 425, 516, TFT_YELLOW, 1, middle_right);
+  draw_waterfall_controls();
 }
 
 void format_spectrum_frequency(char* output, size_t output_size, uint32_t frequency_hz) {
@@ -289,11 +297,11 @@ void draw_spectrum_axis() {
   format_spectrum_frequency(low_text, sizeof(low_text), low);
   format_spectrum_frequency(center_text, sizeof(center_text), current.frequency_hz);
   format_spectrum_frequency(high_text, sizeof(high_text), high);
-  M5.Display.fillRect(kPlotX + 1, kSpectrumY + kSpectrumH - 16, kPlotW - 2, 15, TFT_BLACK);
-  text(low_text, kPlotX + 5, kSpectrumY + kSpectrumH - 8, TFT_LIGHTGREY, 1);
-  text(center_text, kPlotX + kPlotW / 2, kSpectrumY + kSpectrumH - 8, TFT_LIGHTGREY, 1,
+  M5.Display.fillRect(kPlotX + 1, kSpectrumY + kSpectrumH - 23, kPlotW - 2, 22, TFT_BLACK);
+  text(low_text, kPlotX + 5, kSpectrumY + kSpectrumH - 11, TFT_LIGHTGREY, 2);
+  text(center_text, kPlotX + kPlotW / 2, kSpectrumY + kSpectrumH - 11, TFT_LIGHTGREY, 2,
        middle_center);
-  text(high_text, kPlotX + kPlotW - 5, kSpectrumY + kSpectrumH - 8, TFT_LIGHTGREY, 1,
+  text(high_text, kPlotX + kPlotW - 5, kSpectrumY + kSpectrumH - 11, TFT_LIGHTGREY, 2,
        middle_right);
 }
 
@@ -301,13 +309,13 @@ void draw_tuning_controls() {
   M5.Display.fillRect(kPlotX, 544, 610, 84, TFT_BLACK);
   panel(kPlotX, 544, 610, 84, kCyan, 9);
   panel(338, 557, 60, 56, kCyan, 7); text("<", 368, 585, kGreen, 3, middle_center);
-  text("SPAN", 470, 568, kCyan, 1, middle_center);
+  text("SPAN", 470, 568, kCyan, 2, middle_center);
   char value[24];
   snprintf(value, sizeof(value), "%.0f kHz", current.span_hz / 1000.0);
   text(value, 470, 596, kGreen, 2, middle_center);
   panel(548, 557, 60, 56, kCyan, 7); text(">", 578, 585, kGreen, 3, middle_center);
   panel(640, 557, 60, 56, kCyan, 7); text("<", 670, 585, kGreen, 3, middle_center);
-  text("STEP", 780, 568, kCyan, 1, middle_center);
+  text("STEP", 780, 568, kCyan, 2, middle_center);
   snprintf(value, sizeof(value), "%.1f kHz", current.step_hz / 1000.0);
   text(value, 780, 596, kGreen, 2, middle_center);
   panel(864, 557, 60, 56, kCyan, 7); text(">", 894, 585, kGreen, 3, middle_center);
@@ -319,7 +327,7 @@ void draw_audio_controls() {
   text("-", 1033, 494, kGreen, 4, middle_center);
   panel(1076, 458, 80, 72, kCyan, 8);
   text(current.sound_enabled ? "VOL" : "MUTE", 1116, 476,
-       current.sound_enabled ? kCyan : TFT_ORANGE, 1, middle_center);
+       current.sound_enabled ? kCyan : TFT_ORANGE, 2, middle_center);
   char value[8];
   snprintf(value, sizeof(value), "%u", current.volume);
   text(value, 1116, 505, current.sound_enabled ? kGreen : TFT_LIGHTGREY, 2,
@@ -394,26 +402,24 @@ void draw_receiver_chrome() {
   }
   M5.Display.fillRect(kPlotX, kWaterfallY, kPlotW, kWaterfallH, TFT_BLACK);
   M5.Display.drawRect(kPlotX, kWaterfallY, kPlotW, kWaterfallH, kDim);
-  text("WATERFALL", kPlotX + 3, kWaterfallY + 12, kCyan, 2);
-  draw_waterfall_controls();
   draw_frequency();
   panel(770, 458, 92, 72, kCyan, 8);
-  text("MODE", 816, 474, kCyan, 1, middle_center);
+  text("MODE", 816, 474, kCyan, 2, middle_center);
   text(current.mode[0] ? current.mode : "--", 816, 506, kGreen, 2, middle_center);
   panel(874, 458, 112, 72, kCyan, 8);
-  text("STEP", 930, 474, kCyan, 1, middle_center);
+  text("STEP", 930, 474, kCyan, 2, middle_center);
   char value[24]; snprintf(value, sizeof(value), "%.1f kHz", current.step_hz / 1000.0);
-  text(value, 930, 506, kGreen, 1, middle_center);
+  text(value, 930, 506, kGreen, 2, middle_center);
   draw_audio_controls();
   draw_tuning_controls();
   panel(950, 557, 128, 56, kCyan, 7);
-  text("FILTER", 1014, 572, kCyan, 1, middle_center);
+  text("FILTER", 1014, 572, kCyan, 2, middle_center);
   snprintf(value, sizeof(value), "%lu kHz", static_cast<unsigned long>(current.filter_bandwidth_hz / 1000u));
-  text(current.filter_bandwidth_hz ? value : "AUTO", 1014, 598, kGreen, 1, middle_center);
+  text(current.filter_bandwidth_hz ? value : "AUTO", 1014, 598, kGreen, 2, middle_center);
   panel(1090, 557, 144, 56, kCyan, 7);
-  text("SIGNAL", 1162, 572, kCyan, 1, middle_center);
+  text("SIGNAL", 1162, 572, kCyan, 2, middle_center);
   snprintf(value, sizeof(value), "%.1f dBFS", static_cast<double>(current.relative_dbfs));
-  text(value, 1162, 598, kGreen, 1, middle_center);
+  text(value, 1162, 598, kGreen, 2, middle_center);
 }
 
 void draw_browser() {
@@ -464,9 +470,9 @@ Action tap_action(int32_t x, int32_t y) {
     }
     return {};
   }
-  if (inside(x, y, 1004, kWaterfallY + 2, 36, 27))
+  if (inside(x, y, kContrastDownX, kContrastY, kContrastButtonW, kContrastButtonH))
     return {ActionKind::waterfall_contrast_down};
-  if (inside(x, y, 1200, kWaterfallY + 2, 34, 27))
+  if (inside(x, y, kContrastUpX, kContrastY, kContrastButtonW, kContrastButtonH))
     return {ActionKind::waterfall_contrast_up};
   if (inside(x, y, kListX, kAllY, kListW, 42)) return {ActionKind::open_browser};
   if (inside(x, y, kListX, kListY, kListW, kListH)) {
@@ -532,12 +538,12 @@ void update(const Snapshot& snapshot) {
     draw_frequency();
     M5.Display.fillRect(770, 458, 216, 72, TFT_BLACK);
     panel(770, 458, 92, 72, kCyan, 8);
-    text("MODE", 816, 474, kCyan, 1, middle_center);
+    text("MODE", 816, 474, kCyan, 2, middle_center);
     text(current.mode, 816, 506, kGreen, 2, middle_center);
     panel(874, 458, 112, 72, kCyan, 8);
     char value[24]; snprintf(value, sizeof(value), "%.1f kHz", current.step_hz / 1000.0);
-    text("STEP", 930, 474, kCyan, 1, middle_center);
-    text(value, 930, 506, kGreen, 1, middle_center);
+    text("STEP", 930, 474, kCyan, 2, middle_center);
+    text(value, 930, 506, kGreen, 2, middle_center);
   }
   if (audio_changed) draw_audio_controls();
   if (tuning_controls_changed) draw_tuning_controls();
@@ -581,8 +587,8 @@ void draw_spectrum(const float* levels, size_t first_bin, size_t visible_bins,
   M5.Display.drawFastVLine(kPlotX + kPlotW / 2, kSpectrumY, kSpectrumH, kGreen);
   M5.Display.clearClipRect();
   draw_spectrum_axis();
-  M5.Display.setScrollRect(kPlotX + 1, kWaterfallY + 30, kPlotW - 2,
-                           kWaterfallH - 31, TFT_BLACK);
+  M5.Display.setScrollRect(kPlotX + 1, kWaterfallY + 1, kPlotW - 2,
+                           kWaterfallH - 2, TFT_BLACK);
   M5.Display.scroll(0, -2);
   for (size_t i = 0; i < samples; ++i) {
     const float normalized = std::clamp(
@@ -655,12 +661,16 @@ bool browser_active() { return shown && browser; }
 
 bool self_check() {
   const float levels[] = {60.0f, 60.0f, 60.0f, 84.0f};
-  return dashboards::self_check() && kVisibleRows == 6 && kTapDragThreshold == 10 &&
+  return dashboards::self_check() && kVisibleRows == 7 && kTapDragThreshold == 10 &&
          dashboards::count() > static_cast<size_t>(kVisibleRows) &&
-         kHeaderStatusX + kHeaderStatusW < 1114 &&
+         kHeaderStatusX + kHeaderStatusW <= 1099 &&
          waterfall_range_db(1) == 48 && waterfall_range_db(7) == 12 &&
-         tap_action(1223, 9).kind == ActionKind::open_device_settings &&
-         tap_action(1100, 9).kind == ActionKind::sound_toggle &&
+         tap_action(kContrastDownX + 1, kContrastY + 1).kind ==
+             ActionKind::waterfall_contrast_down &&
+         tap_action(kContrastUpX + 1, kContrastY + 1).kind ==
+             ActionKind::waterfall_contrast_up &&
+         tap_action(1223, 13).kind == ActionKind::open_device_settings &&
+         tap_action(1100, 13).kind == ActionKind::sound_toggle &&
          std::abs(home_spectrum_floor(levels, std::size(levels), 10.0f) - 62.0f) < 0.01f;
 }
 

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -8718,10 +8718,11 @@ orcsdr::home::Snapshot home_dashboard_snapshot(bool demo) {
   } else {
     strlcpy(snapshot.wifi_ip, device.wifi_ip, sizeof(snapshot.wifi_ip));
     const uint32_t seconds = millis() / 1000u;
-    snprintf(snapshot.clock, sizeof(snapshot.clock), "UP %02lu:%02lu",
+    snprintf(snapshot.clock, sizeof(snapshot.clock), "%02lu:%02lu:%02lu",
              static_cast<unsigned long>((seconds / 3600u) % 100u),
-             static_cast<unsigned long>((seconds / 60u) % 60u));
-    strlcpy(snapshot.date, "DEVICE UPTIME", sizeof(snapshot.date));
+             static_cast<unsigned long>((seconds / 60u) % 60u),
+             static_cast<unsigned long>(seconds % 60u));
+    strlcpy(snapshot.date, "UPTIME", sizeof(snapshot.date));
   }
   snapshot.driver_ready = demo || device.rtl_ready;
   snapshot.receiving = demo ||


### PR DESCRIPTION
The Tab5 Home dashboard had overlapping header controls, small tuning labels, unused space in the dashboard list, and inconsistent control-panel heights. Its USB badge also incorrectly reported DISCONNECTED because the installed M5Unified implementation returns -1 (unavailable) for Tab5 VBUS voltage.

This PR improves the existing Home layout and makes the receiver badge reflect actual RTL-SDR readiness:

- Reposition and widen the status panel; space the sound, VIS, and settings badges away from one another and the border.
- Display uptime as HH:MM:SS with a larger UPTIME caption.
- Expand the recent-dashboard rail to seven visible rows and rename the Wi-Fi dashboard entry to 2.4 GHz WIFI.
- Enlarge Home tuning labels and spectrum frequency-axis text; move waterfall contrast into the Frequency area and remove the Waterfall heading.
- Raise the spectrum top, expand waterfall history, move the frequency controls down, align the Span/Step and Filter/Signal panels, and reposition the frequency value. Update corresponding touch targets and layout self-checks.
- Replace the voltage-based USB badge with RTL-SDR / READY / NOT READY using the existing driver-ready snapshot and status redraw path.

Validation and provenance:

- Layout commits 2a64bc8 and 7bbb16d were built with native ESP-IDF 5.5.4, flashed with hash verification, and iterated using on-device framebuffer captures and user feedback.
- RTL_UI_REGRESSION CHECK and authenticated RUN passed during layout validation. Earlier RTL_HEALTH samples showed stable memory and no restart during those checks.
- Final badge commit 0739d50 passed the incremental build: app size 0x21a640, 47% partition free. git diff --check passed.
- Before merge, idf.py -B build-native-hosted3 -p COM17 flash completed with hash verification for bootloader, application, and partition table.
- Before merge, apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1 -Port COM17 -Run -PairingKeyPath <existing local key> passed: pass=1, all reported component/workflow checks=1, transitioned=1, restored=1, active=home, band=FM, frequency_hz=103718000. The final badge has not had a fresh screenshot inspection or physical unplug/reconnect test.

Diagnostic observations and limitations:

During earlier testing, saved Wi-Fi connection stalled with repeated SDIO 0x107 timeouts. A separate observed state mismatch accepted/saved FM frequencies while actual retunes remained at ADS-B 1090 MHz. After a user-initiated full reboot, serial showed a successful ADS-B stop and FM restart at 960000 samples/s, followed by live Wi-Fi connection in 8134 ms with zero reported USB overruns, USB drops, and audio drops at completion. The user then reported the ADS-B dashboard working with Wi-Fi on, but no aircraft were observed; this does not establish decoded aircraft reception.

A captured boot reported reset reason panic, and UI_DOC_SELF_CHECK_FAIL followed by UI_DOC_SELF_CHECK_OK. Neither was diagnosed or repaired in this PR. Reboot recovery does not prove the root cause, that the failures were caused by this branch or the earlier refactor, or that they cannot recur. No speculative radio or Wi-Fi patch was made.

USB hub support remains disabled and deferred. No C6 firmware/update logic, radio/DSP implementation, sample-rate configuration, or release packaging changes are included. The web API's separate USB power field is unchanged.
Review status: CodeRabbit completed review through 7bbb16d with no actionable findings. Its generic docstring-coverage warning was left optional. The manually requested incremental review for badge commit 0739d50 was rate-limited; GitHub displayed a successful CodeRabbit context labeled Review rate limited, which is not evidence of review of that final commit. The four-line correction was inspected locally, built, flashed, and passed the device UI regression before merge. Merge was explicitly authorized by the user.