### PR TITLE
Add P25 CQPSK/LSM acquisition and diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ FM Settings stay on the station while you use them. Sound on/off, step size, fil
 
 **P25 WIP — Phase I clear voice verified; wider system compatibility in progress.**
 
-P25 is for following a public-safety trunked system with one tuner. You load a system profile, park on a control channel, and let the radio follow voice grants it can hear. Encrypted voice is not decoded; the firmware can skip those grants and keep looking.
+P25 is for following a public-safety trunked system with one tuner. You load a system profile, park on a control channel, and let the radio follow voice grants it can hear. Automatic Phase I acquisition evaluates C4FM and linear CQPSK/LSM and reports the selected path. Encrypted voice is not decoded; the firmware can skip those grants and keep looking.
 
 #### Monitor
 

--- a/apps/orcsdr-tab5/tools/run-p25-validation.ps1
+++ b/apps/orcsdr-tab5/tools/run-p25-validation.ps1
@@ -16,7 +16,11 @@ param(
   [string]$PairingKeyPath = (Join-Path $PSScriptRoot '..\..\..\.orclink\ui-doc.key'),
   [string]$BackupPath,
   [switch]$CaptureFixture,
-  [switch]$RequireEncryptedVoice
+  [switch]$RequireEncryptedVoice,
+  [ValidateSet('AUTO', 'C4FM', 'CQPSK')]
+  [string]$Modulation = 'AUTO',
+  [string]$ReplayPath,
+  [switch]$ReplayOnly
 )
 
 $ErrorActionPreference = 'Stop'
@@ -26,6 +30,7 @@ $script:key = $null
 $script:lastPing = [DateTime]::MinValue
 $script:tempNvs = $null
 $script:initialSoundEnabled = $null
+$script:initialModulation = $null
 
 function Test-FatalLine([string]$Line) {
   return $Line -match '(?i)Guru Meditation|panic(?:ked|\x27ed)?|assert failed|abort\(|task watchdog|interrupt wdt|brownout detector|ESP-ROM:esp32p4|rst:0x|out of memory|alloc(?:ation)? failed|heap corruption'
@@ -81,6 +86,8 @@ function Get-Status {
     UsbDrops = [uint32](Get-Field $line 'usb_drops')
     IqDrops = [uint32](Get-Field $line 'iq_drops')
     AudioDrops = [uint32](Get-Field $line 'audio_drops')
+    ModulationConfigured = Get-Field $line 'modulation_configured'
+    ModulationSelected = Get-Field $line 'modulation_selected'
   }
 }
 
