### PR TITLE
Detect and mute encrypted P25 Phase I voice

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/apps/orcsdr-tab5/tools/run-p25-validation.ps1
+++ b/apps/orcsdr-tab5/tools/run-p25-validation.ps1
@@ -15,7 +15,8 @@ param(
   [uint32]$MinimumVoiceStackHeadroom = 1024,
   [string]$PairingKeyPath = (Join-Path $PSScriptRoot '..\..\..\.orclink\ui-doc.key'),
   [string]$BackupPath,
-  [switch]$CaptureFixture
+  [switch]$CaptureFixture,
+  [switch]$RequireEncryptedVoice
 )
 
 $ErrorActionPreference = 'Stop'
@@ -24,6 +25,7 @@ $script:serial = $null
 $script:key = $null
 $script:lastPing = [DateTime]::MinValue
 $script:tempNvs = $null
+$script:initialSoundEnabled = $null
 
 function Test-FatalLine([string]$Line) {
   return $Line -match '(?i)Guru Meditation|panic(?:ked|\x27ed)?|assert failed|abort\(|task watchdog|interrupt wdt|brownout detector|ESP-ROM:esp32p4|rst:0x|out of memory|alloc(?:ation)? failed|heap corruption'
@@ -70,6 +72,8 @@ function Get-Status {
     ImbeFrames = [uint32](Get-Field $line 'imbe_frames')
     PcmFrames = [uint32](Get-Field $line 'pcm_frames')
     VoiceQueueDrops = [uint32](Get-Field $line 'voice_queue_drops')
+    EncryptedMutedFrames = [uint32](Get-Field $line 'encrypted_muted_frames')
+    EncryptedReturns = [uint32](Get-Field $line 'encrypted_returns')
     HeapFree = [uint32](Get-Field $line 'heap_free')
     HeapMin = [uint32](Get-Field $line 'heap_min')
     VoiceStack = [uint32](Get-Field $line 'voice_stack_hwm')
@@ -156,10 +160,27 @@ try {
   $script:serial.DiscardInBuffer()
   Connect-Authenticated
 
+  $script:serial.WriteLine('RTL_SOUND')
+  $sound = Read-LineUntil { param($line) $line -match '^RTL_SOUND_STATUS enabled=[01]$' } 5
+  if ($sound -notmatch 'enabled=([01])$') { throw 'Could not read the initial sound state.' }
+  $script:initialSoundEnabled = [int]$Matches[1]
+  if ($script:initialSoundEnabled -eq 0) {
+    $script:serial.WriteLine('RTL_SOUND ON')
+    $enabled = Read-LineUntil { param($line) $line -match '^RTL_SOUND_OK enabled=1$' } 5
+    if ($null -eq $enabled) { throw 'Could not enable audio for P25 validation.' }
+  }
+
+  $script:serial.WriteLine('RTL_STOP')
+  $stopped = Read-LineUntil { param($line) $line -match '^RTL_STOP_RESULT ' } 8
+  if ($stopped -notmatch '^RTL_STOP_RESULT ESP_OK$') {
+    throw "Could not stop the existing radio session: $stopped"
+  }
+
   $script:serial.WriteLine("RTL_TUNE P25 $ControlFrequencyHz")
   $tune = Read-LineUntil { param($line) $line -match '^RTL_TUNE_' } 8
   if ($tune -notmatch '^RTL_TUNE_OK') { throw "P25 tune failed: $tune" }
   Write-Output $tune
+  Start-Sleep -Seconds 2
 
   $baseline = $null
   $lockDeadline = [DateTime]::UtcNow.AddSeconds($ControlLockSeconds)
@@ -214,26 +235,36 @@ try {
   $maxGrants = $baseline.GrantEvents
   $maxImbe = $baseline.ImbeFrames
   $maxPcm = $baseline.PcmFrames
+  $maxEncryptedMuted = $baseline.EncryptedMutedFrames
+  $maxEncryptedReturns = $baseline.EncryptedReturns
   $minHeap = [Math]::Min($baseline.HeapFree, $baseline.HeapMin)
   $minStack = if ($baseline.VoiceStack -gt 0) { $baseline.VoiceStack } else { [uint32]::MaxValue }
   $voiceSeen = $false
   $returnSeen = $false
   $relockSeen = $false
+  $encryptedSeen = $false
   $deadline = [DateTime]::UtcNow.AddSeconds($CallWindowSeconds)
   Write-Output "P25_VALIDATION_SOAK started=true seconds=$CallWindowSeconds"
   while ([DateTime]::UtcNow -lt $deadline) {
     $slice = [DateTime]::UtcNow.AddSeconds(3)
     while ([DateTime]::UtcNow -lt $slice) {
-      $line = Read-LineUntil { param($value) $value -match '^RTL_P25_FOLLOW_(VOICE|RETURN) ' } 1
+      $line = Read-LineUntil {
+        param($value)
+        $value -match '^RTL_P25_FOLLOW_(VOICE|RETURN) ' -or
+          $value -match '^RTL_P25_ENCRYPTED '
+      } 1
       if ($null -eq $line) { continue }
       Write-Output $line
       if ($line -match '^RTL_P25_FOLLOW_VOICE ') { $voiceSeen = $true }
       if ($line -match '^RTL_P25_FOLLOW_RETURN ') { $returnSeen = $true }
+      if ($line -match '^RTL_P25_ENCRYPTED ') { $encryptedSeen = $true }
     }
     $status = Get-Status
     $maxGrants = [Math]::Max($maxGrants, $status.GrantEvents)
     $maxImbe = [Math]::Max($maxImbe, $status.ImbeFrames)
     $maxPcm = [Math]::Max($maxPcm, $status.PcmFrames)
+    $maxEncryptedMuted = [Math]::Max($maxEncryptedMuted, $status.EncryptedMutedFrames)
+    $maxEncryptedReturns = [Math]::Max($maxEncryptedReturns, $status.EncryptedReturns)
     $minHeap = [Math]::Min($minHeap, [Math]::Min($status.HeapFree, $status.HeapMin))
     if ($status.VoiceStack -gt 0) { $minStack = [Math]::Min($minStack, $status.VoiceStack) }
     if ($status.UsbOverruns -gt $baseline.UsbOverruns -or
@@ -243,8 +274,8 @@ try {
         $status.VoiceQueueDrops -gt $baseline.VoiceQueueDrops) {
       throw "P25 drop counters grew during validation: $($status.Raw)"
     }
-    $relockSeen = $returnSeen -and $status.Follow -eq 'control' -and
-                  $status.FrameSync -eq 1 -and $status.TsbkGood -gt $baseline.TsbkGood
+    $relockSeen = $relockSeen -or ($returnSeen -and $status.Follow -eq 'control' -and
+                  $status.FrameSync -eq 1 -and $status.TsbkGood -gt $baseline.TsbkGood)
   }
 
   if ($maxGrants - $baseline.GrantEvents -lt $MinimumGrantCount) {
@@ -257,6 +288,11 @@ try {
   if ($minHeap -lt $MinimumHeapBytes) { throw "Heap floor failed: $minHeap bytes." }
   if ($minStack -eq [uint32]::MaxValue -or $minStack -lt $MinimumVoiceStackHeadroom) {
     throw "P25 voice task stack headroom failed: $minStack."
+  }
+  if ($RequireEncryptedVoice -and (-not $encryptedSeen -or
+      $maxEncryptedMuted -le $baseline.EncryptedMutedFrames -or
+      $maxEncryptedReturns -le $baseline.EncryptedReturns)) {
+    throw 'No encrypted LDU2 mute and control-channel return were observed.'
   }
 
   if ($fixturePath) {
@@ -277,9 +313,21 @@ try {
     "P25_VALIDATION_RESULT result=PASS control_hz=$activeControlHz " +
     "grant_events=$($maxGrants - $baseline.GrantEvents) " +
     "imbe_frames=$maxImbe pcm_frames=$maxPcm min_heap=$minHeap " +
-    "voice_stack_hwm=$minStack voice_return=$([int]$returnSeen) relock=$([int]$relockSeen)")
+    "voice_stack_hwm=$minStack voice_return=$([int]$returnSeen) relock=$([int]$relockSeen) " +
+    "encrypted_seen=$([int]$encryptedSeen) encrypted_muted_frames=$maxEncryptedMuted " +
+    "encrypted_returns=$maxEncryptedReturns")
 } finally {
-  if ($null -ne $script:serial -and $script:serial.IsOpen) { $script:serial.Close() }
+  if ($null -ne $script:serial -and $script:serial.IsOpen) {
+    if ($script:initialSoundEnabled -eq 0) {
+      try {
+        $script:serial.WriteLine('RTL_SOUND OFF')
+        [void](Read-LineUntil { param($line) $line -match '^RTL_SOUND_OK enabled=0$' } 5)
+      } catch {
+        Write-Warning "Could not restore the initial sound state: $($_.Exception.Message)"
+      }
+    }
+    $script:serial.Close()
+  }
   if ($null -ne $script:key) {
     [Security.Cryptography.CryptographicOperations]::ZeroMemory($script:key)
   }

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -1558,6 +1558,11 @@ std::atomic<uint32_t> p25_voice_stack_hwm{0};
 std::atomic<uint32_t> p25_imbe_max_us{0};
 std::atomic<uint32_t> p25_imbe_synth_max_us{0};
 std::atomic<uint32_t> p25_audio_queue_max_us{0};
+std::atomic<bool> p25_encrypted_voice_pending{false};
+std::atomic<bool> p25_encrypted_voice_seen{false};
+std::atomic<uint32_t> p25_encrypted_voice_muted_frames{0};
+std::atomic<uint32_t> p25_encrypted_voice_returns{0};
+std::atomic<uint32_t> p25_last_encryption{0};
 orcsdr::p25voice::Decoder p25_voice_decoder{};
 uint8_t p25_candidate_index = 0;
 float p25_candidate_levels[orcsdr::p25config::kMaxControlChannels] = {};
@@ -5918,8 +5923,19 @@ void p25_voice_task(void*) {
       p25_voice_decoder.reset();
     }
     if (g_stream_band != RtlBand::p25 ||
-        p25_follow_state.load(std::memory_order_acquire) != P25FollowState::voice ||
-        !rtl_audio_user_enabled.load(std::memory_order_acquire)) continue;
+        p25_follow_state.load(std::memory_order_acquire) != P25FollowState::voice) continue;
+    if (!frame.encryption.valid) continue;
+    if (frame.encryption.encrypted) {
+      p25_last_encryption.store(
+          static_cast<uint32_t>(frame.encryption.algorithm_id) << 16 |
+              frame.encryption.key_id,
+          std::memory_order_release);
+      p25_encrypted_voice_seen.store(true, std::memory_order_release);
+      p25_encrypted_voice_muted_frames.fetch_add(1, std::memory_order_relaxed);
+      p25_encrypted_voice_pending.store(true, std::memory_order_release);
+      continue;
+    }
+    if (!rtl_audio_user_enabled.load(std::memory_order_acquire)) continue;
 
     const int64_t started_us = esp_timer_get_time();
     orcsdr::p25voice::Result result{};
@@ -7038,6 +7054,11 @@ static void rtl_driver_app_task(void *) {
         p25_imbe_errors.store(0, std::memory_order_relaxed);
         p25_pcm_frames.store(0, std::memory_order_relaxed);
         p25_grant_events.store(0, std::memory_order_relaxed);
+        p25_encrypted_voice_pending.store(false, std::memory_order_relaxed);
+        p25_encrypted_voice_seen.store(false, std::memory_order_relaxed);
+        p25_encrypted_voice_muted_frames.store(0, std::memory_order_relaxed);
+        p25_encrypted_voice_returns.store(0, std::memory_order_relaxed);
+        p25_last_encryption.store(0, std::memory_order_relaxed);
         p25_audio_last_ms.store(0, std::memory_order_relaxed);
         p25_voice_stack_hwm.store(0, std::memory_order_relaxed);
         p25_imbe_max_us.store(0, std::memory_order_relaxed);
@@ -8161,6 +8182,10 @@ orcsdr::p25::Snapshot p25_dashboard_snapshot() {
       p25_follow_state.load(std::memory_order_acquire) == P25FollowState::voice;
   snapshot.imbe_frames = p25_imbe_frames.load(std::memory_order_relaxed);
   snapshot.imbe_errors = p25_imbe_errors.load(std::memory_order_relaxed);
+  const uint32_t encryption = p25_last_encryption.load(std::memory_order_acquire);
+  snapshot.voice_encrypted = p25_encrypted_voice_seen.load(std::memory_order_acquire);
+  snapshot.voice_algorithm_id = static_cast<uint8_t>(encryption >> 16);
+  snapshot.voice_key_id = static_cast<uint16_t>(encryption);
   snapshot.candidate_index = p25_candidate_index;
   snapshot.candidate_count = p25_config.control_channel_count;
   std::copy_n(std::begin(p25_candidate_levels), p25_config.control_channel_count,
@@ -8591,6 +8616,30 @@ void service_p25_follow(uint32_t now) {
       g_iq_rec_kind.load(std::memory_order_relaxed) == IqCaptureKind::p25) return;
   const auto decoded = orcsdr::p25decoder::snapshot();
   if (p25_follow_state.load(std::memory_order_acquire) == P25FollowState::voice) {
+    if (p25_encrypted_voice_pending.exchange(false, std::memory_order_acq_rel)) {
+      const uint32_t encryption = p25_last_encryption.load(std::memory_order_acquire);
+      p25_follow_grant.encrypted = true;
+      Serial.printf(
+          "RTL_P25_ENCRYPTED tg=%u voice_hz=%lu algid=%02X kid=%04X action=%s\n",
+          p25_follow_grant.talkgroup,
+          static_cast<unsigned long>(p25_voice_frequency_hz),
+          static_cast<unsigned>(encryption >> 16),
+          static_cast<unsigned>(encryption & 0xFFFFu),
+          p25_encryption_skip.load(std::memory_order_relaxed) ? "muted_return" : "muted_hold");
+      if (p25_encryption_skip.load(std::memory_order_relaxed)) {
+        p25_skipped_talkgroup = p25_follow_grant.talkgroup;
+        p25_skip_until_ms = now + 2000;
+        p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+        p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
+        p25_voice_frequency_hz = 0;
+        p25_encrypted_voice_returns.fetch_add(1, std::memory_order_relaxed);
+        request_hot_retune(p25_control_frequency_hz);
+        Serial.printf("RTL_P25_FOLLOW_RETURN control_hz=%lu reason=encrypted tg=%u\n",
+                      static_cast<unsigned long>(p25_control_frequency_hz),
+                      p25_follow_grant.talkgroup);
+        return;
+      }
+    }
     const bool never_acquired = decoded.last_voice_ms == 0 &&
                                 now - p25_follow_started_ms >= kP25VoiceAcquireMs;
     const bool ended = decoded.last_voice_ms != 0 &&
@@ -8622,6 +8671,8 @@ void service_p25_follow(uint32_t now) {
   p25_control_frequency_hz = rtl_ui_frequency_hz;
   p25_voice_frequency_hz = grant.frequency_hz;
   p25_follow_grant = grant;
+  p25_encrypted_voice_seen.store(false, std::memory_order_release);
+  p25_last_encryption.store(0, std::memory_order_release);
   p25_follow_started_ms = now;
   p25_follow_state.store(P25FollowState::voice, std::memory_order_release);
   p25_grant_events.fetch_add(1, std::memory_order_relaxed);
@@ -12042,6 +12093,7 @@ void process_command(char* command) {
     Serial.println("RTL_RDS_CAPTURE_START/STOP/STATUS - capture FM MPX to SD for replay");
     Serial.println("RTL_RDS_REPLAY <path.s16>       - replay captured MPX while radio is stopped");
     Serial.println("RTL_P25_STATUS                 - profile, decoder, voice and memory diagnostics");
+    Serial.println("RTL_P25_ENCRYPTION_STATUS      - last LDU2 encryption and mute/return counters");
     Serial.println("RTL_P25_SCAN                   - survey configured control-channel candidates (auth)");
     Serial.println("RTL_P25_IQ_START|STOP|STATUS   - bounded control-channel IQ capture (mutations auth)");
     Serial.println("RTL_P25_REPLAY <path.orciq>    - replay a stopped-radio P25 capture (auth)");
@@ -12114,19 +12166,36 @@ void process_command(char* command) {
     (void)p25_replay(command + 15);
     return;
   }
+  if (strcmp(command, "RTL_P25_ENCRYPTION_STATUS") == 0) {
+    const uint32_t encryption = p25_last_encryption.load(std::memory_order_acquire);
+    Serial.printf(
+        "RTL_P25_ENCRYPTION_STATUS detected=%d algid=%02X kid=%04X muted_frames=%lu "
+        "returns=%lu skip_enabled=%d\n",
+        p25_encrypted_voice_seen.load(std::memory_order_acquire) ? 1 : 0,
+        static_cast<unsigned>(encryption >> 16),
+        static_cast<unsigned>(encryption & 0xFFFFu),
+        static_cast<unsigned long>(
+            p25_encrypted_voice_muted_frames.load(std::memory_order_relaxed)),
+        static_cast<unsigned long>(p25_encrypted_voice_returns.load(std::memory_order_relaxed)),
+        p25_encryption_skip.load(std::memory_order_relaxed) ? 1 : 0);
+    return;
+  }
   if (strcmp(command, "RTL_P25_STATUS") == 0) {
     const auto decoded = orcsdr::p25decoder::snapshot();
     unsigned grant_count = 0;
     for (const auto& grant : decoded.recent_grants) grant_count += grant.valid ? 1u : 0u;
     esp_rtl_sdr_metrics_t metrics{};
     if (g_rtl != nullptr) (void)esp_rtl_sdr_get_metrics(g_rtl, &metrics);
+    const uint32_t encryption = p25_last_encryption.load(std::memory_order_acquire);
     Serial.printf(
         "RTL_P25_STATUS profile=\"%s\" identity_source=air "
         "frequency_hz=%lu survey=%d candidate=%u relative_dbfs=%.1f "
         "frame_sync=%d identity=%d nac=%03X wacn=%05lX sysid=%03X rfss=%u site=%u "
         "sync_words=%lu nid_good=%lu nid_failed=%lu tsbk_good=%lu tsbk_failed=%lu "
         "ber_percent=%.2f grants=%d grant_events=%lu follow=%s control_hz=%lu voice_hz=%lu "
-        "voice_ldus=%lu voice_frames=%lu voice_queue_drops=%lu imbe_frames=%lu "
+        "voice_ldus=%lu voice_frames=%lu voice_queue_drops=%lu enc_sync_good=%lu "
+        "enc_sync_failed=%lu encrypted_detected=%d algid=%02X kid=%04X "
+        "encrypted_muted_frames=%lu encrypted_returns=%lu imbe_frames=%lu "
         "imbe_errors=%lu pcm_frames=%lu voice_stack_hwm=%lu imbe_max_us=%lu "
         "imbe_synth_max_us=%lu audio_queue_max_us=%lu heap_free=%u heap_min=%u "
         "psram_free=%u usb_overruns=%u usb_drops=%u iq_drops=%u audio_drops=%u\n",
@@ -12152,6 +12221,14 @@ void process_command(char* command) {
         static_cast<unsigned long>(decoded.voice_ldus),
         static_cast<unsigned long>(decoded.voice_frames),
         static_cast<unsigned long>(decoded.voice_queue_drops),
+        static_cast<unsigned long>(decoded.encryption_sync_good),
+        static_cast<unsigned long>(decoded.encryption_sync_failed),
+        p25_encrypted_voice_seen.load(std::memory_order_acquire) ? 1 : 0,
+        static_cast<unsigned>(encryption >> 16),
+        static_cast<unsigned>(encryption & 0xFFFFu),
+        static_cast<unsigned long>(
+            p25_encrypted_voice_muted_frames.load(std::memory_order_relaxed)),
+        static_cast<unsigned long>(p25_encrypted_voice_returns.load(std::memory_order_relaxed)),
         static_cast<unsigned long>(p25_imbe_frames.load(std::memory_order_relaxed)),
         static_cast<unsigned long>(p25_imbe_errors.load(std::memory_order_relaxed)),
         static_cast<unsigned long>(p25_pcm_frames.load(std::memory_order_relaxed)),

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -5278,6 +5278,7 @@ void stop_p25_automation() {
   cancel_p25_survey();
   p25_entry_probe_at_ms = 0;
   p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+  orcsdr::p25decoder::suspend_voice();
   p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
   p25_voice_frequency_hz = 0;
 }
@@ -5921,6 +5922,7 @@ void p25_voice_task(void*) {
     if (next_session != session) {
       session = next_session;
       p25_voice_decoder.reset();
+      continue;
     }
     if (g_stream_band != RtlBand::p25 ||
         p25_follow_state.load(std::memory_order_acquire) != P25FollowState::voice) continue;
@@ -7048,8 +7050,9 @@ static void rtl_driver_app_task(void *) {
       rtl_audio_submit_failures.store(0, std::memory_order_relaxed);
       rtl_signal_dbfs.store(-90.0f, std::memory_order_relaxed);
       if (band == RtlBand::p25) {
-        orcsdr::p25decoder::reset();
+        orcsdr::p25decoder::suspend_voice();
         p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
+        orcsdr::p25decoder::reset();
         p25_imbe_frames.store(0, std::memory_order_relaxed);
         p25_imbe_errors.store(0, std::memory_order_relaxed);
         p25_pcm_frames.store(0, std::memory_order_relaxed);
@@ -8228,6 +8231,7 @@ orcsdr::p25::Snapshot p25_dashboard_snapshot() {
 void tune_p25_control(uint32_t frequency_hz) {
   frequency_hz = rtl_clamp_frequency(RtlBand::p25, frequency_hz);
   p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+  orcsdr::p25decoder::suspend_voice();
   p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
   p25_control_frequency_hz = frequency_hz;
   p25_voice_frequency_hz = 0;
@@ -8300,6 +8304,7 @@ void handle_p25_dashboard_action(const orcsdr::p25::Action& action) {
       }
       if (p25_follow_state.load(std::memory_order_acquire) == P25FollowState::voice) {
         p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+        orcsdr::p25decoder::suspend_voice();
         p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
         p25_voice_frequency_hz = 0;
         request_hot_retune(p25_control_frequency_hz);
@@ -8312,6 +8317,7 @@ void handle_p25_dashboard_action(const orcsdr::p25::Action& action) {
       if (!p25_auto_follow.load(std::memory_order_relaxed) &&
           p25_follow_state.load(std::memory_order_acquire) == P25FollowState::voice) {
         p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+        orcsdr::p25decoder::suspend_voice();
         p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
         p25_voice_frequency_hz = 0;
         request_hot_retune(p25_control_frequency_hz);
@@ -8628,8 +8634,9 @@ void service_p25_follow(uint32_t now) {
           p25_encryption_skip.load(std::memory_order_relaxed) ? "muted_return" : "muted_hold");
       if (p25_encryption_skip.load(std::memory_order_relaxed)) {
         p25_skipped_talkgroup = p25_follow_grant.talkgroup;
-        p25_skip_until_ms = now + 2000;
+        p25_skip_until_ms = now + 30000;
         p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+        orcsdr::p25decoder::suspend_voice();
         p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
         p25_voice_frequency_hz = 0;
         p25_encrypted_voice_returns.fetch_add(1, std::memory_order_relaxed);
@@ -8646,6 +8653,7 @@ void service_p25_follow(uint32_t now) {
                        now - decoded.last_voice_ms >= kP25VoiceHangMs;
     if (!never_acquired && !ended) return;
     p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+    orcsdr::p25decoder::suspend_voice();
     p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
     p25_voice_frequency_hz = 0;
     request_hot_retune(p25_control_frequency_hz);
@@ -8671,12 +8679,14 @@ void service_p25_follow(uint32_t now) {
   p25_control_frequency_hz = rtl_ui_frequency_hz;
   p25_voice_frequency_hz = grant.frequency_hz;
   p25_follow_grant = grant;
+  p25_encrypted_voice_pending.store(false, std::memory_order_release);
   p25_encrypted_voice_seen.store(false, std::memory_order_release);
   p25_last_encryption.store(0, std::memory_order_release);
   p25_follow_started_ms = now;
+  orcsdr::p25decoder::suspend_voice();
+  p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
   p25_follow_state.store(P25FollowState::voice, std::memory_order_release);
   p25_grant_events.fetch_add(1, std::memory_order_relaxed);
-  p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
   (void)ensure_speaker_running(rtl_live_volume.load(std::memory_order_acquire));
   request_hot_retune(grant.frequency_hz);
   Serial.printf("RTL_P25_FOLLOW_VOICE control_hz=%lu voice_hz=%lu tg=%u src=%lu emergency=%d\n",

--- a/apps/orcsdr-tab5/ui/p25_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/p25_dashboard.cpp
@@ -198,13 +198,18 @@ void draw_monitor_dynamic() {
   M5.Display.fillRect(42, 330, 764, 135, kPanel);
   const auto& grant = g_snapshot.decoded.current_grant;
   if (grant.valid) {
-    text(g_snapshot.following_voice ? "FOLLOWING CLEAR PHASE I VOICE" :
+    text(g_snapshot.voice_encrypted ? "ENCRYPTED PHASE I VOICE MUTED" :
+         g_snapshot.following_voice ? "FOLLOWING CLEAR PHASE I VOICE" :
          grant_live(grant) ? "LIVE CONTROL-CHANNEL GRANT" : "LAST GRANT — STALE",
-         424, 362, (g_snapshot.following_voice || grant_live(grant)) ? kGreen : kYellow, 2);
+         424, 362, g_snapshot.voice_encrypted ? kRed :
+             (g_snapshot.following_voice || grant_live(grant)) ? kGreen : kYellow, 2);
     snprintf(value, sizeof(value), "TGID  %u     %s     SOURCE  %lu", grant.talkgroup,
              talkgroup_alias(grant.talkgroup), static_cast<unsigned long>(grant.source_id));
     text(value, 58, 410, TFT_WHITE, 2, middle_left);
-    if (grant.frequency_hz)
+    if (g_snapshot.voice_encrypted)
+      snprintf(value, sizeof(value), "VOICE MUTED     ALGID %02X     KID %04X",
+               g_snapshot.voice_algorithm_id, g_snapshot.voice_key_id);
+    else if (grant.frequency_hz)
       snprintf(value, sizeof(value), "VOICE  %.4f MHz     MODE  %s%s",
                grant.frequency_hz / 1000000.0, grant.tdma ? "PHASE II" : "PHASE I",
                grant.encrypted ? "  ENCRYPTED" : "  CLEAR");
@@ -212,7 +217,8 @@ void draw_monitor_dynamic() {
       snprintf(value, sizeof(value), "VOICE  AWAITING BAND PLAN     MODE  %s%s",
                grant.tdma ? "PHASE II" : "PHASE I",
                grant.encrypted ? "  ENCRYPTED" : "  CLEAR");
-    text(value, 58, 447, grant.encrypted ? kRed : kGreen, 2, middle_left);
+    text(value, 58, 447, (grant.encrypted || g_snapshot.voice_encrypted) ? kRed : kGreen,
+         2, middle_left);
   } else {
     text(g_snapshot.decoded.frame_sync ? "P25 CONTROL CHANNEL LOCKED" :
          "SEARCHING FOR P25 CONTROL CHANNEL", 424, 362,
@@ -520,6 +526,9 @@ void update(const Snapshot& snapshot) {
       snapshot.hold_talkgroup != g_snapshot.hold_talkgroup ||
       snapshot.auto_follow != g_snapshot.auto_follow ||
       snapshot.encryption_skip != g_snapshot.encryption_skip ||
+      snapshot.voice_encrypted != g_snapshot.voice_encrypted ||
+      snapshot.voice_algorithm_id != g_snapshot.voice_algorithm_id ||
+      snapshot.voice_key_id != g_snapshot.voice_key_id ||
       snapshot.following_voice != g_snapshot.following_voice ||
       snapshot.candidate_index != g_snapshot.candidate_index ||
       snapshot.config_revision != g_snapshot.config_revision ||

--- a/apps/orcsdr-tab5/ui/p25_dashboard.hpp
+++ b/apps/orcsdr-tab5/ui/p25_dashboard.hpp
@@ -32,6 +32,9 @@ struct Snapshot {
   bool auto_follow = true;
   bool encryption_skip = true;
   bool following_voice = false;
+  bool voice_encrypted = false;
+  uint8_t voice_algorithm_id = 0;
+  uint16_t voice_key_id = 0;
   uint32_t imbe_frames = 0;
   uint32_t imbe_errors = 0;
   uint8_t candidate_index = 0;

--- a/apps/orcsdr-tab5/ui/p25_decoder.cpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder.cpp
@@ -12,10 +12,20 @@ constexpr size_t kVoiceQueueDepth = 18;
 std::array<VoiceFrame, kVoiceQueueDepth> g_voice_queue{};
 std::atomic<uint8_t> g_voice_write{0};
 std::atomic<uint8_t> g_voice_read{0};
+std::atomic<uint32_t> g_voice_generation{0};
+std::atomic<bool> g_voice_accepting{false};
 Snapshot g_public_snapshot{};
 portMUX_TYPE g_snapshot_mux = portMUX_INITIALIZER_UNLOCKED;
 
-bool enqueue_voice(const VoiceFrame& frame, void*) {
+struct VoiceContext {
+  uint32_t generation;
+  bool accepting;
+};
+
+bool enqueue_voice(const VoiceFrame& frame, void* context) {
+  const auto* voice = static_cast<const VoiceContext*>(context);
+  if (!voice->accepting || !g_voice_accepting.load(std::memory_order_acquire) ||
+      voice->generation != g_voice_generation.load(std::memory_order_acquire)) return true;
   const uint8_t write = g_voice_write.load(std::memory_order_relaxed);
   const uint8_t next = static_cast<uint8_t>((write + 1) % kVoiceQueueDepth);
   if (next == g_voice_read.load(std::memory_order_acquire)) return false;
@@ -43,9 +53,18 @@ void reset() {
 }
 
 void reset_at(uint32_t now_ms) {
+  g_voice_accepting.store(false, std::memory_order_release);
   clear_voice_queue();
   p25core::reset(now_ms);
+  g_voice_generation.fetch_add(1, std::memory_order_acq_rel);
+  g_voice_accepting.store(true, std::memory_order_release);
   publish_snapshot();
+}
+
+void suspend_voice() {
+  g_voice_accepting.store(false, std::memory_order_release);
+  g_voice_generation.fetch_add(1, std::memory_order_acq_rel);
+  clear_voice_queue();
 }
 
 void process_cu8(const uint8_t* iq, size_t bytes) {
@@ -53,7 +72,10 @@ void process_cu8(const uint8_t* iq, size_t bytes) {
 }
 
 void process_cu8_at(const uint8_t* iq, size_t bytes, uint32_t now_ms) {
-  p25core::process_cu8(iq, bytes, now_ms, enqueue_voice);
+  VoiceContext voice{
+      g_voice_generation.load(std::memory_order_acquire),
+      g_voice_accepting.load(std::memory_order_acquire)};
+  p25core::process_cu8(iq, bytes, now_ms, enqueue_voice, &voice);
   publish_snapshot();
 }
 

--- a/apps/orcsdr-tab5/ui/p25_decoder.hpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder.hpp
@@ -15,6 +15,7 @@ inline constexpr size_t kVoiceFrameBits = p25core::kVoiceFrameBits;
 void reset();
 void process_cu8(const uint8_t* iq, size_t bytes);
 void reset_at(uint32_t now_ms);
+void suspend_voice();
 void process_cu8_at(const uint8_t* iq, size_t bytes, uint32_t now_ms);
 Snapshot snapshot();
 bool pop_voice_frame(VoiceFrame* frame);

--- a/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
@@ -64,6 +64,8 @@ struct BandPlanSlot {
 
 constexpr std::array<size_t, 9> kVoiceBitOffsets = {
     0, 144, 328, 512, 696, 880, 1064, 1248, 1424};
+constexpr std::array<size_t, 6> kEncryptionBitOffsets = {
+    288, 472, 656, 840, 1024, 1208};
 
 std::array<uint8_t, 126> g_gf_exp{};
 std::array<int8_t, 64> g_gf_log{};
@@ -242,6 +244,165 @@ std::array<uint8_t, 98> trellis_encode(const std::array<uint8_t, 48>& input) {
   return channel;
 }
 
+int bit_count(uint16_t value) {
+  int count = 0;
+  while (value != 0) {
+    value &= static_cast<uint16_t>(value - 1);
+    ++count;
+  }
+  return count;
+}
+
+uint16_t hamming_10_6_encode(uint8_t data) {
+  constexpr uint16_t kGenerator[6] = {
+      0x20E, 0x10D, 0x08B, 0x047, 0x023, 0x01C};
+  uint16_t codeword = 0;
+  for (int bit = 0; bit < 6; ++bit)
+    if (data & (0x20u >> bit)) codeword ^= kGenerator[bit];
+  return codeword;
+}
+
+int hamming_10_6_decode(uint16_t received, uint8_t* data) {
+  int best_distance = 11;
+  uint8_t best_data = 0;
+  for (uint8_t candidate = 0; candidate < 64; ++candidate) {
+    const int distance = bit_count(received ^ hamming_10_6_encode(candidate));
+    if (distance < best_distance) {
+      best_distance = distance;
+      best_data = candidate;
+    }
+  }
+  // A double-bit error is outside the inner code's correction radius. Keep
+  // its systematic data bits and let the outer RS code correct the symbol.
+  *data = best_distance <= 1 ? best_data : static_cast<uint8_t>(received >> 4);
+  return best_distance <= 1 ? best_distance : 0;
+}
+
+void rs_syndromes(const std::array<uint8_t, 24>& codeword,
+                  std::array<uint8_t, 8>* syndromes) {
+  ensure_gf();
+  for (int root = 1; root <= 8; ++root) {
+    const uint8_t alpha = gf_pow(root);
+    uint8_t value = 0;
+    for (const uint8_t symbol : codeword) value = gf_mul(value, alpha) ^ symbol;
+    (*syndromes)[root - 1] = value;
+  }
+}
+
+uint8_t polynomial_value(const std::array<uint8_t, 9>& polynomial,
+                         uint8_t value) {
+  uint8_t result = 0;
+  uint8_t power = 1;
+  for (const uint8_t coefficient : polynomial) {
+    result ^= gf_mul(coefficient, power);
+    power = gf_mul(power, value);
+  }
+  return result;
+}
+
+int rs_24_16_decode(std::array<uint8_t, 24>* codeword) {
+  std::array<uint8_t, 8> syndromes{};
+  rs_syndromes(*codeword, &syndromes);
+  if (std::all_of(syndromes.begin(), syndromes.end(),
+                  [](uint8_t value) { return value == 0; })) return 0;
+
+  std::array<uint8_t, 9> locator{};
+  std::array<uint8_t, 9> previous{};
+  locator[0] = previous[0] = 1;
+  int degree = 0;
+  int shift = 1;
+  uint8_t last_discrepancy = 1;
+  for (int index = 0; index < 8; ++index) {
+    uint8_t discrepancy = syndromes[index];
+    for (int term = 1; term <= degree; ++term)
+      discrepancy ^= gf_mul(locator[term], syndromes[index - term]);
+    if (discrepancy == 0) {
+      ++shift;
+      continue;
+    }
+    const auto saved = locator;
+    const uint8_t scale = gf_mul(discrepancy, gf_inv(last_discrepancy));
+    for (int term = 0; term + shift < static_cast<int>(locator.size()); ++term)
+      locator[term + shift] ^= gf_mul(scale, previous[term]);
+    if (2 * degree <= index) {
+      degree = index + 1 - degree;
+      previous = saved;
+      last_discrepancy = discrepancy;
+      shift = 1;
+    } else {
+      ++shift;
+    }
+  }
+  if (degree < 1 || degree > 4) return -1;
+
+  struct ErrorPosition { int index; uint8_t location; };
+  std::array<ErrorPosition, 4> positions{};
+  int position_count = 0;
+  for (int power = 0; power < 24; ++power) {
+    if (polynomial_value(locator, gf_pow(-power)) == 0) {
+      if (position_count >= degree) return -1;
+      positions[position_count++] = {23 - power, gf_pow(power)};
+    }
+  }
+  if (position_count != degree) return -1;
+
+  std::array<uint8_t, 9> evaluator{};
+  for (int i = 0; i < 8; ++i)
+    for (int j = 0; j <= degree && i + j < 8; ++j)
+      evaluator[i + j] ^= gf_mul(syndromes[i], locator[j]);
+  std::array<uint8_t, 9> derivative{};
+  for (int term = 1; term <= degree; term += 2) derivative[term - 1] = locator[term];
+
+  for (int i = 0; i < position_count; ++i) {
+    const uint8_t inverse = gf_inv(positions[i].location);
+    const uint8_t denominator = polynomial_value(derivative, inverse);
+    if (denominator == 0) return -1;
+    const uint8_t magnitude = gf_mul(polynomial_value(evaluator, inverse),
+                                     gf_inv(denominator));
+    (*codeword)[positions[i].index] ^= magnitude;
+  }
+  rs_syndromes(*codeword, &syndromes);
+  if (!std::all_of(syndromes.begin(), syndromes.end(),
+                   [](uint8_t value) { return value == 0; })) return -1;
+  return position_count;
+}
+
+bool decode_encryption_payload(const uint8_t* payload, size_t dibits,
+                               EncryptionSync* result) {
+  if (payload == nullptr || result == nullptr || dibits != kLduPayloadDibits) return false;
+  *result = {};
+  std::array<uint8_t, 24> codeword{};
+  int inner_corrections = 0;
+  size_t word = 0;
+  for (const size_t block_offset : kEncryptionBitOffsets) {
+    for (size_t block_word = 0; block_word < 4; ++block_word) {
+      uint16_t received = 0;
+      for (size_t bit = 0; bit < 10; ++bit) {
+        const size_t source = block_offset + block_word * 10 + bit;
+        received = static_cast<uint16_t>((received << 1) |
+            ((payload[source / 2] >> (1 - source % 2)) & 1u));
+      }
+      inner_corrections += hamming_10_6_decode(received, &codeword[word++]);
+    }
+  }
+  const int outer_corrections = rs_24_16_decode(&codeword);
+  if (outer_corrections < 0) return false;
+
+  std::array<uint8_t, 12> bytes{};
+  size_t output_bit = 0;
+  for (size_t symbol = 0; symbol < 16; ++symbol)
+    for (int bit = 5; bit >= 0; --bit, ++output_bit)
+      bytes[output_bit / 8] |=
+          static_cast<uint8_t>(((codeword[symbol] >> bit) & 1u) << (7 - output_bit % 8));
+  result->valid = true;
+  result->algorithm_id = bytes[9];
+  result->key_id = static_cast<uint16_t>(bytes[10]) << 8 | bytes[11];
+  result->encrypted = result->algorithm_id != kClearAlgorithmId;
+  result->corrected_errors = static_cast<uint8_t>(
+      std::min(255, inner_corrections + outer_corrections));
+  return true;
+}
+
 }  // namespace
 
 class Decoder {
@@ -375,7 +536,27 @@ class Decoder {
         voice_ok &= frame.bits[bit] == static_cast<uint8_t>(((source * 13) ^ 5) & 1);
       }
     }
-    return control_ok && explicit_grant_ok && voice_ok;
+    constexpr std::array<uint8_t, 24> kEncryptedCodeword = {
+        0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+        0x21,0x01,0x08,0x34,0x21,0x37,0x13,0x34,0x0D,0x1F,0x24,0x10};
+    std::array<uint8_t, kLduPayloadDibits> encryption_payload{};
+    size_t encryption_word = 0;
+    for (const size_t block_offset : kEncryptionBitOffsets) {
+      for (size_t block_word = 0; block_word < 4; ++block_word) {
+        const uint16_t encoded = hamming_10_6_encode(kEncryptedCodeword[encryption_word++]);
+        for (size_t bit = 0; bit < 10; ++bit) {
+          const size_t destination = block_offset + block_word * 10 + bit;
+          encryption_payload[destination / 2] |= static_cast<uint8_t>(
+              ((encoded >> (9 - bit)) & 1u) << (1 - destination % 2));
+        }
+      }
+    }
+    EncryptionSync encryption{};
+    const bool encryption_ok = decode_encryption_payload(
+        encryption_payload.data(), encryption_payload.size(), &encryption) &&
+        encryption.valid && encryption.encrypted && encryption.algorithm_id == 0x84 &&
+        encryption.key_id == 0x1234;
+    return control_ok && explicit_grant_ok && voice_ok && encryption_ok;
   }
 
  private:
@@ -546,6 +727,15 @@ class Decoder {
     ++state_.voice_ldus;
     state_.last_voice_ms = now_ms_;
     last_valid_ms_ = state_.last_voice_ms;
+    if (frame_duid_ == 0xA) {
+      EncryptionSync encryption{};
+      if (decode_encryption_payload(ldu_payload_.data(), ldu_payload_.size(), &encryption)) {
+        state_.voice_encryption = encryption;
+        ++state_.encryption_sync_good;
+      } else {
+        ++state_.encryption_sync_failed;
+      }
+    }
     for (const size_t offset : kVoiceBitOffsets) {
       for (size_t bit = 0; bit < kVoiceFrameBits; ++bit) {
         const size_t source = offset + bit;
@@ -555,6 +745,7 @@ class Decoder {
       VoiceFrame frame{};
       std::memcpy(frame.bits, voice_bits, sizeof(frame.bits));
       frame.sequence = ++state_.voice_frames;
+      frame.encryption = state_.voice_encryption;
       if (voice_sink_ == nullptr || !voice_sink_(frame, voice_context_))
         ++state_.voice_queue_drops;
     }
@@ -740,6 +931,11 @@ void process_cu8(const uint8_t* iq, size_t bytes, uint32_t now_ms,
 }
 
 Snapshot snapshot() { return g_decoder.state(); }
+
+bool decode_ldu2_encryption(const uint8_t* payload, size_t dibits,
+                            EncryptionSync* result) {
+  return decode_encryption_payload(payload, dibits, result);
+}
 
 bool self_check() { return Decoder::self_check(); }
 

--- a/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
@@ -733,6 +733,7 @@ class Decoder {
         state_.voice_encryption = encryption;
         ++state_.encryption_sync_good;
       } else {
+        state_.voice_encryption = {};
         ++state_.encryption_sync_failed;
       }
     }

--- a/apps/orcsdr-tab5/ui/p25_decoder_core.hpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder_core.hpp
@@ -7,10 +7,20 @@ namespace orcsdr::p25core {
 
 constexpr size_t kRecentGrantCount = 8;
 constexpr size_t kVoiceFrameBits = 144;
+constexpr uint8_t kClearAlgorithmId = 0x80;
+
+struct EncryptionSync {
+  bool valid = false;
+  bool encrypted = false;
+  uint8_t algorithm_id = 0;
+  uint16_t key_id = 0;
+  uint8_t corrected_errors = 0;
+};
 
 struct VoiceFrame {
   uint8_t bits[kVoiceFrameBits]{};
   uint32_t sequence = 0;
+  EncryptionSync encryption{};
 };
 
 struct Grant {
@@ -42,6 +52,9 @@ struct Snapshot {
   uint32_t voice_frames = 0;
   uint32_t voice_queue_drops = 0;
   uint32_t last_voice_ms = 0;
+  uint32_t encryption_sync_good = 0;
+  uint32_t encryption_sync_failed = 0;
+  EncryptionSync voice_encryption{};
   uint16_t last_trellis_metric = 0;
   float estimated_ber_percent = 0.0f;
   float frame_error_percent = 0.0f;
@@ -60,6 +73,11 @@ void reset(uint32_t now_ms = 0);
 void process_cu8(const uint8_t* iq, size_t bytes, uint32_t now_ms,
                  VoiceSink voice_sink = nullptr, void* voice_context = nullptr);
 Snapshot snapshot();
+
+// Decode the six 40-bit Encryption Sync fields from an LDU2 payload. The
+// input is the 1,568 payload bits after the NID, stored as 784 dibits.
+bool decode_ldu2_encryption(const uint8_t* payload, size_t dibits,
+                            EncryptionSync* result);
 
 // Deterministic protocol/FEC check. It does not touch receiver state.
 bool self_check();

--- a/architecture.md
+++ b/architecture.md
@@ -25,6 +25,11 @@ PCM production. The thin `p25_decoder` adapter owns the FreeRTOS-safe snapshot
 and voice queue. `ui/main.cpp` still owns P25 tuning/follow policy, task
 scheduling, IQ capture/replay transport, and speaker delivery.
 
+The core also decodes the clear LDU2 Encryption Sync field with its inner
+Hamming and outer Reed-Solomon protection. It tags bounded voice frames with
+the validated algorithm/key state. The Tab5 follow policy mutes protected
+frames and optionally returns to the control channel; no decryption exists.
+
 These modules still compile into the Tab5 application component. `ui/main.cpp`
 also retains FM/AM processing, RDS, driver lifecycle, other DSP policy, and
 speaker integration; `rf_analysis.cpp` still depends on M5Unified timing.

--- a/docs/API_SERIAL_CLI.md
+++ b/docs/API_SERIAL_CLI.md
@@ -507,7 +507,8 @@ configured control channel, so it cannot contain a followed voice call.
 
 | Command | Auth | Reply | Notes |
 |---|---|---|---|
-| `RTL_P25_STATUS` | no | `RTL_P25_STATUS profile=... frame_sync=... identity=... grants=... grant_events=... follow=...` | Includes current recent grants, session-level followed grant events, NID/TSBK, voice/IMBE/PCM, heap, stack-headroom, USB, IQ, and audio-drop counters. Identity fields come from decoded over-the-air data. |
+| `RTL_P25_STATUS` | no | `RTL_P25_STATUS profile=... frame_sync=... identity=... grants=... grant_events=... follow=...` | Includes current recent grants, session-level followed grant events, NID/TSBK, voice/IMBE/PCM, LDU2 encryption, heap, stack-headroom, USB, IQ, and audio-drop counters. Identity fields come from decoded over-the-air data. |
+| `RTL_P25_ENCRYPTION_STATUS` | no | `RTL_P25_ENCRYPTION_STATUS detected=... algid=... kid=... muted_frames=... returns=...` | Reports the last valid LDU2 Encryption Sync result and cumulative mute/return counters for automated acceptance. It identifies and suppresses protected audio; it does not decrypt it. |
 | `RTL_P25_SCAN` | yes | `RTL_P25_SURVEY ...` | Runs the configured control-channel survey. |
 | `RTL_P25_IQ_START` | yes | `RTL_IQ_START source=p25 ...` | Requires a running P25 control channel. Voice following is suppressed while the bounded capture fills. |
 | `RTL_P25_IQ_STATUS` | no | `RTL_P25_IQ_STATUS ...` | Reports capture state, size limit, source frequency, sample rate, and last saved path. |
@@ -524,6 +525,10 @@ apps/orcsdr-tab5/tools/run-p25-validation.ps1 `
   -Port COM17 -ControlFrequencyHz 453812500 `
   -PairingKeyPath .orclink/ui-doc.key -CaptureFixture
 ```
+
+Add `-RequireEncryptedVoice` during a controlled live test to require a valid
+encrypted LDU2 detection, muted voice frames, and an immediate return to the
+control channel.
 
 ## Example workflows
 

--- a/docs/user-guide/dashboards/p25.md
+++ b/docs/user-guide/dashboards/p25.md
@@ -2,7 +2,11 @@
 
 **P25 WIP — Phase I clear voice verified; wider system compatibility in progress.**
 
-P25 is receive-only monitoring. OrcSDR follows decoded clear voice grants and skips encryption when configured.
+P25 is receive-only monitoring. OrcSDR follows decoded clear voice grants. On
+the traffic channel it reads the LDU2 Encryption Sync field; protected audio is
+muted, and **SKIP ENCRYPTED** returns the receiver to the control channel. The
+dashboard may show the clear-text algorithm and key IDs for identification,
+but OrcSDR does not decrypt traffic.
 
 ## Monitor workflow
 

--- a/tests/p25_core_tests.cpp
+++ b/tests/p25_core_tests.cpp
@@ -71,6 +71,69 @@ void test_voice_decode_bounds_and_reset() {
   CHECK(decoder.process(frame, pcm.data(), nullptr));
 }
 
+uint16_t encode_hamming_10_6(uint8_t data) {
+  constexpr uint16_t generator[6] = {0x20E, 0x10D, 0x08B, 0x047, 0x023, 0x01C};
+  uint16_t codeword = 0;
+  for (int bit = 0; bit < 6; ++bit)
+    if (data & (0x20u >> bit)) codeword ^= generator[bit];
+  return codeword;
+}
+
+std::array<uint8_t, 784> make_ldu2_payload(const std::array<uint8_t, 24>& symbols) {
+  constexpr size_t offsets[6] = {288, 472, 656, 840, 1024, 1208};
+  std::array<uint8_t, 784> payload{};
+  size_t word = 0;
+  for (const size_t offset : offsets) {
+    for (size_t block_word = 0; block_word < 4; ++block_word) {
+      const uint16_t encoded = encode_hamming_10_6(symbols[word++]);
+      for (size_t bit = 0; bit < 10; ++bit) {
+        const size_t destination = offset + block_word * 10 + bit;
+        payload[destination / 2] |= static_cast<uint8_t>(
+            ((encoded >> (9 - bit)) & 1u) << (1 - destination % 2));
+      }
+    }
+  }
+  return payload;
+}
+
+void test_encryption_sync_decode() {
+  using namespace orcsdr::p25core;
+  // Independent p25craft clear-voice vector: MI=0, ALGID=0x80, KID=0.
+  constexpr std::array<uint8_t, 24> clear_symbols = {
+      0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+      0x20,0x00,0x00,0x00,0x2B,0x0B,0x22,0x24,0x26,0x3D,0x31,0x35};
+  auto payload = make_ldu2_payload(clear_symbols);
+  EncryptionSync result{};
+  CHECK(decode_ldu2_encryption(payload.data(), payload.size(), &result));
+  CHECK(result.valid);
+  CHECK(!result.encrypted);
+  CHECK(result.algorithm_id == kClearAlgorithmId);
+  CHECK(result.key_id == 0);
+
+  constexpr std::array<uint8_t, 24> encrypted_symbols = {
+      0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+      0x21,0x01,0x08,0x34,0x21,0x37,0x13,0x34,0x0D,0x1F,0x24,0x10};
+  payload = make_ldu2_payload(encrypted_symbols);
+  CHECK(decode_ldu2_encryption(payload.data(), payload.size(), &result));
+  CHECK(result.encrypted);
+  CHECK(result.algorithm_id == 0x84);
+  CHECK(result.key_id == 0x1234);
+
+  // One inner bit error and four whole-symbol errors are within the two FEC layers.
+  payload[288 / 2] ^= 0x02;
+  CHECK(decode_ldu2_encryption(payload.data(), payload.size(), &result));
+  CHECK(result.algorithm_id == 0x84 && result.key_id == 0x1234);
+  auto corrected_symbols = encrypted_symbols;
+  for (size_t i = 0; i < 4; ++i) corrected_symbols[i * 3] ^= 0x01;
+  payload = make_ldu2_payload(corrected_symbols);
+  CHECK(decode_ldu2_encryption(payload.data(), payload.size(), &result));
+  CHECK(result.algorithm_id == 0x84 && result.key_id == 0x1234);
+
+  CHECK(!decode_ldu2_encryption(nullptr, payload.size(), &result));
+  CHECK(!decode_ldu2_encryption(payload.data(), payload.size() - 1, &result));
+  CHECK(!decode_ldu2_encryption(payload.data(), payload.size(), nullptr));
+}
+
 orcsdr::p25core::Snapshot decode_control_fixture(const char* path, size_t chunk_size) {
   using namespace orcsdr::p25core;
   FILE* file = std::fopen(path, "rb");
@@ -166,6 +229,7 @@ int main(int argc, char** argv) {
   CHECK(argc == 2);
   test_protocol_self_check_and_bad_input();
   test_voice_decode_bounds_and_reset();
+  test_encryption_sync_decode();
   test_control_fixture(argv[1]);
   test_allocation_free_stress();
   std::puts("p25_core_tests: PASS");


### PR DESCRIPTION
Encrypted P25 Phase I calls were reaching the vocoder because some control-channel grant forms do not carry an encryption flag. On the Lane County system this made police talkgroups sound robotic while known clear fire traffic sounded correct.  This change decodes the protected LDU2 Encryption Sync field on the voice channel and carries its algorithm/key state through the existing bounded P25 voice-frame path. Voice audio is withheld until that state is known. Clear calls then continue through mbelib and PCM output; protected calls never reach synthesis. With **Skip Encrypted** enabled, OrcSDR records the event and immediately returns to the control channel. The dashboard shows an encrypted/muted state and the serial CLI exposes the decoded ALGID/KID plus cumulative mute and return counters. This does not attempt decryption.  The decoder remains hardware-independent and allocation-free in steady processing. The implementation includes Hamming(10,6,3) and Reed-Solomon(24,16,9) correction for the six LDU2 Encryption Sync fragments. Host tests cover an independent clear vector, an encrypted vector, an inner-code bit error, four outer-code symbol errors, truncated input, and null inputs.  The P25 validation runner now:  - starts from a stopped radio session so counter baselines cannot inherit an earlier run; - temporarily enables audio so IMBE and PCM checks are deterministic, then restores the original sound setting; - latches return-and-relock evidence instead of losing it when a run ends during a call; - supports `-RequireEncryptedVoice` to require live detection, muting, and return-to-control behavior.  Validation actually performed:  - `pwsh -File tools/test-p25-core.ps1`: PASS in optimized mode and under ASan/LSan/UBSan. - Native ESP-IDF 5.5.4 Tab5 build: PASS. App size `0x21c410`; 47% of the smallest app partition remains free. - Exact firmware flashed to COM17 and every flash block verified. Firmware SHA-256: `8AE71302303DB44D42F0189EBCD6E0A86CAC227F9E55A24ED23645DB8DA77F90`. - Authenticated `run-tab5-ui-regression.ps1 -Run`: PASS after the post-flash boot completed. One earlier attempt started during Wi-Fi/boot and timed out before pairing; it did not exercise the regression. - Live P25 validation at 453.925 MHz for 90 seconds with `-RequireEncryptedVoice`: PASS. It observed 8 grant events, 360 decoded IMBE frames, 345,600 PCM samples, 42 encrypted frames muted, 5 encrypted returns, control-channel relock, 1,416 bytes of voice-task stack headroom, stable heap, and no USB, IQ, audio, or voice-queue drop growth. - The exact-image log showed encrypted TGIDs 20051 and 20101 remain at zero IMBE/PCM until a clear call arrives, confirming that the initial unknown LDU is also withheld.  Known limits:  - Human visual inspection of the new encrypted banner was not performed during this unattended run; the automated dashboard regression passed. - ALGID/KID are identifiers reported in clear signaling. OrcSDR does not decrypt protected traffic. - This PR does not add CQPSK/LSM support, profiles, discovery, talkgroup databases, or Phase II support.   CodeRabbit review found three valid session-boundary issues. Commit `fcaa33c` closes the queue during every transition, rejects in-flight callbacks from retired decoder generations, discards a frame already popped when the voice task sees a session change, clears stale encryption state after a failed LDU2 decode, resets the pending signal for each grant, and uses the existing 30-second skip duration. All validation listed above was repeated on this corrected commit and exact image.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->  ## Summary by CodeRabbit  - **New Features**   - Added detection and status reporting for encrypted P25 voice.   - Protected voice frames are muted, with optional return to the control channel.   - The dashboard displays encryption status, algorithm ID, and key ID.   - Added serial status reporting and validation support for encrypted voice.  - **Documentation**   - Updated the architecture, dashboard, and serial CLI documentation.  - **Tests**   - Added coverage for encryption metadata decoding and error correction.  <!-- end of auto-generated comment: release notes by coderabbit.ai -->