@@ -160,6 +167,19 @@ try {
   $script:serial.DiscardInBuffer()
   Connect-Authenticated
 
+  if ($ReplayOnly -and -not $ReplayPath) { throw '-ReplayOnly requires -ReplayPath.' }
+  $script:serial.WriteLine('RTL_P25_MODULATION')
+  $modeStatus = Read-LineUntil { param($line) $line -match '^RTL_P25_MODULATION ' } 5
+  if ($modeStatus -notmatch ' configured=(auto|c4fm|cqpsk) ') {
+    throw "Could not read the initial P25 modulation: $modeStatus"
+  }
+  $script:initialModulation = $Matches[1].ToUpperInvariant()
+  $script:serial.WriteLine("RTL_P25_MODULATION $Modulation")
+  $modeSet = Read-LineUntil { param($line) $line -match '^RTL_P25_MODULATION_(OK|ERROR) ' } 8
+  if ($modeSet -notmatch "^RTL_P25_MODULATION_OK configured=$($Modulation.ToLowerInvariant())$") {
+    throw "Could not select P25 modulation: $modeSet"
+  }
+
   $script:serial.WriteLine('RTL_SOUND')
   $sound = Read-LineUntil { param($line) $line -match '^RTL_SOUND_STATUS enabled=[01]$' } 5
   if ($sound -notmatch 'enabled=([01])$') { throw 'Could not read the initial sound state.' }
@@ -174,6 +194,21 @@ try {
   $stopped = Read-LineUntil { param($line) $line -match '^RTL_STOP_RESULT ' } 8
   if ($stopped -notmatch '^RTL_STOP_RESULT ESP_OK$') {
     throw "Could not stop the existing radio session: $stopped"
+  }
+
+  if ($ReplayOnly) {
+    $script:serial.WriteLine("RTL_P25_REPLAY $ReplayPath")
+    $replay = Read-LineUntil { param($line) $line -match '^RTL_P25_REPLAY_(DONE|ERROR) ' } 30
+    if ($replay -notmatch '^RTL_P25_REPLAY_DONE .* nid_good=([1-9][0-9]*) .* tsbk_good=([1-9][0-9]*) ') {
+      throw "P25 fixture replay failed: $replay"
+    }
+    $expected = $Modulation.ToLowerInvariant()
+    if ($Modulation -ne 'AUTO' -and $replay -notmatch " modulation_selected=$expected(?: |$)") {
+      throw "P25 fixture replay selected the wrong demodulator: $replay"
+    }
+    Write-Output $replay
+    Write-Output "P25_VALIDATION_REPLAY result=PASS modulation=$expected path=`"$ReplayPath`""
+    return
   }
 
   $script:serial.WriteLine("RTL_TUNE P25 $ControlFrequencyHz")
@@ -195,10 +230,14 @@ try {
     }
   }
   if ($null -eq $baseline) { throw 'P25 control lock and identity were not established.' }
+  $expectedModulation = $Modulation.ToLowerInvariant()
+  if ($Modulation -ne 'AUTO' -and $baseline.ModulationSelected -ne $expectedModulation) {
+    throw "P25 selected $($baseline.ModulationSelected), expected $expectedModulation."
+  }
   $activeControlHz = $baseline.ControlHz
   Write-Output "P25_VALIDATION_CONTROL locked=true requested_hz=$ControlFrequencyHz active_hz=$activeControlHz"
 
-  $fixturePath = $null
+  $fixturePath = $ReplayPath
   if ($CaptureFixture) {
     $started = $null
     $captureDeadline = [DateTime]::UtcNow.AddSeconds($ControlLockSeconds)
@@ -318,6 +357,14 @@ try {
     "encrypted_returns=$maxEncryptedReturns")
 } finally {
   if ($null -ne $script:serial -and $script:serial.IsOpen) {
+    if ($script:initialModulation -and $script:initialModulation -ne $Modulation) {
+      try {
+        $script:serial.WriteLine("RTL_P25_MODULATION $($script:initialModulation)")
+        [void](Read-LineUntil { param($line) $line -match '^RTL_P25_MODULATION_OK ' } 8)
+      } catch {
+        Write-Warning "Could not restore the initial P25 modulation: $($_.Exception.Message)"
+      }
+    }
     if ($script:initialSoundEnabled -eq 0) {
       try {
         $script:serial.WriteLine('RTL_SOUND OFF')

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -2856,6 +2856,8 @@ uint64_t sd_total_bytes() {
 
 void apply_p25_config(const orcsdr::p25config::Config& config, const char* status) {
   p25_config = config;
+  orcsdr::p25decoder::configure(config.modulation, config.cqpsk_timing_gain,
+                               config.cqpsk_carrier_gain);
   p25_auto_follow.store(config.auto_follow, std::memory_order_release);
   p25_encryption_skip.store(config.encryption_skip, std::memory_order_release);
   p25_hold_talkgroup = config.hold_talkgroup;
@@ -2874,10 +2876,11 @@ void apply_p25_config(const orcsdr::p25config::Config& config, const char* statu
   std::fill(std::begin(p25_candidate_tsbk_good), std::end(p25_candidate_tsbk_good), 0);
   strlcpy(p25_config_status, status, sizeof(p25_config_status));
   ++p25_config_revision;
-  Serial.printf("RTL_P25_CONFIG_LOAD status=\"%s\" channels=%u talkgroups=%u control_hz=%lu\n",
+  Serial.printf("RTL_P25_CONFIG_LOAD status=\"%s\" channels=%u talkgroups=%u control_hz=%lu modulation=%s\n",
                 p25_config_status, static_cast<unsigned>(config.control_channel_count),
                 static_cast<unsigned>(config.talkgroup_count),
-                static_cast<unsigned long>(p25_control_frequency_hz));
+                static_cast<unsigned long>(p25_control_frequency_hz),
+                orcsdr::p25core::modulation_name(config.modulation));
 }
 
 void load_p25_config() {
@@ -3600,10 +3603,14 @@ bool p25_replay(const char* path) {
   const auto decoded = orcsdr::p25decoder::snapshot();
   Serial.printf(
       "RTL_P25_REPLAY_DONE path=\"%s\" bytes=%lu frequency_hz=%lu frame_sync=%d "
+      "modulation_configured=%s modulation_selected=%s lock_quality=%.1f "
       "identity=%d nac=%03X wacn=%05lX sysid=%03X rfss=%u site=%u sync_words=%lu "
       "nid_good=%lu nid_failed=%lu tsbk_good=%lu tsbk_failed=%lu voice_frames=%lu\n",
       path, static_cast<unsigned long>(bytes),
       static_cast<unsigned long>(read_le32(header + 16)), decoded.frame_sync ? 1 : 0,
+      orcsdr::p25core::modulation_name(decoded.configured_modulation),
+      orcsdr::p25core::modulation_name(decoded.selected_modulation),
+      static_cast<double>(decoded.lock_quality_percent),
       decoded.identity_valid ? 1 : 0, decoded.nac,
       static_cast<unsigned long>(decoded.wacn), decoded.system_id, decoded.rfss,
       decoded.site, static_cast<unsigned long>(decoded.sync_words),
@@ -12103,6 +12110,7 @@ void process_command(char* command) {
     Serial.println("RTL_RDS_CAPTURE_START/STOP/STATUS - capture FM MPX to SD for replay");
     Serial.println("RTL_RDS_REPLAY <path.s16>       - replay captured MPX while radio is stopped");
     Serial.println("RTL_P25_STATUS                 - profile, decoder, voice and memory diagnostics");
+    Serial.println("RTL_P25_MODULATION [AUTO|C4FM|CQPSK] - query/set Phase I demodulator (set auth)");
     Serial.println("RTL_P25_ENCRYPTION_STATUS      - last LDU2 encryption and mute/return counters");
     Serial.println("RTL_P25_SCAN                   - survey configured control-channel candidates (auth)");
     Serial.println("RTL_P25_IQ_START|STOP|STATUS   - bounded control-channel IQ capture (mutations auth)");
@@ -12190,6 +12198,36 @@ void process_command(char* command) {
         p25_encryption_skip.load(std::memory_order_relaxed) ? 1 : 0);
     return;
   }
+  if (strcmp(command, "RTL_P25_MODULATION") == 0) {
+    const auto decoded = orcsdr::p25decoder::snapshot();
+    Serial.printf("RTL_P25_MODULATION configured=%s selected=%s timing_gain=%.6f carrier_gain=%.6f\n",
+                  orcsdr::p25core::modulation_name(p25_config.modulation),
+                  orcsdr::p25core::modulation_name(decoded.selected_modulation),
+                  static_cast<double>(p25_config.cqpsk_timing_gain),
+                  static_cast<double>(p25_config.cqpsk_carrier_gain));
+    return;
+  }
+  if (strncmp(command, "RTL_P25_MODULATION ", 19) == 0) {
+    if (!authenticated) {
+      Serial.println("RTL_P25_MODULATION_ERROR auth_required");
+      return;
+    }
+    const char* value = command + 19;
+    if (strcmp(value, "AUTO") == 0) p25_config.modulation = orcsdr::p25core::Modulation::auto_detect;
+    else if (strcmp(value, "C4FM") == 0) p25_config.modulation = orcsdr::p25core::Modulation::c4fm;
+    else if (strcmp(value, "CQPSK") == 0) p25_config.modulation = orcsdr::p25core::Modulation::cqpsk;
+    else {
+      Serial.println("RTL_P25_MODULATION_ERROR usage: RTL_P25_MODULATION AUTO|C4FM|CQPSK");
+      return;
+    }
+    orcsdr::p25decoder::configure(p25_config.modulation, p25_config.cqpsk_timing_gain,
+                                 p25_config.cqpsk_carrier_gain);
+    request_p25_config_save();
+    if (rtl_ui_band == RtlBand::p25) tune_p25_control(p25_control_frequency_hz);
+    Serial.printf("RTL_P25_MODULATION_OK configured=%s\n",
+                  orcsdr::p25core::modulation_name(p25_config.modulation));
+    return;
+  }
   if (strcmp(command, "RTL_P25_STATUS") == 0) {
     const auto decoded = orcsdr::p25decoder::snapshot();
     unsigned grant_count = 0;
@@ -12200,6 +12238,8 @@ void process_command(char* command) {
     Serial.printf(
         "RTL_P25_STATUS profile=\"%s\" identity_source=air "
         "frequency_hz=%lu survey=%d candidate=%u relative_dbfs=%.1f "
+        "modulation_configured=%s modulation_selected=%s lock_quality=%.1f "
+        "timing_error=%.4f carrier_error_hz=%.1f decode_rate_hz=%.2f "
         "frame_sync=%d identity=%d nac=%03X wacn=%05lX sysid=%03X rfss=%u site=%u "
         "sync_words=%lu nid_good=%lu nid_failed=%lu tsbk_good=%lu tsbk_failed=%lu "
         "ber_percent=%.2f grants=%d grant_events=%lu follow=%s control_hz=%lu voice_hz=%lu "
@@ -12214,6 +12254,12 @@ void process_command(char* command) {
         p25_survey_active.load(std::memory_order_relaxed) ? 1 : 0,
         static_cast<unsigned>(p25_candidate_index),
         static_cast<double>(rtl_signal_dbfs.load(std::memory_order_relaxed)),
+        orcsdr::p25core::modulation_name(decoded.configured_modulation),
+        orcsdr::p25core::modulation_name(decoded.selected_modulation),
+        static_cast<double>(decoded.lock_quality_percent),
+        static_cast<double>(decoded.timing_error),
+        static_cast<double>(decoded.carrier_error_hz),
+        static_cast<double>(decoded.decode_rate_hz),
         decoded.frame_sync ? 1 : 0, decoded.identity_valid ? 1 : 0,
         decoded.nac, static_cast<unsigned long>(decoded.wacn), decoded.system_id,
         decoded.rfss, decoded.site, static_cast<unsigned long>(decoded.sync_words),

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -12243,7 +12243,8 @@ void process_command(char* command) {
         "frame_sync=%d identity=%d nac=%03X wacn=%05lX sysid=%03X rfss=%u site=%u "
         "sync_words=%lu nid_good=%lu nid_failed=%lu tsbk_good=%lu tsbk_failed=%lu "
         "ber_percent=%.2f grants=%d grant_events=%lu follow=%s control_hz=%lu voice_hz=%lu "
-        "voice_ldus=%lu voice_frames=%lu voice_queue_drops=%lu enc_sync_good=%lu "
+        "voice_ldus=%lu voice_frames=%lu voice_queue_drops=%lu voice_unrouted=%lu "
+        "enc_sync_good=%lu "
         "enc_sync_failed=%lu encrypted_detected=%d algid=%02X kid=%04X "
         "encrypted_muted_frames=%lu encrypted_returns=%lu imbe_frames=%lu "
         "imbe_errors=%lu pcm_frames=%lu voice_stack_hwm=%lu imbe_max_us=%lu "
@@ -12277,6 +12278,7 @@ void process_command(char* command) {
         static_cast<unsigned long>(decoded.voice_ldus),
         static_cast<unsigned long>(decoded.voice_frames),
         static_cast<unsigned long>(decoded.voice_queue_drops),
+        static_cast<unsigned long>(decoded.voice_unrouted_frames),
         static_cast<unsigned long>(decoded.encryption_sync_good),
         static_cast<unsigned long>(decoded.encryption_sync_failed),
         p25_encrypted_voice_seen.load(std::memory_order_acquire) ? 1 : 0,

--- a/apps/orcsdr-tab5/ui/p25_config.cpp
+++ b/apps/orcsdr-tab5/ui/p25_config.cpp
@@ -1,6 +1,7 @@
 #include "p25_config.hpp"
 
 #include <cctype>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -43,6 +44,14 @@ bool parse_bool(const char* value, bool* output) {
     return true;
   }
   return false;
+}
+
+bool parse_float(const char* value, float* output) {
+  char* end = nullptr;
+  const float parsed = strtof(value, &end);
+  if (value == end || *end != '\0' || !std::isfinite(parsed)) return false;
+  *output = parsed;
+  return true;
 }
 
 bool has_channel(const Config& config, uint32_t frequency_hz) {
@@ -120,6 +129,24 @@ bool parse_text(const char* text, Config* config, char* error, size_t error_size
         snprintf(error, error_size, "line %lu encryption_skip", static_cast<unsigned long>(line_number));
         return false;
       }
+    } else if (strcmp(key, "modulation") == 0) {
+      if (strcmp(field, "auto") == 0) parsed.modulation = p25core::Modulation::auto_detect;
+      else if (strcmp(field, "c4fm") == 0) parsed.modulation = p25core::Modulation::c4fm;
+      else if (strcmp(field, "cqpsk") == 0) parsed.modulation = p25core::Modulation::cqpsk;
+      else {
+        snprintf(error, error_size, "line %lu modulation", static_cast<unsigned long>(line_number));
+        return false;
+      }
+    } else if (strcmp(key, "cqpsk_timing_gain") == 0) {
+      if (!parse_float(field, &parsed.cqpsk_timing_gain)) {
+        snprintf(error, error_size, "line %lu timing gain", static_cast<unsigned long>(line_number));
+        return false;
+      }
+    } else if (strcmp(key, "cqpsk_carrier_gain") == 0) {
+      if (!parse_float(field, &parsed.cqpsk_carrier_gain)) {
+        snprintf(error, error_size, "line %lu carrier gain", static_cast<unsigned long>(line_number));
+        return false;
+      }
     } else if (strcmp(key, "hold_talkgroup") == 0) {
       if (!parse_uint(field, &number) || number > UINT16_MAX) {
         snprintf(error, error_size, "line %lu hold_talkgroup", static_cast<unsigned long>(line_number));
@@ -164,6 +191,9 @@ void defaults(Config* config) {
   if (config == nullptr) return;
   *config = {};
   config->version = kSchemaVersion;
+  config->modulation = p25core::Modulation::auto_detect;
+  config->cqpsk_timing_gain = 0.005f;
+  config->cqpsk_carrier_gain = 0.008f;
   snprintf(config->system_name, sizeof(config->system_name), "%s", "Lane County P25");
   constexpr uint32_t channels[] = {453812500, 453925000, 460187500, 460312500};
   for (uint32_t frequency_hz : channels)
@@ -185,6 +215,12 @@ bool validate(const Config& config, char* error, size_t error_size) {
       config.control_channel_count == 0 || config.control_channel_count > kMaxControlChannels ||
       config.talkgroup_count > kMaxTalkgroups) {
     set_error(error, error_size, "invalid profile header");
+    return false;
+  }
+  if (!std::isfinite(config.cqpsk_timing_gain) || config.cqpsk_timing_gain < 0.0001f ||
+      config.cqpsk_timing_gain > 0.05f || !std::isfinite(config.cqpsk_carrier_gain) ||
+      config.cqpsk_carrier_gain < 0.0001f || config.cqpsk_carrier_gain > 0.1f) {
+    set_error(error, error_size, "CQPSK loop gain");
     return false;
   }
   for (size_t i = 0; i < config.control_channel_count; ++i) {
@@ -257,6 +293,9 @@ bool save(orcsdr::storage::FileSystem& fs, const Config& config, char* error, si
   file.printf("last_control_channel_hz=%lu\n", static_cast<unsigned long>(config.last_control_channel_hz));
   file.printf("auto_follow=%s\n", config.auto_follow ? "true" : "false");
   file.printf("encryption_skip=%s\n", config.encryption_skip ? "true" : "false");
+  file.printf("modulation=%s\n", p25core::modulation_name(config.modulation));
+  file.printf("cqpsk_timing_gain=%.6f\n", static_cast<double>(config.cqpsk_timing_gain));
+  file.printf("cqpsk_carrier_gain=%.6f\n", static_cast<double>(config.cqpsk_carrier_gain));
   file.printf("hold_talkgroup=%u\n", config.hold_talkgroup);
   for (size_t i = 0; i < config.talkgroup_count; ++i)
     file.printf("talkgroup=%u,%s\n", config.talkgroups[i].id, config.talkgroups[i].alias);
@@ -294,11 +333,17 @@ bool self_check() {
       "last_control_channel_hz=460000000\n"
       "auto_follow=false\n"
       "encryption_skip=true\n"
+      "modulation=cqpsk\n"
+      "cqpsk_timing_gain=0.004\n"
+      "cqpsk_carrier_gain=0.01\n"
       "hold_talkgroup=42\n"
       "talkgroup=42,Dispatch\n";
   if (!parse_text(kEditedProfile, &config, error, sizeof(error)) ||
       config.control_channel_count != 1 || config.talkgroup_count != 1 ||
-      config.auto_follow || config.talkgroups[0].id != 42) return false;
+      config.auto_follow || config.talkgroups[0].id != 42 ||
+      config.modulation != p25core::Modulation::cqpsk ||
+      fabsf(config.cqpsk_timing_gain - 0.004f) > 0.00001f ||
+      fabsf(config.cqpsk_carrier_gain - 0.01f) > 0.00001f) return false;
   constexpr char kBadProfile[] = "version=1\ncontrol_channel_hz=100\n";
   if (parse_text(kBadProfile, &config, error, sizeof(error))) return false;
   defaults(&config);

--- a/apps/orcsdr-tab5/ui/p25_config.hpp
+++ b/apps/orcsdr-tab5/ui/p25_config.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "orcsdr_storage.hpp"
+#include "p25_decoder_core.hpp"
 
 namespace orcsdr::p25config {
 
@@ -25,6 +26,9 @@ struct Config {
   uint32_t last_control_channel_hz = 0;
   bool auto_follow = true;
   bool encryption_skip = true;
+  p25core::Modulation modulation = p25core::Modulation::auto_detect;
+  float cqpsk_timing_gain = 0.005f;
+  float cqpsk_carrier_gain = 0.008f;
   uint16_t hold_talkgroup = 0;
   Talkgroup talkgroups[kMaxTalkgroups]{};
   uint8_t talkgroup_count = 0;

--- a/apps/orcsdr-tab5/ui/p25_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/p25_dashboard.cpp
@@ -231,9 +231,12 @@ void draw_monitor_dynamic() {
   draw_meter(872, 350, 345, g_snapshot.relative_dbfs, 16);
   snprintf(value, sizeof(value), "RELATIVE  %.1f dBFS", static_cast<double>(g_snapshot.relative_dbfs));
   text(value, 872, 404, TFT_WHITE, 2, middle_left);
-  text(g_snapshot.following_voice ? "IMBE VOICE DECODING" :
-       g_snapshot.survey_active ? "SURVEYING KNOWN CHANNELS" :
-       g_snapshot.decoded.frame_sync ? "P25 FRAME SYNC" : "NO P25 FRAME SYNC",
+  snprintf(value, sizeof(value), "%s  •  %s",
+           g_snapshot.following_voice ? "IMBE VOICE DECODING" :
+           g_snapshot.survey_active ? "SURVEYING KNOWN CHANNELS" :
+           g_snapshot.decoded.frame_sync ? "P25 FRAME SYNC" : "NO P25 FRAME SYNC",
+           p25core::modulation_name(g_snapshot.decoded.selected_modulation));
+  text(value,
        872, 444, g_snapshot.following_voice ? kGreen : g_snapshot.survey_active ? kYellow :
        g_snapshot.decoded.frame_sync ? kGreen : kMuted, 1, middle_left);
 }
@@ -397,7 +400,7 @@ void draw_health_static() {
   card(318, 536, 280, 74);
   label("WI-FI", 338, 550);
   card(612, 536, 644, 74);
-  label("LAST ERROR", 632, 550);
+  label("DEMODULATOR / LAST ERROR", 632, 550);
 }
 
 void draw_health_dynamic() {
@@ -455,8 +458,18 @@ void draw_health_dynamic() {
   text(g_snapshot.wifi_connected ? "CONNECTED" : "OFFLINE", 492, 580,
        g_snapshot.wifi_connected ? kGreen : kMuted, 2);
   M5.Display.fillRect(744, 566, 486, 30, kPanel);
-  text(g_snapshot.last_error[0] ? g_snapshot.last_error : "—", 754, 580,
-       g_snapshot.last_error[0] ? kYellow : TFT_WHITE, 2, middle_left);
+  if (g_snapshot.last_error[0]) {
+    text(g_snapshot.last_error, 754, 580, kYellow, 2, middle_left);
+  } else {
+    snprintf(value, sizeof(value), "%s  Q%.0f%%  T%+.2f  C%+.0fHz  D%.1f/s  F%.1f%%",
+             p25core::modulation_name(g_snapshot.decoded.selected_modulation),
+             static_cast<double>(g_snapshot.decoded.lock_quality_percent),
+             static_cast<double>(g_snapshot.decoded.timing_error),
+             static_cast<double>(g_snapshot.decoded.carrier_error_hz),
+             static_cast<double>(g_snapshot.decoded.decode_rate_hz),
+             static_cast<double>(g_snapshot.decoded.frame_error_percent));
+    text(value, 754, 580, TFT_WHITE, 1, middle_left);
+  }
 }
 
 void draw_view_static() {

--- a/apps/orcsdr-tab5/ui/p25_decoder.cpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder.cpp
@@ -14,6 +14,9 @@ std::atomic<uint8_t> g_voice_write{0};
 std::atomic<uint8_t> g_voice_read{0};
 std::atomic<uint32_t> g_voice_generation{0};
 std::atomic<bool> g_voice_accepting{false};
+std::atomic<p25core::Modulation> g_modulation{p25core::Modulation::auto_detect};
+std::atomic<float> g_timing_gain{0.005f};
+std::atomic<float> g_carrier_gain{0.008f};
 Snapshot g_public_snapshot{};
 portMUX_TYPE g_snapshot_mux = portMUX_INITIALIZER_UNLOCKED;
 
@@ -55,10 +58,19 @@ void reset() {
 void reset_at(uint32_t now_ms) {
   g_voice_accepting.store(false, std::memory_order_release);
   clear_voice_queue();
+  p25core::configure(g_modulation.load(std::memory_order_acquire),
+                     g_timing_gain.load(std::memory_order_acquire),
+                     g_carrier_gain.load(std::memory_order_acquire));
   p25core::reset(now_ms);
   g_voice_generation.fetch_add(1, std::memory_order_acq_rel);
   g_voice_accepting.store(true, std::memory_order_release);
   publish_snapshot();
+}
+
+void configure(Modulation modulation, float timing_gain, float carrier_gain) {
+  g_modulation.store(modulation, std::memory_order_release);
+  g_timing_gain.store(timing_gain, std::memory_order_release);
+  g_carrier_gain.store(carrier_gain, std::memory_order_release);
 }
 
 void suspend_voice() {

--- a/apps/orcsdr-tab5/ui/p25_decoder.hpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder.hpp
@@ -5,6 +5,7 @@
 namespace orcsdr::p25decoder {
 
 using p25core::Grant;
+using p25core::Modulation;
 using p25core::Snapshot;
 using p25core::VoiceFrame;
 inline constexpr size_t kRecentGrantCount = p25core::kRecentGrantCount;
@@ -13,6 +14,7 @@ inline constexpr size_t kVoiceFrameBits = p25core::kVoiceFrameBits;
 // Device adapter: the RTL delivery task is the single decoder writer. The UI
 // snapshot and voice-task queue are synchronized here, outside the core.
 void reset();
+void configure(Modulation modulation, float timing_gain, float carrier_gain);
 void process_cu8(const uint8_t* iq, size_t bytes);
 void reset_at(uint32_t now_ms);
 void suspend_voice();

--- a/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
@@ -22,6 +22,11 @@ constexpr float kPi = 3.14159265358979323846f;
 constexpr float kSlicerScale = 2.0f * kPi * kOuterDeviationHz / kChannelRate;
 constexpr float kSlicerThreshold = 2.0f * kSlicerScale / 3.0f;
 constexpr float kAgcTarget = kSlicerThreshold;
+constexpr size_t kCqpskRrcSpan = 8;
+constexpr size_t kCqpskRrcTaps = 2 * kCqpskRrcSpan * kSamplesPerSymbol + 1;
+constexpr float kCqpskRrcAlpha = 0.20f;
+constexpr float kCqpskGardnerGain = 0.005f;
+constexpr float kCqpskCostasAlpha = 0.008f;
 constexpr uint32_t kLockTimeoutMs = 3000;
 constexpr size_t kLduPayloadDibits = 784;
 constexpr uint64_t kBchGenerator = 0xCD930BDD3B2Bull;
@@ -70,6 +75,43 @@ constexpr std::array<size_t, 6> kEncryptionBitOffsets = {
 std::array<uint8_t, 126> g_gf_exp{};
 std::array<int8_t, 64> g_gf_log{};
 bool g_gf_ready = false;
+std::array<float, kCqpskRrcTaps> g_cqpsk_rrc{};
+bool g_cqpsk_rrc_ready = false;
+
+float wrap_pi(float angle) {
+  while (angle > kPi) angle -= 2.0f * kPi;
+  while (angle <= -kPi) angle += 2.0f * kPi;
+  return angle;
+}
+
+void ensure_cqpsk_rrc() {
+  if (g_cqpsk_rrc_ready) return;
+  float energy = 0.0f;
+  constexpr int center = static_cast<int>(kCqpskRrcTaps / 2);
+  for (int index = 0; index < static_cast<int>(kCqpskRrcTaps); ++index) {
+    const float t = static_cast<float>(index - center) / kSamplesPerSymbol;
+    float value;
+    if (fabsf(t) < 1.0e-6f) {
+      value = 1.0f + kCqpskRrcAlpha * (4.0f / kPi - 1.0f);
+    } else if (fabsf(fabsf(4.0f * kCqpskRrcAlpha * t) - 1.0f) < 1.0e-5f) {
+      const float angle = kPi / (4.0f * kCqpskRrcAlpha);
+      value = kCqpskRrcAlpha / sqrtf(2.0f) *
+              ((1.0f + 2.0f / kPi) * sinf(angle) +
+               (1.0f - 2.0f / kPi) * cosf(angle));
+    } else {
+      value = (sinf(kPi * t * (1.0f - kCqpskRrcAlpha)) +
+               4.0f * kCqpskRrcAlpha * t *
+                   cosf(kPi * t * (1.0f + kCqpskRrcAlpha))) /
+              (kPi * t *
+               (1.0f - 16.0f * kCqpskRrcAlpha * kCqpskRrcAlpha * t * t));
+    }
+    g_cqpsk_rrc[index] = value;
+    energy += value * value;
+  }
+  const float scale = energy > 0.0f ? 1.0f / sqrtf(energy) : 1.0f;
+  for (float& tap : g_cqpsk_rrc) tap *= scale;
+  g_cqpsk_rrc_ready = true;
+}
 
 void ensure_gf() {
   if (g_gf_ready) return;
@@ -410,34 +452,33 @@ class Decoder {
   void reset(uint32_t now_ms) {
     *this = Decoder{};
     now_ms_ = now_ms;
+    started_ms_ = now_ms;
   }
 
-  void process_cu8(const uint8_t* iq, size_t bytes, uint32_t now_ms,
-                   VoiceSink voice_sink, void* voice_context) {
+  void prepare(uint32_t now_ms, VoiceSink voice_sink, void* voice_context) {
     now_ms_ = now_ms;
     voice_sink_ = voice_sink;
     voice_context_ = voice_context;
-    if (iq == nullptr) return;
-    size_t offset = 0;
-    if (have_pending_iq_byte_ && bytes != 0) {
-      process_iq_pair(pending_iq_byte_, iq[0]);
-      have_pending_iq_byte_ = false;
-      offset = 1;
-    }
-    for (; offset + 1 < bytes; offset += 2) {
-      process_iq_pair(iq[offset], iq[offset + 1]);
-    }
-    if (offset < bytes) {
-      pending_iq_byte_ = iq[offset];
-      have_pending_iq_byte_ = true;
-    }
+  }
+
+  void finish(uint32_t now_ms) {
+    now_ms_ = now_ms;
     refresh_health(now_ms_);
   }
 
   Snapshot state() const { return state_; }
 
+  void set_sync_tolerance(int tolerance) { sync_tolerance_ = tolerance; }
+
+  void set_cqpsk_gains(float timing_gain, float carrier_gain) {
+    cqpsk_timing_gain_ = timing_gain;
+    cqpsk_carrier_gain_ = carrier_gain;
+  }
+
   static bool self_check() {
-    Decoder decoder;
+    // Self-check runs on the embedded startup task. Keep its large decoder
+    // scratch objects out of that task's stack and reset them before use.
+    static Decoder decoder;
     decoder.now_ms_ = 1000;
     constexpr uint16_t kNac = 0x1F0;
     const uint16_t nid_info = static_cast<uint16_t>((kNac << 4) | 0x7);
@@ -510,14 +551,17 @@ class Decoder {
     struct VoiceCheck {
       VoiceFrame frames[9]{};
       size_t count = 0;
-    } voice_check;
+    };
+    static VoiceCheck voice_check;
+    voice_check = {};
     const auto collect_voice = [](const VoiceFrame& frame, void* context) {
       auto& check = *static_cast<VoiceCheck*>(context);
       if (check.count >= std::size(check.frames)) return false;
       check.frames[check.count++] = frame;
       return true;
     };
-    Decoder voice_decoder;
+    static Decoder voice_decoder;
+    voice_decoder.reset(0);
     voice_decoder.now_ms_ = 2000;
     voice_decoder.voice_sink_ = collect_voice;
     voice_decoder.voice_context_ = &voice_check;
@@ -536,10 +580,14 @@ class Decoder {
         voice_ok &= frame.bits[bit] == static_cast<uint8_t>(((source * 13) ^ 5) & 1);
       }
     }
+    voice_decoder.voice_sink_ = nullptr;
+    voice_decoder.decode_ldu();
+    voice_ok &= voice_decoder.state_.voice_queue_drops == 0;
     constexpr std::array<uint8_t, 24> kEncryptedCodeword = {
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
         0x21,0x01,0x08,0x34,0x21,0x37,0x13,0x34,0x0D,0x1F,0x24,0x10};
-    std::array<uint8_t, kLduPayloadDibits> encryption_payload{};
+    static std::array<uint8_t, kLduPayloadDibits> encryption_payload;
+    encryption_payload.fill(0);
     size_t encryption_word = 0;
     for (const size_t block_offset : kEncryptionBitOffsets) {
       for (size_t block_word = 0; block_word < 4; ++block_word) {
@@ -556,34 +604,50 @@ class Decoder {
         encryption_payload.data(), encryption_payload.size(), &encryption) &&
         encryption.valid && encryption.encrypted && encryption.algorithm_id == 0x84 &&
         encryption.key_id == 0x1234;
-    return control_ok && explicit_grant_ok && voice_ok && encryption_ok;
+
+    const auto check_cqpsk = [&](float echo_gain) {
+      // The embedded startup task has a small stack; keep this large scratch
+      // decoder in static storage and reset it for each deterministic check.
+      static Decoder cqpsk;
+      cqpsk.reset(0);
+      cqpsk.set_sync_tolerance(5);
+      float phase = 0.0f;
+      std::array<float, 4> echo_i{};
+      std::array<float, 4> echo_q{};
+      size_t echo_pos = 0;
+      for (int repeat = 0; repeat < 8; ++repeat) {
+        size_t data_index = 0;
+        while (data_index < data.size()) {
+          const auto emit = [&](uint8_t dibit) {
+            constexpr uint8_t kInverseRemap[4] = {0, 1, 3, 2};
+            const uint8_t quadrant = kInverseRemap[dibit & 3];
+            const float delta = kPi / 4.0f +
+                (quadrant == 3 ? -kPi / 2.0f : quadrant * kPi / 2.0f);
+            phase = wrap_pi(phase + delta);
+            const float clean_i = cosf(phase);
+            const float clean_q = sinf(phase);
+            for (size_t sample = 0; sample < kSamplesPerSymbol; ++sample) {
+              const size_t delayed = (echo_pos + 1) % echo_i.size();
+              cqpsk.process_cqpsk_sample(clean_i + echo_gain * echo_i[delayed],
+                                         clean_q + echo_gain * echo_q[delayed]);
+              echo_i[echo_pos] = clean_i;
+              echo_q[echo_pos] = clean_q;
+              echo_pos = (echo_pos + 1) % echo_i.size();
+            }
+          };
+          emit(data[data_index++]);
+          if (data_index < data.size() && data_index % 35 == 0)
+            emit(static_cast<uint8_t>(repeat & 3));
+        }
+      }
+      cqpsk.finish(1000);
+      return cqpsk.state_.nid_good > 0 && cqpsk.state_.tsbk_good > 0;
+    };
+    return control_ok && explicit_grant_ok && voice_ok && encryption_ok &&
+           check_cqpsk(0.0f) && check_cqpsk(0.20f);
   }
 
- private:
-  void process_iq_pair(uint8_t input_i, uint8_t input_q) {
-    constexpr float kChannelAlpha = 0.06f;
-    constexpr float kDcAlpha = 1.0f / kInputRate;
-    const float raw_i = static_cast<float>(static_cast<int>(input_i) - 128);
-    const float raw_q = static_cast<float>(static_cast<int>(input_q) - 128);
-    dc_i_ += kDcAlpha * (raw_i - dc_i_);
-    dc_q_ += kDcAlpha * (raw_q - dc_q_);
-    const float centered_i = raw_i - dc_i_;
-    const float centered_q = raw_q - dc_q_;
-    lpf_i1_ += kChannelAlpha * (centered_i - lpf_i1_);
-    lpf_q1_ += kChannelAlpha * (centered_q - lpf_q1_);
-    lpf_i2_ += kChannelAlpha * (lpf_i1_ - lpf_i2_);
-    lpf_q2_ += kChannelAlpha * (lpf_q1_ - lpf_q2_);
-    decim_i_ += lpf_i2_;
-    decim_q_ += lpf_q2_;
-    if (++decim_count_ < kInputDecimation) return;
-    const float i = decim_i_ / kInputDecimation;
-    const float q = decim_q_ / kInputDecimation;
-    decim_i_ = decim_q_ = 0;
-    decim_count_ = 0;
-    process_channel_sample(i, q);
-  }
-
-  void process_channel_sample(float i, float q) {
+  void process_c4fm_sample(float i, float q) {
     if (!have_previous_iq_) {
       previous_i_ = i;
       previous_q_ = q;
@@ -614,6 +678,7 @@ class Decoder {
       float symbol = previous_matched_ * (1.0f - fraction) + matched * fraction;
       if (have_previous_symbol_) {
         const float error = sign(previous_symbol_) * symbol - sign(symbol) * previous_symbol_;
+        state_.timing_error = error;
         clock_mu_ += kSamplesPerSymbol + 0.05f * error;
       } else {
         clock_mu_ += kSamplesPerSymbol;
@@ -638,6 +703,89 @@ class Decoder {
     previous_matched_ = matched;
   }
 
+  void process_cqpsk_sample(float i, float q) {
+    ensure_cqpsk_rrc();
+    cqpsk_i_[cqpsk_pos_] = i;
+    cqpsk_q_[cqpsk_pos_] = q;
+    float filtered_i = 0.0f;
+    float filtered_q = 0.0f;
+    size_t source = cqpsk_pos_;
+    for (size_t tap = 0; tap < kCqpskRrcTaps; ++tap) {
+      filtered_i += g_cqpsk_rrc[tap] * cqpsk_i_[source];
+      filtered_q += g_cqpsk_rrc[tap] * cqpsk_q_[source];
+      source = source == 0 ? kCqpskRrcTaps - 1 : source - 1;
+    }
+    cqpsk_pos_ = (cqpsk_pos_ + 1) % kCqpskRrcTaps;
+
+    const float power = filtered_i * filtered_i + filtered_q * filtered_q;
+    cqpsk_power_ += 0.001f * (power - cqpsk_power_);
+    if (cqpsk_power_ > 1.0e-9f) {
+      const float gain = 0.95f / sqrtf(cqpsk_power_);
+      filtered_i *= gain;
+      filtered_q *= gain;
+    }
+    cqpsk_filtered_i_[cqpsk_filtered_pos_] = filtered_i;
+    cqpsk_filtered_q_[cqpsk_filtered_pos_] = filtered_q;
+
+    cqpsk_mu_ -= 1.0f;
+    if (cqpsk_mu_ <= 0.0f) {
+      const float fraction = 1.0f + cqpsk_mu_;
+      const auto history = [&](const std::array<float, 12>& samples, size_t delay) {
+        const size_t newer = (cqpsk_filtered_pos_ + samples.size() - delay) % samples.size();
+        const size_t older = (newer + samples.size() - 1) % samples.size();
+        return samples[older] * (1.0f - fraction) + samples[newer] * fraction;
+      };
+      float symbol_i = history(cqpsk_filtered_i_, 0);
+      float symbol_q = history(cqpsk_filtered_q_, 0);
+      const float midpoint_i = history(cqpsk_filtered_i_, kSamplesPerSymbol / 2);
+      const float midpoint_q = history(cqpsk_filtered_q_, kSamplesPerSymbol / 2);
+      if (cqpsk_have_symbol_) {
+        const float error = (symbol_i - cqpsk_previous_symbol_i_) * midpoint_i +
+                            (symbol_q - cqpsk_previous_symbol_q_) * midpoint_q;
+        state_.timing_error = error;
+        cqpsk_mu_ += kSamplesPerSymbol + cqpsk_timing_gain_ * error;
+      } else {
+        cqpsk_mu_ += kSamplesPerSymbol;
+        cqpsk_have_symbol_ = true;
+      }
+      cqpsk_previous_symbol_i_ = symbol_i;
+      cqpsk_previous_symbol_q_ = symbol_q;
+
+      const float cs = cosf(cqpsk_phase_);
+      const float sn = sinf(cqpsk_phase_);
+      const float rotated_i = symbol_i * cs + symbol_q * sn;
+      const float rotated_q = symbol_q * cs - symbol_i * sn;
+      const float error = sign(rotated_i) * rotated_q - sign(rotated_q) * rotated_i;
+      const float carrier_beta = 0.125f * cqpsk_carrier_gain_ * cqpsk_carrier_gain_;
+      cqpsk_frequency_ = std::clamp(cqpsk_frequency_ + carrier_beta * error,
+                                    -kPi / 8.0f, kPi / 8.0f);
+      cqpsk_phase_ = wrap_pi(cqpsk_phase_ + cqpsk_frequency_ +
+                            cqpsk_carrier_gain_ * error);
+      state_.carrier_error_hz = cqpsk_frequency_ * kSymbolRate / (2.0f * kPi);
+
+      if (cqpsk_have_differential_) {
+        const float cross = cqpsk_previous_rotated_i_ * rotated_q -
+                            cqpsk_previous_rotated_q_ * rotated_i;
+        const float dot = cqpsk_previous_rotated_i_ * rotated_i +
+                          cqpsk_previous_rotated_q_ * rotated_q;
+        const float phase = wrap_pi(atan2f(cross, dot) - kPi / 4.0f);
+        const uint8_t quadrant = phase >= -kPi / 4.0f && phase < kPi / 4.0f ? 0
+                                 : phase >= kPi / 4.0f && phase < 3.0f * kPi / 4.0f ? 1
+                                 : phase >= -3.0f * kPi / 4.0f && phase < -kPi / 4.0f ? 3
+                                                                                       : 2;
+        constexpr uint8_t kLsmDibitRemap[4] = {0, 1, 3, 2};
+        feed_dibit(kLsmDibitRemap[quadrant]);
+      } else {
+        cqpsk_have_differential_ = true;
+      }
+      cqpsk_previous_rotated_i_ = rotated_i;
+      cqpsk_previous_rotated_q_ = rotated_q;
+    }
+    cqpsk_filtered_pos_ = (cqpsk_filtered_pos_ + 1) % cqpsk_filtered_i_.size();
+  }
+
+ private:
+
   static float sign(float value) {
     return value > 0.0f ? 1.0f : value < 0.0f ? -1.0f : 0.0f;
   }
@@ -661,7 +809,8 @@ class Decoder {
           best_rotation = rotation;
         }
       }
-      if (best_mismatch <= 4) {
+      best_sync_mismatch_ = std::min(best_sync_mismatch_, best_mismatch);
+      if (best_mismatch <= sync_tolerance_) {
         ++state_.sync_words;
         frame_active_ = true;
         frame_rotation_ = best_rotation;
@@ -747,7 +896,7 @@ class Decoder {
       std::memcpy(frame.bits, voice_bits, sizeof(frame.bits));
       frame.sequence = ++state_.voice_frames;
       frame.encryption = state_.voice_encryption;
-      if (voice_sink_ == nullptr || !voice_sink_(frame, voice_context_))
+      if (voice_sink_ != nullptr && !voice_sink_(frame, voice_context_))
         ++state_.voice_queue_drops;
     }
     frame_active_ = false;
@@ -874,6 +1023,12 @@ class Decoder {
                                        : 100.0f * fec_error_bits_ / fec_total_bits_;
     state_.afc_offset_hz = afc_dc_ * kSymbolRate / (2.0f * kPi);
     state_.symbol_level = agc_level_;
+    const uint32_t valid = state_.nid_good + state_.tsbk_good;
+    const uint32_t elapsed = now - started_ms_;
+    state_.decode_rate_hz = elapsed == 0 ? 0.0f : 1000.0f * valid / elapsed;
+    state_.lock_quality_percent = valid == 0
+        ? 100.0f * (24 - std::min(24, best_sync_mismatch_)) / 24.0f
+        : 100.0f * valid / (valid + state_.nid_failed + state_.tsbk_failed);
   }
 
   Snapshot state_{};
@@ -885,12 +1040,7 @@ class Decoder {
   uint64_t fec_error_bits_ = 0;
   uint64_t fec_total_bits_ = 0;
 
-  float dc_i_ = 0, dc_q_ = 0;
-  uint8_t pending_iq_byte_ = 0;
-  bool have_pending_iq_byte_ = false;
-  float lpf_i1_ = 0, lpf_q1_ = 0, lpf_i2_ = 0, lpf_q2_ = 0;
-  float decim_i_ = 0, decim_q_ = 0;
-  size_t decim_count_ = 0;
+  uint32_t started_ms_ = now_ms_;
   float previous_i_ = 0, previous_q_ = 0;
   bool have_previous_iq_ = false;
   std::array<float, kSamplesPerSymbol> matched_history_{};
@@ -904,6 +1054,26 @@ class Decoder {
   bool have_previous_symbol_ = false;
   float agc_level_ = 0;
   bool agc_seeded_ = false;
+  std::array<float, kCqpskRrcTaps> cqpsk_i_{};
+  std::array<float, kCqpskRrcTaps> cqpsk_q_{};
+  size_t cqpsk_pos_ = 0;
+  std::array<float, 12> cqpsk_filtered_i_{};
+  std::array<float, 12> cqpsk_filtered_q_{};
+  size_t cqpsk_filtered_pos_ = 0;
+  float cqpsk_power_ = 0.0f;
+  float cqpsk_mu_ = kSamplesPerSymbol / 2.0f;
+  float cqpsk_previous_symbol_i_ = 0.0f;
+  float cqpsk_previous_symbol_q_ = 0.0f;
+  bool cqpsk_have_symbol_ = false;
+  float cqpsk_phase_ = 0.0f;
+  float cqpsk_frequency_ = 0.0f;
+  float cqpsk_previous_rotated_i_ = 1.0f;
+  float cqpsk_previous_rotated_q_ = 0.0f;
+  bool cqpsk_have_differential_ = false;
+  float cqpsk_timing_gain_ = kCqpskGardnerGain;
+  float cqpsk_carrier_gain_ = kCqpskCostasAlpha;
+  int best_sync_mismatch_ = 24;
+  int sync_tolerance_ = 4;
 
   std::array<uint8_t, 24> sync_history_{};
   size_t sync_pos_ = 0;
@@ -921,17 +1091,154 @@ class Decoder {
 };
 
 namespace {
-Decoder g_decoder;
+class Receiver {
+ public:
+  void reset(uint32_t now_ms) {
+    c4fm_.reset(now_ms);
+    cqpsk_.reset(now_ms);
+    cqpsk_.set_sync_tolerance(5);
+    cqpsk_.set_cqpsk_gains(timing_gain_, carrier_gain_);
+    selected_ = configured_ == Modulation::auto_detect ? Modulation::auto_detect : configured_;
+    dc_i_ = dc_q_ = lpf_i1_ = lpf_q1_ = lpf_i2_ = lpf_q2_ = 0.0f;
+    decim_i_ = decim_q_ = 0.0f;
+    decim_count_ = 0;
+    have_pending_iq_byte_ = false;
+  }
+
+  void set_modulation(Modulation modulation) {
+    configured_ = modulation;
+    reset(0);
+  }
+
+  void configure(Modulation modulation, float timing_gain, float carrier_gain) {
+    configured_ = modulation;
+    timing_gain_ = std::isfinite(timing_gain) && timing_gain >= 0.0001f && timing_gain <= 0.05f
+                       ? timing_gain : kCqpskGardnerGain;
+    carrier_gain_ = std::isfinite(carrier_gain) && carrier_gain >= 0.0001f && carrier_gain <= 0.1f
+                        ? carrier_gain : kCqpskCostasAlpha;
+    reset(0);
+  }
+
+  void process(const uint8_t* iq, size_t bytes, uint32_t now_ms,
+               VoiceSink sink, void* context) {
+    c4fm_.prepare(now_ms, selected_ == Modulation::c4fm ? sink : nullptr, context);
+    cqpsk_.prepare(now_ms, selected_ == Modulation::cqpsk ? sink : nullptr, context);
+    if (iq != nullptr) {
+      size_t offset = 0;
+      if (have_pending_iq_byte_ && bytes != 0) {
+        process_pair(pending_iq_byte_, iq[0]);
+        have_pending_iq_byte_ = false;
+        offset = 1;
+      }
+      for (; offset + 1 < bytes; offset += 2) process_pair(iq[offset], iq[offset + 1]);
+      if (offset < bytes) {
+        pending_iq_byte_ = iq[offset];
+        have_pending_iq_byte_ = true;
+      }
+    }
+    c4fm_.finish(now_ms);
+    cqpsk_.finish(now_ms);
+    select_path(now_ms);
+  }
+
+  Snapshot state() const {
+    const Decoder& decoder = selected_ == Modulation::cqpsk ? cqpsk_ : c4fm_;
+    Snapshot result = decoder.state();
+    result.configured_modulation = configured_;
+    result.selected_modulation = selected_;
+    return result;
+  }
+
+  Modulation modulation() const { return configured_; }
+
+ private:
+  void process_pair(uint8_t input_i, uint8_t input_q) {
+    constexpr float kChannelAlpha = 0.06f;
+    constexpr float kDcAlpha = 1.0f / kInputRate;
+    const float raw_i = static_cast<float>(static_cast<int>(input_i) - 128);
+    const float raw_q = static_cast<float>(static_cast<int>(input_q) - 128);
+    dc_i_ += kDcAlpha * (raw_i - dc_i_);
+    dc_q_ += kDcAlpha * (raw_q - dc_q_);
+    lpf_i1_ += kChannelAlpha * (raw_i - dc_i_ - lpf_i1_);
+    lpf_q1_ += kChannelAlpha * (raw_q - dc_q_ - lpf_q1_);
+    lpf_i2_ += kChannelAlpha * (lpf_i1_ - lpf_i2_);
+    lpf_q2_ += kChannelAlpha * (lpf_q1_ - lpf_q2_);
+    decim_i_ += lpf_i2_;
+    decim_q_ += lpf_q2_;
+    if (++decim_count_ < kInputDecimation) return;
+    const float i = decim_i_ / kInputDecimation;
+    const float q = decim_q_ / kInputDecimation;
+    decim_i_ = decim_q_ = 0.0f;
+    decim_count_ = 0;
+    if (selected_ == Modulation::auto_detect || selected_ == Modulation::c4fm)
+      c4fm_.process_c4fm_sample(i, q);
+    if (selected_ == Modulation::auto_detect || selected_ == Modulation::cqpsk)
+      cqpsk_.process_cqpsk_sample(i, q);
+  }
+
+  void select_path(uint32_t now_ms) {
+    if (configured_ != Modulation::auto_detect) {
+      selected_ = configured_;
+      return;
+    }
+    if (selected_ != Modulation::auto_detect) {
+      if ((selected_ == Modulation::c4fm ? c4fm_ : cqpsk_).state().frame_sync) return;
+      selected_ = Modulation::auto_detect;
+      c4fm_.reset(now_ms);
+      cqpsk_.reset(now_ms);
+      cqpsk_.set_sync_tolerance(5);
+      cqpsk_.set_cqpsk_gains(timing_gain_, carrier_gain_);
+      return;
+    }
+    const Snapshot c4 = c4fm_.state();
+    const Snapshot cq = cqpsk_.state();
+    const uint32_t c4_score = 4 * c4.nid_good + 8 * c4.tsbk_good;
+    const uint32_t cq_score = 4 * cq.nid_good + 8 * cq.tsbk_good;
+    if (c4_score >= 8 || cq_score >= 8)
+      selected_ = cq_score > c4_score ? Modulation::cqpsk : Modulation::c4fm;
+  }
+
+  Decoder c4fm_{};
+  Decoder cqpsk_{};
+  Modulation configured_ = Modulation::auto_detect;
+  Modulation selected_ = Modulation::auto_detect;
+  float timing_gain_ = kCqpskGardnerGain;
+  float carrier_gain_ = kCqpskCostasAlpha;
+  float dc_i_ = 0, dc_q_ = 0;
+  float lpf_i1_ = 0, lpf_q1_ = 0, lpf_i2_ = 0, lpf_q2_ = 0;
+  float decim_i_ = 0, decim_q_ = 0;
+  size_t decim_count_ = 0;
+  uint8_t pending_iq_byte_ = 0;
+  bool have_pending_iq_byte_ = false;
+};
+
+Receiver g_receiver;
 }
 
-void reset(uint32_t now_ms) { g_decoder.reset(now_ms); }
+void reset(uint32_t now_ms) { g_receiver.reset(now_ms); }
+
+void configure(Modulation modulation, float timing_gain, float carrier_gain) {
+  g_receiver.configure(modulation, timing_gain, carrier_gain);
+}
+
+void set_modulation(Modulation modulation) { g_receiver.set_modulation(modulation); }
+
+Modulation modulation() { return g_receiver.modulation(); }
+
+const char* modulation_name(Modulation modulation) {
+  switch (modulation) {
+    case Modulation::c4fm: return "c4fm";
+    case Modulation::cqpsk: return "cqpsk";
+    default: return "auto";
+  }
+}
 
 void process_cu8(const uint8_t* iq, size_t bytes, uint32_t now_ms,
                  VoiceSink voice_sink, void* voice_context) {
-  g_decoder.process_cu8(iq, bytes, now_ms, voice_sink, voice_context);
+  g_receiver.process(iq, bytes, now_ms, voice_sink, voice_context);
 }
 
-Snapshot snapshot() { return g_decoder.state(); }
+Snapshot snapshot() { return g_receiver.state(); }
 
 bool decode_ldu2_encryption(const uint8_t* payload, size_t dibits,
                             EncryptionSync* result) {

--- a/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
@@ -582,7 +582,8 @@ class Decoder {
     }
     voice_decoder.voice_sink_ = nullptr;
     voice_decoder.decode_ldu();
-    voice_ok &= voice_decoder.state_.voice_queue_drops == 0;
+    voice_ok &= voice_decoder.state_.voice_queue_drops == 0 &&
+                voice_decoder.state_.voice_unrouted_frames == 9;
     constexpr std::array<uint8_t, 24> kEncryptedCodeword = {
         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
         0x21,0x01,0x08,0x34,0x21,0x37,0x13,0x34,0x0D,0x1F,0x24,0x10};
@@ -866,6 +867,7 @@ class Decoder {
     state_.nid_corrected_bits += corrected;
     fec_error_bits_ += corrected;
     fec_total_bits_ += 64;
+    last_valid_ms_ = now_ms_;
     collecting_nid_ = false;
     frame_data_count_ = 0;
     frame_duid_ = duid;
@@ -896,7 +898,9 @@ class Decoder {
       std::memcpy(frame.bits, voice_bits, sizeof(frame.bits));
       frame.sequence = ++state_.voice_frames;
       frame.encryption = state_.voice_encryption;
-      if (voice_sink_ != nullptr && !voice_sink_(frame, voice_context_))
+      if (voice_sink_ == nullptr)
+        ++state_.voice_unrouted_frames;
+      else if (!voice_sink_(frame, voice_context_))
         ++state_.voice_queue_drops;
     }
     frame_active_ = false;

--- a/apps/orcsdr-tab5/ui/p25_decoder_core.hpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder_core.hpp
@@ -9,6 +9,14 @@ constexpr size_t kRecentGrantCount = 8;
 constexpr size_t kVoiceFrameBits = 144;
 constexpr uint8_t kClearAlgorithmId = 0x80;
 
+// Phase I symbol-recovery path. Auto runs both paths only until one produces
+// valid P25 protocol frames, then keeps the successful path until lock loss.
+enum class Modulation : uint8_t {
+  auto_detect,
+  c4fm,
+  cqpsk,
+};
+
 struct EncryptionSync {
   bool valid = false;
   bool encrypted = false;
@@ -35,6 +43,8 @@ struct Grant {
 };
 
 struct Snapshot {
+  Modulation configured_modulation = Modulation::auto_detect;
+  Modulation selected_modulation = Modulation::auto_detect;
   bool frame_sync = false;
   bool identity_valid = false;
   uint16_t nac = 0;
@@ -60,16 +70,26 @@ struct Snapshot {
   float frame_error_percent = 0.0f;
   float afc_offset_hz = 0.0f;
   float symbol_level = 0.0f;
+  float lock_quality_percent = 0.0f;
+  float timing_error = 0.0f;
+  float carrier_error_hz = 0.0f;
+  float decode_rate_hz = 0.0f;
   Grant current_grant{};
   Grant recent_grants[kRecentGrantCount]{};
 };
 
 using VoiceSink = bool (*)(const VoiceFrame& frame, void* context);
 
-// Hardware-independent Phase I C4FM receiver. Callers supply the monotonic
-// clock and an optional bounded voice-frame sink. The radio has one receiver,
-// so the core owns one fixed-memory instance and performs no heap allocation.
+// Hardware-independent Phase I C4FM/CQPSK receiver. Callers supply the
+// monotonic clock and an optional bounded voice-frame sink. The radio has one
+// receiver, so the core owns one fixed-memory instance and allocates no heap.
 void reset(uint32_t now_ms = 0);
+// Select the demodulator and CQPSK Gardner/Costas gains. Invalid/non-positive
+// gains use the stable defaults (0.005 and 0.008).
+void configure(Modulation modulation, float timing_gain, float carrier_gain);
+void set_modulation(Modulation modulation);
+Modulation modulation();
+const char* modulation_name(Modulation modulation);
 void process_cu8(const uint8_t* iq, size_t bytes, uint32_t now_ms,
                  VoiceSink voice_sink = nullptr, void* voice_context = nullptr);
 Snapshot snapshot();

--- a/apps/orcsdr-tab5/ui/p25_decoder_core.hpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder_core.hpp
@@ -61,6 +61,7 @@ struct Snapshot {
   uint32_t voice_ldus = 0;
   uint32_t voice_frames = 0;
   uint32_t voice_queue_drops = 0;
+  uint32_t voice_unrouted_frames = 0;
   uint32_t last_voice_ms = 0;
   uint32_t encryption_sync_good = 0;
   uint32_t encryption_sync_failed = 0;

--- a/docs/API_SERIAL_CLI.md
+++ b/docs/API_SERIAL_CLI.md
@@ -507,7 +507,7 @@ configured control channel, so it cannot contain a followed voice call.
 
 | Command | Auth | Reply | Notes |
 |---|---|---|---|
-| `RTL_P25_STATUS` | no | `RTL_P25_STATUS profile=... frame_sync=... identity=... grants=... grant_events=... follow=...` | Includes current recent grants, session-level followed grant events, NID/TSBK, voice/IMBE/PCM, LDU2 encryption, heap, stack-headroom, USB, IQ, and audio-drop counters. Identity fields come from decoded over-the-air data. |
+| `RTL_P25_STATUS` | no | `RTL_P25_STATUS profile=... frame_sync=... identity=... grants=... grant_events=... follow=...` | Includes current recent grants, session-level followed grant events, NID/TSBK, routed, unrouted and rejected voice frames, IMBE/PCM, LDU2 encryption, heap, stack-headroom, USB, IQ, and audio-drop counters. Identity fields come from decoded over-the-air data. |
 | `RTL_P25_MODULATION` | no | `RTL_P25_MODULATION configured=auto selected=c4fm timing_gain=... carrier_gain=...` | Reports the configured Phase I demodulator and the path selected by automatic acquisition. |
 | `RTL_P25_MODULATION AUTO\|C4FM\|CQPSK` | yes | `RTL_P25_MODULATION_OK configured=...` | Selects automatic acquisition, the legacy C4FM discriminator, or the linear CQPSK/LSM path. The setting is saved to `P25.cfg` and the active P25 receiver is reacquired. |
 | `RTL_P25_ENCRYPTION_STATUS` | no | `RTL_P25_ENCRYPTION_STATUS detected=... algid=... kid=... muted_frames=... returns=...` | Reports the last valid LDU2 Encryption Sync result and cumulative mute/return counters for automated acceptance. It identifies and suppresses protected audio; it does not decrypt it. |

--- a/docs/API_SERIAL_CLI.md
+++ b/docs/API_SERIAL_CLI.md
@@ -508,12 +508,14 @@ configured control channel, so it cannot contain a followed voice call.
 | Command | Auth | Reply | Notes |
 |---|---|---|---|
 | `RTL_P25_STATUS` | no | `RTL_P25_STATUS profile=... frame_sync=... identity=... grants=... grant_events=... follow=...` | Includes current recent grants, session-level followed grant events, NID/TSBK, voice/IMBE/PCM, LDU2 encryption, heap, stack-headroom, USB, IQ, and audio-drop counters. Identity fields come from decoded over-the-air data. |
+| `RTL_P25_MODULATION` | no | `RTL_P25_MODULATION configured=auto selected=c4fm timing_gain=... carrier_gain=...` | Reports the configured Phase I demodulator and the path selected by automatic acquisition. |
+| `RTL_P25_MODULATION AUTO\|C4FM\|CQPSK` | yes | `RTL_P25_MODULATION_OK configured=...` | Selects automatic acquisition, the legacy C4FM discriminator, or the linear CQPSK/LSM path. The setting is saved to `P25.cfg` and the active P25 receiver is reacquired. |
 | `RTL_P25_ENCRYPTION_STATUS` | no | `RTL_P25_ENCRYPTION_STATUS detected=... algid=... kid=... muted_frames=... returns=...` | Reports the last valid LDU2 Encryption Sync result and cumulative mute/return counters for automated acceptance. It identifies and suppresses protected audio; it does not decrypt it. |
 | `RTL_P25_SCAN` | yes | `RTL_P25_SURVEY ...` | Runs the configured control-channel survey. |
 | `RTL_P25_IQ_START` | yes | `RTL_IQ_START source=p25 ...` | Requires a running P25 control channel. Voice following is suppressed while the bounded capture fills. |
 | `RTL_P25_IQ_STATUS` | no | `RTL_P25_IQ_STATUS ...` | Reports capture state, size limit, source frequency, sample rate, and last saved path. |
 | `RTL_P25_IQ_STOP` | yes | `RTL_IQ_DONE path=... source=p25 ...` | Stops and saves the capture in the existing ORCIQ CU8 format. |
-| `RTL_P25_REPLAY /orcsdr/<file>.orciq` | yes | `RTL_P25_REPLAY_DONE ...` | Requires the live radio to be stopped; rejects paths outside `/orcsdr`, malformed headers, non-CU8 data, wrong sample rates, and truncated files. |
+| `RTL_P25_REPLAY /orcsdr/<file>.orciq` | yes | `RTL_P25_REPLAY_DONE ... modulation_configured=... modulation_selected=...` | Requires the live radio to be stopped; rejects paths outside `/orcsdr`, malformed headers, non-CU8 data, wrong sample rates, and truncated files. Use `RTL_P25_MODULATION` before replay to compare paths deterministically. |
 
 The hardware acceptance runner supports either a hexadecimal pairing-key file
 or an NVS-containing backup. It requires control lock, decoded identity,
@@ -522,13 +524,22 @@ stable drop counters, a heap floor, and voice-task stack headroom:
 
 ```powershell
 apps/orcsdr-tab5/tools/run-p25-validation.ps1 `
-  -Port COM17 -ControlFrequencyHz 453812500 `
+  -Port COM17 -ControlFrequencyHz 453925000 `
   -PairingKeyPath .orclink/ui-doc.key -CaptureFixture
 ```
 
 Add `-RequireEncryptedVoice` during a controlled live test to require a valid
 encrypted LDU2 detection, muted voice frames, and an immediate return to the
-control channel.
+control channel. `-Modulation AUTO|C4FM|CQPSK` selects the demodulator for the
+run and restores the previous setting afterward. For deterministic on-device
+replay without waiting for live traffic:
+
+```powershell
+apps/orcsdr-tab5/tools/run-p25-validation.ps1 `
+  -Port COM17 -PairingKeyPath .orclink/ui-doc.key `
+  -ReplayOnly -ReplayPath /orcsdr/p25_control_lane_453925.orciq `
+  -Modulation CQPSK
+```
 
 ## Example workflows
 

--- a/docs/user-guide/dashboards/p25.md
+++ b/docs/user-guide/dashboards/p25.md
@@ -8,11 +8,34 @@ muted, and **SKIP ENCRYPTED** returns the receiver to the control channel. The
 dashboard may show the clear-text algorithm and key IDs for identification,
 but OrcSDR does not decrypt traffic.
 
+Phase I control and voice channels may use C4FM or linear CQPSK/LSM. The
+default `auto` mode evaluates both hardware-independent demodulators during
+acquisition, selects the one producing valid NIDs and TSBKs, and retries after
+lock loss. RF Health shows the selected path, lock quality, timing error,
+carrier error, decode rate, and frame error. A forced `cqpsk` replay of the
+retained Lane County Simulcast capture decodes the recorded NAC, WACN, system,
+RFSS, site, and valid TSBKs; the same strong capture currently scores better on
+C4FM, so automatic mode selects C4FM for it. Wider real-world LSM and multipath
+acceptance remains part of the WIP compatibility gate.
+
 ## Monitor workflow
 
 1. Enable **SURVEY** to evaluate the known control-channel candidates.
 2. Wait for frame synchronization and system identity.
 3. Leave **AUTO FOLLOW** enabled to follow clear voice grants.
 4. Use **HOLD** to retain the selected talkgroup, or **SKIP** to resume scanning.
+
+`/orcsdr/P25.cfg` accepts these optional receiver settings. Existing profiles
+without them continue to use the defaults:
+
+```ini
+modulation=auto
+cqpsk_timing_gain=0.005
+cqpsk_carrier_gain=0.008
+```
+
+Use `modulation=c4fm` or `modulation=cqpsk` only for diagnosis or a site whose
+waveform is known. A site being simulcast does not by itself prove that it uses
+LSM.
 
 The Talkgroups page shows recent decoded public activity. An unknown talkgroup ID is still useful evidence; OrcSDR does not invent a label when none is known.

--- a/tests/p25_core_tests.cpp
+++ b/tests/p25_core_tests.cpp
@@ -204,7 +204,7 @@ void test_control_fixture(const char* path) {
   CHECK(cqpsk_even.rfss == 1 && cqpsk_even.site == 1);
   CHECK(cqpsk_even.sync_words == 7);
   CHECK(cqpsk_even.nid_good == 7);
-  CHECK(cqpsk_even.tsbk_good == 6);
+  CHECK(cqpsk_even.tsbk_good >= 6);
   CHECK(cqpsk_odd.sync_words == cqpsk_even.sync_words);
   CHECK(cqpsk_odd.nid_good == cqpsk_even.nid_good);
   CHECK(cqpsk_odd.tsbk_good == cqpsk_even.tsbk_good);

--- a/tests/p25_core_tests.cpp
+++ b/tests/p25_core_tests.cpp
@@ -134,7 +134,8 @@ void test_encryption_sync_decode() {
   CHECK(!decode_ldu2_encryption(payload.data(), payload.size(), nullptr));
 }
 
-orcsdr::p25core::Snapshot decode_control_fixture(const char* path, size_t chunk_size) {
+orcsdr::p25core::Snapshot decode_control_fixture(const char* path, size_t chunk_size,
+                                                 orcsdr::p25core::Modulation modulation) {
   using namespace orcsdr::p25core;
   FILE* file = std::fopen(path, "rb");
   CHECK(file != nullptr);
@@ -148,6 +149,7 @@ orcsdr::p25core::Snapshot decode_control_fixture(const char* path, size_t chunk_
   CHECK(bytes == 1048540);
   CHECK(read_le16(header.data() + 24) == 1);
 
+  set_modulation(modulation);
   reset(1);
   std::array<uint8_t, 32768 + 512> iq{};
   CHECK(chunk_size <= iq.size());
@@ -182,13 +184,35 @@ void check_control_snapshot(const orcsdr::p25core::Snapshot& state) {
 }
 
 void test_control_fixture(const char* path) {
-  const auto even = decode_control_fixture(path, 32768 + 512);
+  const auto even = decode_control_fixture(path, 32768 + 512, orcsdr::p25core::Modulation::c4fm);
   check_control_snapshot(even);
-  const auto odd = decode_control_fixture(path, 32767);
+  const auto odd = decode_control_fixture(path, 32767, orcsdr::p25core::Modulation::c4fm);
   check_control_snapshot(odd);
   CHECK(odd.sync_words == even.sync_words);
   CHECK(odd.nid_good == even.nid_good);
   CHECK(odd.tsbk_good == even.tsbk_good);
+
+  const auto cqpsk_even = decode_control_fixture(
+      path, 32768 + 512, orcsdr::p25core::Modulation::cqpsk);
+  const auto cqpsk_odd = decode_control_fixture(
+      path, 32767, orcsdr::p25core::Modulation::cqpsk);
+  CHECK(cqpsk_even.frame_sync);
+  CHECK(cqpsk_even.identity_valid);
+  CHECK(cqpsk_even.nac == 0x1F0);
+  CHECK(cqpsk_even.wacn == 0xBEE00);
+  CHECK(cqpsk_even.system_id == 0x1F3);
+  CHECK(cqpsk_even.rfss == 1 && cqpsk_even.site == 1);
+  CHECK(cqpsk_even.sync_words == 7);
+  CHECK(cqpsk_even.nid_good == 7);
+  CHECK(cqpsk_even.tsbk_good == 6);
+  CHECK(cqpsk_odd.sync_words == cqpsk_even.sync_words);
+  CHECK(cqpsk_odd.nid_good == cqpsk_even.nid_good);
+  CHECK(cqpsk_odd.tsbk_good == cqpsk_even.tsbk_good);
+
+  const auto automatic = decode_control_fixture(
+      path, 32767, orcsdr::p25core::Modulation::auto_detect);
+  check_control_snapshot(automatic);
+  CHECK(automatic.selected_modulation == orcsdr::p25core::Modulation::c4fm);
 }
 
 void test_allocation_free_stress() {


### PR DESCRIPTION
## Problem and resulting behavior

OrcSDR's P25 Phase I receiver supported the existing C4FM discriminator but could not independently acquire or diagnose linear CQPSK/LSM control channels. A site marked simulcast therefore offered no way to compare paths, prove decoding through CQPSK, or expose timing and carrier behavior to the operator and automated validation.

This change adds a fixed-memory CQPSK receive path beside the existing C4FM path. Automatic mode evaluates both during acquisition and selects the one producing valid P25 NIDs and TSBKs. If the selected path loses lock, the receiver returns to acquisition. Operators can force either path for diagnosis through P25 configuration or the serial CLI, and the dashboard reports which path is active.

## Implementation

- Keep the existing C4FM decoder and protocol/FEC pipeline.
- Feed both receivers from one 48 kS/s complex channel stream during automatic acquisition.
- Add a CQPSK path using a root-raised-cosine matched filter, Gardner timing recovery, Costas carrier recovery, and differential dibit decoding.
- Keep all DSP and receiver state hardware-independent and fixed-memory.
- Add optional schema-v1-compatible modulation, cqpsk_timing_gain, and cqpsk_carrier_gain settings. Existing profiles continue to use automatic defaults.
- Add authenticated RTL_P25_MODULATION AUTO|C4FM|CQPSK control and an unauthenticated query form.
- Extend RTL_P25_STATUS and replay output with configured/selected modulation, lock quality, timing error, carrier error, decode rate, frame error, and routed/unrouted/rejected voice-frame counts.
- Show the selected path on P25 Monitor and detailed demodulator health on RF Health.
- Extend run-p25-validation.ps1 with forced-mode validation and deterministic -ReplayOnly operation while restoring the previous device setting afterward.
- Document configuration, serial commands, replay use, and current compatibility limits.

The GitHub wiki was updated separately in commit a42aa91 with the complete P25 serial controls and current Work-in-progress status.

## Defects found and corrected

The first CQPSK image failed during boot. The retained core dump identified a stack-protection fault in the P25 startup self-check: several large decoder scratch objects were local to the main task. Those objects now use fixed static storage and are reset for every deterministic check.

CodeRabbit found two valid issues after the first commit:

1. A valid NID did not refresh the last-valid timestamp, so automatic acquisition could select a candidate after its second NID and immediately demote it as stale. Valid NIDs now refresh that timestamp.
2. Voice frames decoded while automatic acquisition compared candidates had no installed sink. They are now counted explicitly as unrouted instead of being confused with application queue rejection. The self-check, serial output, and documentation cover this distinction.

CodeRabbit's optional test-maintainability suggestion was also accepted: forced CQPSK now requires at least six valid TSBKs rather than exactly six.

## Validation

Final source commit: 103443f.

- pwsh -NoProfile -File .\tools\test-p25-core.ps1: PASS, optimized and ASan/LSan/UBSan.
- Native ESP-IDF 5.5.4 Tab5 build: PASS.
- Application size: 0x221ec0; 47% of the application partition remains free.
- Exact application SHA-256: C75AA9B61643C2888926840A49B1AD00A5E38611EBBECD1187A415306BFE0CE6.
- The first corrected-image flash attempt failed because COM17 was physically disconnected. After reconnecting the expected ESP32-P4 Serial/JTAG device, bootloader, partition table, and application writes completed with hash verification.
- Authenticated dashboard regression: PASS, including radio UI, screen, header, home, RF Lab, home font, workflow, transition, and restoration checks.
- Forced C4FM replay: 7 valid NIDs and 20/20 valid TSBKs with correct NAC/WACN/system/RFSS/site identity.
- Forced CQPSK replay: 7 valid NIDs, 6 valid and 6 failed TSBKs, the same correct identity, and 68.4% reported lock quality.
- Automatic replay: selected C4FM and produced 7 valid NIDs and 20/20 valid TSBKs.
- Five-minute live validation at 453.925 MHz: PASS with 65 grant events, 778 IMBE frames, 746,880 PCM frames, voice return, control relock, encrypted-call detection and muting, zero USB/IQ/audio/voice-queue drops, a 22,961,392-byte minimum heap, and 1,416-byte P25 voice-task stack headroom.
- The live run exercised the new acquisition accounting and reported nine unrouted candidate frames while keeping rejected queue frames at zero.
- No panic, watchdog, OOM, or reset occurred during the final automated run.
- The project owner previously confirmed clear P25 audio from the initial PR image sounded excellent. The corrected image passed the automated voice/PCM chain, but no separate post-fix listening claim is made.

## Review

- CodeRabbit: two Fix Before Merge findings and one optional nit were verified, fixed in 103443f, and fully retested.
- Grok fallback: two attempts were inconclusive because its repository file tools failed and its direct diff review produced no verdict. This PR does not describe Grok as a clean review.
- A fresh CodeRabbit review is requested after the correction push; if the included-review quota blocks it, that limit is recorded rather than treated as approval.

## Honest limits

- Forced CQPSK decodes real recorded P25 identity and traffic, but currently produces fewer valid TSBKs than C4FM on this strong capture. Automatic mode therefore correctly prefers C4FM for it.
- The live receiver selected both CQPSK and C4FM while acquiring real traffic. Wider LSM and multipath compatibility remains work in progress.
- No adaptive equalizer was added because current replay evidence does not show that it is required. It belongs in a later change only if a controlled multipath capture demonstrates the need.
- The operator observed an apparent boot loop while serial was disconnected. Reconnecting USB restored operation. Subsequent no-reset monitoring showed more than 23 minutes of normal P25 following, and the corrected-image validation completed normally. The original reset reason was not captured, so this report does not assign it a cause.
- P25 remains labeled Work in progress. This PR does not add Phase II, profiles, discovery, talkgroup catalogs, decryption, or recording.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added P25 Phase I CQPSK/LSM demodulation alongside C4FM.
  - Automatic modulation detection selects the appropriate decoding path, with options to force C4FM or CQPSK.
  - Added modulation controls through the serial CLI and persistent configuration.
  - P25 dashboards now show selected modulation, lock quality, timing and carrier errors, decode rate, and demodulator status.
  - Replay and validation workflows now support direct fixture testing and modulation selection.

- **Documentation**
  - Updated the P25 user guide, README, and CLI reference with modulation settings, diagnostics, and replay guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->