### PR TITLE
Add live-validated P25 Phase II transport probe

### DIFF
--- a/apps/orcsdr-tab5/tools/run-p25-validation.ps1
+++ b/apps/orcsdr-tab5/tools/run-p25-validation.ps1
@@ -19,6 +19,8 @@ param(
   [switch]$RequireEncryptedVoice,
   [ValidateSet('AUTO', 'C4FM', 'CQPSK')]
   [string]$Modulation = 'AUTO',
+  [uint16[]]$WatchTalkgroup = @(),
+  [switch]$UseExistingSession,
   [string]$ReplayPath,
   [switch]$ReplayOnly
 )
@@ -31,6 +33,7 @@ $script:lastPing = [DateTime]::MinValue
 $script:tempNvs = $null
 $script:initialSoundEnabled = $null
 $script:initialModulation = $null
+$script:initialPhase2Trace = $null
 
 function Test-FatalLine([string]$Line) {
   return $Line -match '(?i)Guru Meditation|panic(?:ked|\x27ed)?|assert failed|abort\(|task watchdog|interrupt wdt|brownout detector|ESP-ROM:esp32p4|rst:0x|out of memory|alloc(?:ation)? failed|heap corruption'
@@ -88,6 +91,8 @@ function Get-Status {
     AudioDrops = [uint32](Get-Field $line 'audio_drops')
     ModulationConfigured = Get-Field $line 'modulation_configured'
     ModulationSelected = Get-Field $line 'modulation_selected'
+    Phase2Grants = [uint32](Get-Field $line 'p2_grants')
+    Phase2SyncWords = [uint32](Get-Field $line 'p2_sync_words')
   }
 }
 
@@ -156,6 +161,10 @@ function Connect-Authenticated {
   Write-Output 'P25_VALIDATION_AUTH verified=true'
 }
 
+function Test-FrequencyNear([uint32]$Actual, [uint32]$Expected) {
+  return [Math]::Abs([int64]$Actual - [int64]$Expected) -le 1000
+}
+
 try {
   $script:serial = [System.IO.Ports.SerialPort]::new($Port, 115200, 'None', 8, 'One')
   $script:serial.ReadTimeout = 200
@@ -166,6 +175,22 @@ try {
   Start-Sleep -Milliseconds 500
   $script:serial.DiscardInBuffer()
   Connect-Authenticated
+
+  $phase2Required = $WatchTalkgroup.Count -gt 0
+  if ($phase2Required) {
+    Write-Output "P25_VALIDATION_PHASE2 watchlist=$($WatchTalkgroup -join ',') acceptance=any_live_phase2_tgid"
+    $script:serial.WriteLine('RTL_P25_PHASE2_TRACE')
+    $trace = Read-LineUntil { param($line) $line -match '^RTL_P25_PHASE2_TRACE enabled=[01]$' } 5
+    if ($trace -notmatch 'enabled=([01])$') { throw 'Could not read Phase II trace state.' }
+    $script:initialPhase2Trace = [int]$Matches[1]
+    if ($script:initialPhase2Trace -eq 0) {
+      $script:serial.WriteLine('RTL_P25_PHASE2_TRACE ON')
+      $enabled = Read-LineUntil { param($line) $line -match '^RTL_P25_PHASE2_TRACE_(OK|ERROR) ' } 5
+      if ($enabled -notmatch '^RTL_P25_PHASE2_TRACE_OK enabled=1$') {
+        throw "Could not enable Phase II trace: $enabled"
+      }
+    }
+  }
 
   if ($ReplayOnly -and -not $ReplayPath) { throw '-ReplayOnly requires -ReplayPath.' }
   $script:serial.WriteLine('RTL_P25_MODULATION')
@@ -190,10 +215,15 @@ try {
     if ($null -eq $enabled) { throw 'Could not enable audio for P25 validation.' }
   }
 
-  $script:serial.WriteLine('RTL_STOP')
-  $stopped = Read-LineUntil { param($line) $line -match '^RTL_STOP_RESULT ' } 8
-  if ($stopped -notmatch '^RTL_STOP_RESULT ESP_OK$') {
-    throw "Could not stop the existing radio session: $stopped"
+  if ($ReplayOnly -and $UseExistingSession) {
+    throw '-UseExistingSession cannot be combined with -ReplayOnly.'
+  }
+  if (-not $UseExistingSession) {
+    $script:serial.WriteLine('RTL_STOP')
+    $stopped = Read-LineUntil { param($line) $line -match '^RTL_STOP_RESULT ' } 8
+    if ($stopped -notmatch '^RTL_STOP_RESULT ESP_OK$') {
+      throw "Could not stop the existing radio session: $stopped"
+    }
   }
 
   if ($ReplayOnly) {
@@ -211,11 +241,15 @@ try {
     return
   }
 
-  $script:serial.WriteLine("RTL_TUNE P25 $ControlFrequencyHz")
-  $tune = Read-LineUntil { param($line) $line -match '^RTL_TUNE_' } 8
-  if ($tune -notmatch '^RTL_TUNE_OK') { throw "P25 tune failed: $tune" }
-  Write-Output $tune
-  Start-Sleep -Seconds 2
+  if (-not $UseExistingSession) {
+    $script:serial.WriteLine("RTL_TUNE P25 $ControlFrequencyHz")
+    $tune = Read-LineUntil { param($line) $line -match '^RTL_TUNE_' } 8
+    if ($tune -notmatch '^RTL_TUNE_OK') { throw "P25 tune failed: $tune" }
+    Write-Output $tune
+    Start-Sleep -Seconds 2
+  } else {
+    Write-Output "P25_VALIDATION_SESSION reuse=true requested_hz=$ControlFrequencyHz"
+  }
 
   $baseline = $null
   $lockDeadline = [DateTime]::UtcNow.AddSeconds($ControlLockSeconds)
@@ -223,7 +257,9 @@ try {
     $status = Get-Status
     if ($status.Survey -eq 0 -and $status.Follow -eq 'control' -and
         $status.FrameSync -eq 1 -and $status.Identity -eq 1 -and
-        $status.TsbkGood -gt 0 -and $status.FrequencyHz -eq $status.ControlHz) {
+        $status.TsbkGood -gt 0 -and
+        (Test-FrequencyNear $status.FrequencyHz $ControlFrequencyHz) -and
+        (Test-FrequencyNear $status.ControlHz $ControlFrequencyHz)) {
       $baseline = $status
     } else {
       Start-Sleep -Seconds 2
@@ -282,6 +318,10 @@ try {
   $returnSeen = $false
   $relockSeen = $false
   $encryptedSeen = $false
+  $phase2GrantSeen = $false
+  $phase2AcquireSeen = $false
+  $phase2SyncSeen = $false
+  [uint16]$phase2Tgid = 0
   $deadline = [DateTime]::UtcNow.AddSeconds($CallWindowSeconds)
   Write-Output "P25_VALIDATION_SOAK started=true seconds=$CallWindowSeconds"
   while ([DateTime]::UtcNow -lt $deadline) {
@@ -290,15 +330,35 @@ try {
       $line = Read-LineUntil {
         param($value)
         $value -match '^RTL_P25_FOLLOW_(VOICE|RETURN) ' -or
-          $value -match '^RTL_P25_ENCRYPTED '
+          $value -match '^RTL_P25_ENCRYPTED ' -or
+          $value -match '^P25P2_CALL '
       } 1
       if ($null -eq $line) { continue }
       Write-Output $line
       if ($line -match '^RTL_P25_FOLLOW_VOICE ') { $voiceSeen = $true }
       if ($line -match '^RTL_P25_FOLLOW_RETURN ') { $returnSeen = $true }
       if ($line -match '^RTL_P25_ENCRYPTED ') { $encryptedSeen = $true }
+      if ($phase2Required -and $line -match '^P25P2_CALL .*?(?:^| )tg=([0-9]+)(?: |$)') {
+        $eventTgid = [uint16]$Matches[1]
+        if ($line -match ' event=grant ' -and $phase2Tgid -eq 0) {
+          $phase2Tgid = $eventTgid
+          $phase2GrantSeen = $true
+          Write-Output "P25_VALIDATION_PHASE2_SELECTED tg=$phase2Tgid watchlist_match=$([int]($WatchTalkgroup -contains $phase2Tgid))"
+        }
+        if ($eventTgid -eq $phase2Tgid -and $line -match ' event=acquisition ') {
+          $phase2AcquireSeen = $true
+          $voiceSeen = $true
+        }
+        if ($eventTgid -eq $phase2Tgid -and $line -match ' event=completion .* result=burst_sync') {
+          $phase2SyncSeen = $true
+          $returnSeen = $true
+        }
+      }
     }
     $status = Get-Status
+    if (-not (Test-FrequencyNear $status.ControlHz $ControlFrequencyHz)) {
+      throw "P25 control channel changed during validation: requested=$ControlFrequencyHz active=$($status.ControlHz)."
+    }
     $maxGrants = [Math]::Max($maxGrants, $status.GrantEvents)
     $maxImbe = [Math]::Max($maxImbe, $status.ImbeFrames)
     $maxPcm = [Math]::Max($maxPcm, $status.PcmFrames)
@@ -317,15 +377,24 @@ try {
                   $status.FrameSync -eq 1 -and $status.TsbkGood -gt $baseline.TsbkGood)
   }
 
-  if ($maxGrants - $baseline.GrantEvents -lt $MinimumGrantCount) {
+  if ($phase2Required) {
+    if (-not $phase2GrantSeen) { throw 'No live Phase II grant was observed.' }
+    if (-not $phase2AcquireSeen) { throw "No Phase II traffic probe started for observed TGID $phase2Tgid." }
+    if (-not $phase2SyncSeen) { throw "No Phase II burst synchronization completed for observed TGID $phase2Tgid." }
+  } elseif ($maxGrants - $baseline.GrantEvents -lt $MinimumGrantCount) {
     throw "Only $($maxGrants - $baseline.GrantEvents) voice grant events were observed."
   }
   if (-not $voiceSeen) { throw 'No P25 voice retune was observed.' }
-  if ($maxImbe -le $baseline.ImbeFrames) { throw 'IMBE frame count did not grow.' }
-  if ($maxPcm -le $baseline.PcmFrames) { throw 'PCM sample count did not grow.' }
+  if (-not $phase2Required -and $maxImbe -le $baseline.ImbeFrames) {
+    throw 'IMBE frame count did not grow.'
+  }
+  if (-not $phase2Required -and $maxPcm -le $baseline.PcmFrames) {
+    throw 'PCM sample count did not grow.'
+  }
   if (-not $returnSeen -or -not $relockSeen) { throw 'Control-channel return and relock were not observed.' }
   if ($minHeap -lt $MinimumHeapBytes) { throw "Heap floor failed: $minHeap bytes." }
-  if ($minStack -eq [uint32]::MaxValue -or $minStack -lt $MinimumVoiceStackHeadroom) {
+  if (-not $phase2Required -and
+      ($minStack -eq [uint32]::MaxValue -or $minStack -lt $MinimumVoiceStackHeadroom)) {
     throw "P25 voice task stack headroom failed: $minStack."
   }
   if ($RequireEncryptedVoice -and (-not $encryptedSeen -or
@@ -348,15 +417,25 @@ try {
     Write-Output $replay
   }
 
+  $reportedStack = if ($minStack -eq [uint32]::MaxValue) { 0 } else { $minStack }
   Write-Output (
     "P25_VALIDATION_RESULT result=PASS control_hz=$activeControlHz " +
     "grant_events=$($maxGrants - $baseline.GrantEvents) " +
     "imbe_frames=$maxImbe pcm_frames=$maxPcm min_heap=$minHeap " +
-    "voice_stack_hwm=$minStack voice_return=$([int]$returnSeen) relock=$([int]$relockSeen) " +
+    "voice_stack_hwm=$reportedStack voice_return=$([int]$returnSeen) relock=$([int]$relockSeen) " +
     "encrypted_seen=$([int]$encryptedSeen) encrypted_muted_frames=$maxEncryptedMuted " +
-    "encrypted_returns=$maxEncryptedReturns")
+    "encrypted_returns=$maxEncryptedReturns phase2_tgid=$phase2Tgid " +
+    "phase2_grant=$([int]$phase2GrantSeen) phase2_sync=$([int]$phase2SyncSeen)")
 } finally {
   if ($null -ne $script:serial -and $script:serial.IsOpen) {
+    if ($script:initialPhase2Trace -eq 0) {
+      try {
+        $script:serial.WriteLine('RTL_P25_PHASE2_TRACE OFF')
+        [void](Read-LineUntil { param($line) $line -match '^RTL_P25_PHASE2_TRACE_OK enabled=0$' } 5)
+      } catch {
+        Write-Warning "Could not restore Phase II trace state: $($_.Exception.Message)"
+      }
+    }
     if ($script:initialModulation -and $script:initialModulation -ne $Modulation) {
       try {
         $script:serial.WriteLine("RTL_P25_MODULATION $($script:initialModulation)")

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -8204,7 +8204,9 @@ orcsdr::p25::Snapshot p25_dashboard_snapshot() {
   snapshot.config_revision = p25_config_revision;
   strlcpy(snapshot.config_status, p25_config_status, sizeof(snapshot.config_status));
   snapshot.decoded = orcsdr::p25decoder::snapshot();
-  if (p25_follow_state.load(std::memory_order_acquire) == P25FollowState::voice) {
+  const auto follow_state = p25_follow_state.load(std::memory_order_acquire);
+  if (follow_state == P25FollowState::voice ||
+      follow_state == P25FollowState::phase2_probe) {
     snapshot.decoded.current_grant = p25_follow_grant;
     snapshot.decoded.recent_grants[0] = p25_follow_grant;
   }
@@ -12420,6 +12422,12 @@ void process_command(char* command) {
     esp_rtl_sdr_metrics_t metrics{};
     if (g_rtl != nullptr) (void)esp_rtl_sdr_get_metrics(g_rtl, &metrics);
     const uint32_t encryption = p25_last_encryption.load(std::memory_order_acquire);
+    const auto follow_state = p25_follow_state.load(std::memory_order_acquire);
+    const char* follow_name = follow_state == P25FollowState::voice
+                                  ? "voice"
+                                  : follow_state == P25FollowState::phase2_probe
+                                        ? "phase2_probe"
+                                        : "control";
     Serial.printf(
         "RTL_P25_STATUS configured=%d profile_id=\"%s\" profile=\"%s\" identity_source=air "
         "frequency_hz=%lu survey=%d candidate=%u hold=%d hold_tg=%u auto_follow=%d "
@@ -12475,8 +12483,7 @@ void process_command(char* command) {
         static_cast<double>(decoded.estimated_ber_percent),
         grant_count,
         static_cast<unsigned long>(p25_grant_events.load(std::memory_order_relaxed)),
-        p25_follow_state.load(std::memory_order_acquire) == P25FollowState::voice
-            ? "voice" : "control",
+        follow_name,
         static_cast<unsigned long>(p25_control_frequency_hz),
         static_cast<unsigned long>(p25_voice_frequency_hz),
         static_cast<unsigned long>(decoded.voice_ldus),

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -233,6 +233,7 @@ constexpr size_t kRtlAudioPlayBlockSamples = kRtlAudioPlayBlockFrames * 2;
 constexpr uint32_t kRtlAudioPlaySafetyMs = 12;
 constexpr uint32_t kP25VoiceHangMs = 1800;
 constexpr uint32_t kP25VoiceAcquireMs = 3000;
+constexpr uint32_t kP25Phase2AcquireMs = 3000;
 /*
  * WBFM mono DSP targets (app-side; not RF hardware calibration).
  * Pipeline: 960 kS/s IQ → complex channel LPF → ×4 → discr → audio LPF → ×5 → 48 kHz
@@ -1535,7 +1536,7 @@ std::atomic<bool> p25_survey_active{false};
 std::atomic<bool> p25_hold{false};
 std::atomic<bool> p25_auto_follow{true};
 std::atomic<bool> p25_encryption_skip{true};
-enum class P25FollowState : uint8_t { control, voice };
+enum class P25FollowState : uint8_t { control, voice, phase2_probe };
 std::atomic<P25FollowState> p25_follow_state{P25FollowState::control};
 uint32_t p25_control_frequency_hz = kP25DefaultHz;
 orcsdr::p25config::Config p25_config{};
@@ -1553,6 +1554,11 @@ std::atomic<uint32_t> p25_imbe_frames{0};
 std::atomic<uint32_t> p25_imbe_errors{0};
 std::atomic<uint32_t> p25_pcm_frames{0};
 std::atomic<uint32_t> p25_grant_events{0};
+std::atomic<bool> p25_phase2_trace{false};
+std::atomic<uint32_t> p25_phase2_grant_events{0};
+std::atomic<uint32_t> p25_phase2_sync_events{0};
+std::atomic<uint32_t> p25_phase2_rejections{0};
+uint32_t p25_phase2_last_grant_ms = 0;
 std::atomic<uint32_t> p25_audio_last_ms{0};
 std::atomic<uint32_t> p25_voice_session{0};
 std::atomic<uint32_t> p25_voice_stack_hwm{0};
@@ -5275,6 +5281,7 @@ void stop_p25_automation() {
   cancel_p25_survey();
   p25_entry_probe_at_ms = 0;
   p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+  orcsdr::p25decoder::set_phase2_acquisition(false);
   orcsdr::p25decoder::suspend_voice();
   p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
   p25_voice_frequency_hz = 0;
@@ -8180,6 +8187,8 @@ orcsdr::p25::Snapshot p25_dashboard_snapshot() {
   snapshot.encryption_skip = p25_encryption_skip.load(std::memory_order_relaxed);
   snapshot.following_voice =
       p25_follow_state.load(std::memory_order_acquire) == P25FollowState::voice;
+  snapshot.probing_phase2 =
+      p25_follow_state.load(std::memory_order_acquire) == P25FollowState::phase2_probe;
   snapshot.imbe_frames = p25_imbe_frames.load(std::memory_order_relaxed);
   snapshot.imbe_errors = p25_imbe_errors.load(std::memory_order_relaxed);
   const uint32_t encryption = p25_last_encryption.load(std::memory_order_acquire);
@@ -8229,6 +8238,7 @@ orcsdr::p25::Snapshot p25_dashboard_snapshot() {
 void tune_p25_control(uint32_t frequency_hz) {
   frequency_hz = rtl_clamp_frequency(RtlBand::p25, frequency_hz);
   p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+  orcsdr::p25decoder::set_phase2_acquisition(false);
   orcsdr::p25decoder::suspend_voice();
   p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
   p25_control_frequency_hz = frequency_hz;
@@ -8247,6 +8257,7 @@ void start_p25_survey() {
     return;
   }
   p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+  orcsdr::p25decoder::set_phase2_acquisition(false);
   orcsdr::p25decoder::suspend_voice();
   p25_voice_session.fetch_add(1, std::memory_order_acq_rel);
   p25_voice_frequency_hz = 0;
@@ -8721,7 +8732,30 @@ void service_p25_follow(uint32_t now) {
   if (g_iq_rec_active.load(std::memory_order_relaxed) &&
       g_iq_rec_kind.load(std::memory_order_relaxed) == IqCaptureKind::p25) return;
   const auto decoded = orcsdr::p25decoder::snapshot();
-  if (p25_follow_state.load(std::memory_order_acquire) == P25FollowState::voice) {
+  if (p25_follow_state.load(std::memory_order_acquire) == P25FollowState::phase2_probe) {
+    const bool synchronized = decoded.phase2_sync_words != 0;
+    const bool timed_out = now - p25_follow_started_ms >= kP25Phase2AcquireMs;
+    if (!synchronized && !timed_out && p25_phase2_trace.load(std::memory_order_relaxed))
+      return;
+    Serial.printf(
+        "P25P2_CALL event=%s tg=%u src=%lu carrier_hz=%lu slot=%u symbols=%lu "
+        "sync_words=%lu best_sync_errors=%u%s\n",
+        synchronized ? "completion" : "rejection", p25_follow_grant.talkgroup,
+        static_cast<unsigned long>(p25_follow_grant.source_id),
+        static_cast<unsigned long>(p25_follow_grant.frequency_hz), p25_follow_grant.slot,
+        static_cast<unsigned long>(decoded.phase2_symbols),
+        static_cast<unsigned long>(decoded.phase2_sync_words),
+        decoded.phase2_best_sync_errors,
+        synchronized ? " result=burst_sync" : " reason=no_burst_sync");
+    if (synchronized) p25_phase2_sync_events.fetch_add(1, std::memory_order_relaxed);
+    else p25_phase2_rejections.fetch_add(1, std::memory_order_relaxed);
+    p25_follow_state.store(P25FollowState::control, std::memory_order_release);
+    orcsdr::p25decoder::set_phase2_acquisition(false);
+    p25_voice_frequency_hz = 0;
+    request_hot_retune(p25_control_frequency_hz);
+    return;
+  }
+  if (p25_follow_state.load(std::memory_order_acquire) != P25FollowState::control) {
     if (p25_encrypted_voice_pending.exchange(false, std::memory_order_acq_rel)) {
       const uint32_t encryption = p25_last_encryption.load(std::memory_order_acquire);
       p25_follow_grant.encrypted = true;
@@ -8769,7 +8803,44 @@ void service_p25_follow(uint32_t now) {
   if (p25_skipped_talkgroup != 0 &&
       static_cast<int32_t>(p25_skip_until_ms - now) <= 0) p25_skipped_talkgroup = 0;
   if (grant.talkgroup == p25_skipped_talkgroup) return;
-  if (grant.tdma || (grant.encrypted && p25_encryption_skip.load(std::memory_order_relaxed))) return;
+  if (grant.tdma) {
+    if (grant.seen_ms == p25_phase2_last_grant_ms) return;
+    p25_phase2_last_grant_ms = grant.seen_ms;
+    p25_phase2_grant_events.fetch_add(1, std::memory_order_relaxed);
+    Serial.printf(
+        "P25P2_CALL event=grant tg=%u src=%lu carrier_hz=%lu slot=%u channel_id=%u "
+        "channel=%u service=%02X encrypted=%d emergency=%d wacn=%05lX sysid=%03X "
+        "rfss=%u site=%u\n",
+        grant.talkgroup, static_cast<unsigned long>(grant.source_id),
+        static_cast<unsigned long>(grant.frequency_hz), grant.slot, grant.channel_id,
+        grant.channel_number, grant.service_options, grant.encrypted ? 1 : 0,
+        grant.emergency ? 1 : 0, static_cast<unsigned long>(grant.wacn), grant.system_id,
+        grant.rfss, grant.site);
+    if (!p25_phase2_trace.load(std::memory_order_relaxed) || grant.encrypted) return;
+    if (p25_hold.load(std::memory_order_relaxed)) {
+      if (p25_hold_talkgroup == 0) {
+        p25_hold_talkgroup = grant.talkgroup;
+        request_p25_config_save();
+        Serial.printf("RTL_P25_HOLD enabled=1 tg=%u mode=talkgroup\n", p25_hold_talkgroup);
+      }
+      if (grant.talkgroup != p25_hold_talkgroup) return;
+    }
+    if (grant.frequency_hz == rtl_ui_frequency_hz) return;
+    p25_control_frequency_hz = rtl_ui_frequency_hz;
+    p25_voice_frequency_hz = grant.frequency_hz;
+    p25_follow_grant = grant;
+    p25_follow_started_ms = now;
+    p25_follow_state.store(P25FollowState::phase2_probe, std::memory_order_release);
+    orcsdr::p25decoder::suspend_voice();
+    orcsdr::p25decoder::set_phase2_acquisition(true);
+    request_hot_retune(grant.frequency_hz);
+    Serial.printf("P25P2_CALL event=acquisition tg=%u carrier_hz=%lu slot=%u timeout_ms=%lu\n",
+                  grant.talkgroup, static_cast<unsigned long>(grant.frequency_hz), grant.slot,
+                  static_cast<unsigned long>(kP25Phase2AcquireMs));
+    return;
+  }
+
+  if (grant.encrypted && p25_encryption_skip.load(std::memory_order_relaxed)) return;
   if (p25_hold.load(std::memory_order_relaxed)) {
     if (p25_hold_talkgroup == 0) {
       p25_hold_talkgroup = grant.talkgroup;
@@ -10766,8 +10837,11 @@ orcsdr::p25::Snapshot ui_doc_p25_snapshot(bool demo) {
   snapshot.decoded.nid_good = 1801;
   snapshot.decoded.tsbk_good = 932;
   snapshot.decoded.estimated_ber_percent = 1.2f;
-  snapshot.decoded.current_grant = {true, false, false, false, 38130, 1204521,
-                                    453487500, millis()};
+  snapshot.decoded.current_grant.valid = true;
+  snapshot.decoded.current_grant.talkgroup = 38130;
+  snapshot.decoded.current_grant.source_id = 1204521;
+  snapshot.decoded.current_grant.frequency_hz = 453487500;
+  snapshot.decoded.current_grant.seen_ms = millis();
   snapshot.decoded.recent_grants[0] = snapshot.decoded.current_grant;
   snapshot.imbe_frames = 428;
   snapshot.imbe_errors = 2;
@@ -12212,6 +12286,8 @@ void process_command(char* command) {
     Serial.println("RTL_RDS_CAPTURE_START/STOP/STATUS - capture FM MPX to SD for replay");
     Serial.println("RTL_RDS_REPLAY <path.s16>       - replay captured MPX while radio is stopped");
     Serial.println("RTL_P25_STATUS                 - profile, decoder, voice and memory diagnostics");
+    Serial.println("RTL_P25_PHASE2_STATUS          - TDMA grant mapping and burst-sync diagnostics");
+    Serial.println("RTL_P25_PHASE2_TRACE ON|OFF    - authenticated one-call transport probe");
     Serial.println("RTL_P25_PROFILE_LIST           - list installed P25 system profiles");
     Serial.println("RTL_P25_PROFILE_SELECT <id>    - select a P25 system profile (auth)");
     Serial.println("RTL_P25_PROFILE_IMPORT <path> <id> - import and select a profile (auth)");
@@ -12352,6 +12428,9 @@ void process_command(char* command) {
         "timing_error=%.4f carrier_error_hz=%.1f decode_rate_hz=%.2f "
         "frame_sync=%d identity=%d nac=%03X wacn=%05lX sysid=%03X rfss=%u site=%u "
         "sync_words=%lu nid_good=%lu nid_failed=%lu tsbk_good=%lu tsbk_failed=%lu "
+        "p2_band_plans=%lu p2_grants=%lu p2_mapping_errors=%lu p2_syncs=%lu "
+        "p2_rejections=%lu p2_trace=%d "
+        "p2_active=%d p2_symbols=%lu p2_sync_words=%lu p2_best_sync_errors=%u "
         "ber_percent=%.2f grants=%d grant_events=%lu follow=%s control_hz=%lu voice_hz=%lu "
         "voice_ldus=%lu voice_frames=%lu voice_queue_drops=%lu voice_unrouted=%lu "
         "enc_sync_good=%lu "
@@ -12383,6 +12462,16 @@ void process_command(char* command) {
         static_cast<unsigned long>(decoded.nid_failed),
         static_cast<unsigned long>(decoded.tsbk_good),
         static_cast<unsigned long>(decoded.tsbk_failed),
+        static_cast<unsigned long>(decoded.phase2_band_plans),
+        static_cast<unsigned long>(p25_phase2_grant_events.load(std::memory_order_relaxed)),
+        static_cast<unsigned long>(decoded.phase2_mapping_errors),
+        static_cast<unsigned long>(p25_phase2_sync_events.load(std::memory_order_relaxed)),
+        static_cast<unsigned long>(p25_phase2_rejections.load(std::memory_order_relaxed)),
+        p25_phase2_trace.load(std::memory_order_relaxed) ? 1 : 0,
+        decoded.phase2_acquisition ? 1 : 0,
+        static_cast<unsigned long>(decoded.phase2_symbols),
+        static_cast<unsigned long>(decoded.phase2_sync_words),
+        decoded.phase2_best_sync_errors,
         static_cast<double>(decoded.estimated_ber_percent),
         grant_count,
         static_cast<unsigned long>(p25_grant_events.load(std::memory_order_relaxed)),
@@ -12420,6 +12509,54 @@ void process_command(char* command) {
                     static_cast<unsigned>(i),
                     static_cast<unsigned long>(p25_config.control_channels_hz[i]),
                     static_cast<double>(p25_candidate_levels[i]));
+    return;
+  }
+  if (strcmp(command, "RTL_P25_PHASE2_STATUS") == 0) {
+    const auto decoded = orcsdr::p25decoder::snapshot();
+    const auto& grant = p25_follow_state.load(std::memory_order_acquire) ==
+                                P25FollowState::phase2_probe
+                            ? p25_follow_grant : decoded.current_grant;
+    Serial.printf(
+        "RTL_P25_PHASE2_STATUS trace=%d active=%d grants=%lu mapping_errors=%lu "
+        "syncs=%lu rejections=%lu "
+        "tg=%u src=%lu carrier_hz=%lu slot=%u channel_id=%u channel=%u service=%02X "
+        "encrypted=%d wacn=%05lX sysid=%03X rfss=%u site=%u symbols=%lu "
+        "sync_words=%lu best_sync_errors=%u last_sync_ms=%lu\n",
+        p25_phase2_trace.load(std::memory_order_relaxed) ? 1 : 0,
+        decoded.phase2_acquisition ? 1 : 0,
+        static_cast<unsigned long>(p25_phase2_grant_events.load(std::memory_order_relaxed)),
+        static_cast<unsigned long>(decoded.phase2_mapping_errors),
+        static_cast<unsigned long>(p25_phase2_sync_events.load(std::memory_order_relaxed)),
+        static_cast<unsigned long>(p25_phase2_rejections.load(std::memory_order_relaxed)),
+        grant.talkgroup,
+        static_cast<unsigned long>(grant.source_id),
+        static_cast<unsigned long>(grant.frequency_hz), grant.slot, grant.channel_id,
+        grant.channel_number, grant.service_options, grant.encrypted ? 1 : 0,
+        static_cast<unsigned long>(grant.wacn), grant.system_id, grant.rfss, grant.site,
+        static_cast<unsigned long>(decoded.phase2_symbols),
+        static_cast<unsigned long>(decoded.phase2_sync_words),
+        decoded.phase2_best_sync_errors,
+        static_cast<unsigned long>(decoded.phase2_last_sync_ms));
+    return;
+  }
+  if (strcmp(command, "RTL_P25_PHASE2_TRACE") == 0) {
+    Serial.printf("RTL_P25_PHASE2_TRACE enabled=%d\n",
+                  p25_phase2_trace.load(std::memory_order_relaxed) ? 1 : 0);
+    return;
+  }
+  if (strncmp(command, "RTL_P25_PHASE2_TRACE ", 21) == 0) {
+    if (!authenticated) {
+      Serial.println("RTL_P25_PHASE2_TRACE_ERROR auth_required");
+      return;
+    }
+    const char* value = command + 21;
+    if (strcmp(value, "ON") != 0 && strcmp(value, "OFF") != 0) {
+      Serial.println("RTL_P25_PHASE2_TRACE_ERROR usage: RTL_P25_PHASE2_TRACE ON|OFF");
+      return;
+    }
+    const bool enabled = strcmp(value, "ON") == 0;
+    p25_phase2_trace.store(enabled, std::memory_order_release);
+    Serial.printf("RTL_P25_PHASE2_TRACE_OK enabled=%d\n", enabled ? 1 : 0);
     return;
   }
   if (strcmp(command, "RTL_P25_PROFILE_LIST") == 0) {

--- a/apps/orcsdr-tab5/ui/p25_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/p25_dashboard.cpp
@@ -5,6 +5,7 @@
 #include "text_editor.hpp"
 
 #include <M5Unified.h>
+#include <esp_attr.h>
 
 #include <algorithm>
 #include <cmath>
@@ -42,7 +43,7 @@ View g_view = View::monitor;
 bool g_active = false;
 audio_header::Control g_audio_control{};
 uint32_t g_last_dynamic_ms = 0;
-uint16_t g_waterfall_row[kSpectrumW]{};
+EXT_RAM_BSS_ATTR uint16_t g_waterfall_row[kSpectrumW]{};
 uint8_t g_profile_cursor = 0;
 bool g_delete_armed = false;
 char g_profile_name[48]{};
@@ -191,7 +192,8 @@ void draw_monitor_static() {
 void draw_monitor_dynamic() {
   char value[96];
   M5.Display.fillRect(40, 160, 390, 30, kPanel);
-  label(g_snapshot.following_voice ? "VOICE CHANNEL" : "CONTROL CHANNEL", 44, 166);
+  label(g_snapshot.following_voice ? "VOICE CHANNEL" :
+        g_snapshot.probing_phase2 ? "PHASE II PROBE" : "CONTROL CHANNEL", 44, 166);
   M5.Display.fillRect(42, 198, 384, 55, kPanel);
   format_mhz(value, sizeof(value), g_snapshot.frequency_hz);
   text(value, 52, 227, TFT_WHITE, 4, middle_left);
@@ -204,13 +206,14 @@ void draw_monitor_dynamic() {
              g_snapshot.decoded.system_id, g_snapshot.decoded.nac);
     text(value, 478, 246, kGreen, 1, middle_left);
   } else {
-    text("PROFILE: WACN BEE00  SYSID 1F3  NAC 1F0", 478, 246, kMuted, 1, middle_left);
+    text("AWAITING OVER-THE-AIR SYSTEM IDENTITY", 478, 246, kMuted, 1, middle_left);
   }
 
   M5.Display.fillRect(42, 330, 764, 135, kPanel);
   const auto& grant = g_snapshot.decoded.current_grant;
   if (grant.valid) {
-    text(g_snapshot.voice_encrypted ? "ENCRYPTED PHASE I VOICE MUTED" :
+    text(g_snapshot.probing_phase2 ? "PHASE II CALL DETECTED — CHECKING TRAFFIC" :
+         g_snapshot.voice_encrypted ? "ENCRYPTED PHASE I VOICE MUTED" :
          g_snapshot.following_voice ? "FOLLOWING CLEAR PHASE I VOICE" :
          grant_live(grant) ? "LIVE CONTROL-CHANNEL GRANT" : "LAST GRANT — STALE",
          424, 362, g_snapshot.voice_encrypted ? kRed :
@@ -580,6 +583,7 @@ void update(const Snapshot& snapshot) {
       snapshot.voice_algorithm_id != g_snapshot.voice_algorithm_id ||
       snapshot.voice_key_id != g_snapshot.voice_key_id ||
       snapshot.following_voice != g_snapshot.following_voice ||
+      snapshot.probing_phase2 != g_snapshot.probing_phase2 ||
       snapshot.candidate_index != g_snapshot.candidate_index ||
       snapshot.config_revision != g_snapshot.config_revision ||
       memcmp(snapshot.candidate_levels, g_snapshot.candidate_levels,

--- a/apps/orcsdr-tab5/ui/p25_dashboard.hpp
+++ b/apps/orcsdr-tab5/ui/p25_dashboard.hpp
@@ -32,6 +32,7 @@ struct Snapshot {
   bool auto_follow = true;
   bool encryption_skip = true;
   bool following_voice = false;
+  bool probing_phase2 = false;
   bool voice_encrypted = false;
   uint8_t voice_algorithm_id = 0;
   uint16_t voice_key_id = 0;

--- a/apps/orcsdr-tab5/ui/p25_decoder.cpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder.cpp
@@ -17,6 +17,8 @@ std::atomic<bool> g_voice_accepting{false};
 std::atomic<p25core::Modulation> g_modulation{p25core::Modulation::auto_detect};
 std::atomic<float> g_timing_gain{0.005f};
 std::atomic<float> g_carrier_gain{0.008f};
+std::atomic<bool> g_phase2_acquisition{false};
+bool g_phase2_applied = false;
 Snapshot g_public_snapshot{};
 portMUX_TYPE g_snapshot_mux = portMUX_INITIALIZER_UNLOCKED;
 
@@ -62,6 +64,8 @@ void reset_at(uint32_t now_ms) {
                      g_timing_gain.load(std::memory_order_acquire),
                      g_carrier_gain.load(std::memory_order_acquire));
   p25core::reset(now_ms);
+  g_phase2_applied = g_phase2_acquisition.load(std::memory_order_acquire);
+  p25core::set_phase2_acquisition(g_phase2_applied, now_ms);
   g_voice_generation.fetch_add(1, std::memory_order_acq_rel);
   g_voice_accepting.store(true, std::memory_order_release);
   publish_snapshot();
@@ -79,11 +83,20 @@ void suspend_voice() {
   clear_voice_queue();
 }
 
+void set_phase2_acquisition(bool enabled) {
+  g_phase2_acquisition.store(enabled, std::memory_order_release);
+}
+
 void process_cu8(const uint8_t* iq, size_t bytes) {
   process_cu8_at(iq, bytes, millis());
 }
 
 void process_cu8_at(const uint8_t* iq, size_t bytes, uint32_t now_ms) {
+  const bool phase2 = g_phase2_acquisition.load(std::memory_order_acquire);
+  if (phase2 != g_phase2_applied) {
+    p25core::set_phase2_acquisition(phase2, now_ms);
+    g_phase2_applied = phase2;
+  }
   VoiceContext voice{
       g_voice_generation.load(std::memory_order_acquire),
       g_voice_accepting.load(std::memory_order_acquire)};

--- a/apps/orcsdr-tab5/ui/p25_decoder.hpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder.hpp
@@ -18,6 +18,7 @@ void configure(Modulation modulation, float timing_gain, float carrier_gain);
 void process_cu8(const uint8_t* iq, size_t bytes);
 void reset_at(uint32_t now_ms);
 void suspend_voice();
+void set_phase2_acquisition(bool enabled);
 void process_cu8_at(const uint8_t* iq, size_t bytes, uint32_t now_ms);
 Snapshot snapshot();
 bool pop_voice_frame(VoiceFrame* frame);

--- a/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder_core.cpp
@@ -15,8 +15,10 @@ namespace {
 constexpr uint32_t kInputRate = 960000;
 constexpr uint32_t kChannelRate = 48000;
 constexpr uint32_t kSymbolRate = 4800;
+constexpr uint32_t kPhase2SymbolRate = 6000;
 constexpr size_t kInputDecimation = kInputRate / kChannelRate;
 constexpr size_t kSamplesPerSymbol = kChannelRate / kSymbolRate;
+constexpr size_t kPhase2SamplesPerSymbol = kChannelRate / kPhase2SymbolRate;
 constexpr float kOuterDeviationHz = 1800.0f;
 constexpr float kPi = 3.14159265358979323846f;
 constexpr float kSlicerScale = 2.0f * kPi * kOuterDeviationHz / kChannelRate;
@@ -62,9 +64,93 @@ constexpr uint8_t kTrellisPairs[16][2] = {
 
 struct BandPlanSlot {
   bool known = false;
-  bool tdma = false;
+  uint8_t slots_per_carrier = 1;
   uint32_t spacing_hz = 0;
   uint64_t base_hz = 0;
+};
+
+uint8_t slots_for_channel_type(uint8_t channel_type) {
+  constexpr std::array<uint8_t, 6> kSlots = {1, 1, 1, 2, 4, 2};
+  return channel_type < kSlots.size() ? kSlots[channel_type] : 0;
+}
+
+float wrap_pi(float angle);
+
+uint8_t bit_errors_40(uint64_t value) {
+  value &= 0xFFFFFFFFFFULL;
+  uint8_t count = 0;
+  while (value != 0) {
+    value &= value - 1;
+    ++count;
+  }
+  return count;
+}
+
+struct Phase2State {
+  uint32_t symbols = 0;
+  uint32_t sync_words = 0;
+  uint32_t last_sync_ms = 0;
+  uint8_t best_sync_errors = 40;
+};
+
+class Phase2Acquirer {
+ public:
+  void reset(uint32_t now_ms) {
+    state_ = {};
+    state_.best_sync_errors = 40;
+    now_ms_ = now_ms;
+    sample_index_ = 0;
+    have_previous_.fill(false);
+    primed_.fill(0);
+    history_.fill(0);
+  }
+
+  void process(float i, float q, uint32_t now_ms) {
+    now_ms_ = now_ms;
+    const size_t phase_index = sample_index_++ % kPhase2SamplesPerSymbol;
+    if (have_previous_[phase_index]) {
+      const float cross = previous_i_[phase_index] * q - previous_q_[phase_index] * i;
+      const float dot = previous_i_[phase_index] * i + previous_q_[phase_index] * q;
+      const float phase = wrap_pi(atan2f(cross, dot) - kPi / 4.0f);
+      const uint8_t quadrant = phase >= -kPi / 4.0f && phase < kPi / 4.0f ? 0
+          : phase >= kPi / 4.0f && phase < 3.0f * kPi / 4.0f ? 1
+          : phase >= -3.0f * kPi / 4.0f && phase < -kPi / 4.0f ? 3 : 2;
+      constexpr uint8_t kDibit[4] = {0, 1, 3, 2};
+      history_[phase_index] = ((history_[phase_index] << 2) | kDibit[quadrant]) &
+                              0xFFFFFFFFFFULL;
+      if (phase_index == 0) ++state_.symbols;
+      if (primed_[phase_index] < 20) ++primed_[phase_index];
+      if (primed_[phase_index] < 20) {
+        previous_i_[phase_index] = i;
+        previous_q_[phase_index] = q;
+        return;
+      }
+      constexpr uint64_t kSync = 0x575D57F7FFULL;
+      constexpr uint64_t kReversePolarity = kSync ^ 0xAAAAAAAAAAULL;
+      const uint8_t errors = std::min(bit_errors_40(history_[phase_index] ^ kSync),
+                                      bit_errors_40(history_[phase_index] ^ kReversePolarity));
+      state_.best_sync_errors = std::min(state_.best_sync_errors, errors);
+      if (errors <= 4 && now_ms_ != state_.last_sync_ms) {
+        ++state_.sync_words;
+        state_.last_sync_ms = now_ms_;
+      }
+    }
+    previous_i_[phase_index] = i;
+    previous_q_[phase_index] = q;
+    have_previous_[phase_index] = true;
+  }
+
+  const Phase2State& state() const { return state_; }
+
+ private:
+  Phase2State state_{};
+  uint32_t now_ms_ = 0;
+  uint32_t sample_index_ = 0;
+  std::array<float, kPhase2SamplesPerSymbol> previous_i_{};
+  std::array<float, kPhase2SamplesPerSymbol> previous_q_{};
+  std::array<bool, kPhase2SamplesPerSymbol> have_previous_{};
+  std::array<uint8_t, kPhase2SamplesPerSymbol> primed_{};
+  std::array<uint64_t, kPhase2SamplesPerSymbol> history_{};
 };
 
 constexpr std::array<size_t, 9> kVoiceBitOffsets = {
@@ -533,7 +619,7 @@ class Decoder {
                             result.nid_corrected_bits == 5 && result.tsbk_good == 1 &&
                             result.wacn == 0xBEE00 && result.system_id == 0x1F3 &&
                             result.last_trellis_metric > 0;
-    decoder.band_plan_[1] = {true, false, 12500, 450000000};
+    decoder.band_plan_[1] = {true, 1, 12500, 450000000};
     std::array<uint8_t, 12> explicit_grant{};
     explicit_grant[0] = 0x80 | 0x03;
     explicit_grant[2] = 0x80;
@@ -548,6 +634,34 @@ class Decoder {
     const bool explicit_grant_ok = grant.valid && grant.emergency &&
                                    grant.frequency_hz == 450087500 &&
                                    grant.talkgroup == 0x1234 && grant.source_id == 0;
+    Decoder tdma_decoder;
+    tdma_decoder.reset(100);
+    std::array<uint8_t, 12> tdma_plan{};
+    tdma_plan[0] = 0x33;
+    tdma_plan[2] = 0x23;  // identifier 2, two-slot channel type 3
+    tdma_plan[4] = 0x00;
+    tdma_plan[5] = 100;   // 12.5 kHz spacing in 125 Hz units
+    constexpr uint32_t base5 = 769000000 / 5;
+    tdma_plan[6] = static_cast<uint8_t>(base5 >> 24);
+    tdma_plan[7] = static_cast<uint8_t>(base5 >> 16);
+    tdma_plan[8] = static_cast<uint8_t>(base5 >> 8);
+    tdma_plan[9] = static_cast<uint8_t>(base5);
+    tdma_decoder.dispatch_tsbk(tdma_plan);
+    std::array<uint8_t, 12> tdma_grant{};
+    tdma_grant[0] = 0x03;
+    tdma_grant[2] = 0x04;
+    tdma_grant[4] = 0x20;
+    tdma_grant[5] = 41;
+    tdma_grant[8] = 0x56;
+    tdma_grant[9] = 0x78;
+    tdma_decoder.dispatch_tsbk(tdma_grant);
+    const Grant& tdma = tdma_decoder.state_.current_grant;
+    const bool tdma_grant_ok = tdma.valid && tdma.tdma && tdma.slot == 1 &&
+                               tdma.frequency_hz == 769250000 &&
+                               tdma.channel_id == 2 && tdma.channel_number == 41 &&
+                               tdma.talkgroup == 0x5678 &&
+                               tdma_decoder.state_.phase2_band_plans == 1 &&
+                               tdma_decoder.state_.phase2_grants == 1;
     struct VoiceCheck {
       VoiceFrame frames[9]{};
       size_t count = 0;
@@ -644,7 +758,7 @@ class Decoder {
       cqpsk.finish(1000);
       return cqpsk.state_.nid_good > 0 && cqpsk.state_.tsbk_good > 0;
     };
-    return control_ok && explicit_grant_ok && voice_ok && encryption_ok &&
+    return control_ok && explicit_grant_ok && tdma_grant_ok && voice_ok && encryption_ok &&
            check_cqpsk(0.0f) && check_cqpsk(0.20f);
   }
 
@@ -942,12 +1056,16 @@ class Decoder {
     const uint8_t* payload = bytes.data() + 2;
     if (opcode == 0x3D || opcode == 0x34 || opcode == 0x33) {
       const uint8_t id = payload[0] >> 4;
+      const uint8_t slots = opcode == 0x33
+                                ? slots_for_channel_type(payload[0] & 0x0F)
+                                : 1;
       const uint16_t step = static_cast<uint16_t>(payload[2] & 0x03) << 8 | payload[3];
       const uint32_t base5 = static_cast<uint32_t>(payload[4]) << 24 |
                              static_cast<uint32_t>(payload[5]) << 16 |
                              static_cast<uint32_t>(payload[6]) << 8 | payload[7];
-      band_plan_[id] = {true, opcode == 0x33, static_cast<uint32_t>(step) * 125u,
+      band_plan_[id] = {slots != 0, slots, static_cast<uint32_t>(step) * 125u,
                         static_cast<uint64_t>(base5) * 5u};
+      if (opcode == 0x33 && slots != 0) ++state_.phase2_band_plans;
       return;
     }
     if (opcode == 0x3B) {
@@ -999,15 +1117,27 @@ class Decoder {
     grant.valid = talkgroup != 0;
     grant.encrypted = (service & 0x40) != 0;
     grant.emergency = (service & 0x80) != 0;
+    grant.service_options = service;
+    grant.channel_id = channel_id;
+    grant.channel_number = channel_number;
     grant.talkgroup = talkgroup;
     grant.source_id = source;
+    grant.wacn = state_.wacn;
+    grant.system_id = state_.system_id;
+    grant.rfss = state_.rfss;
+    grant.site = state_.site;
     grant.seen_ms = now_ms_;
     if (channel_id < band_plan_.size() && band_plan_[channel_id].known) {
-      const BandPlanSlot& slot = band_plan_[channel_id];
-      const uint64_t frequency = slot.base_hz +
-                                 static_cast<uint64_t>(channel_number) * slot.spacing_hz;
-      if (frequency <= UINT32_MAX) grant.frequency_hz = static_cast<uint32_t>(frequency);
-      grant.tdma = slot.tdma;
+      const BandPlanSlot& plan = band_plan_[channel_id];
+      const ChannelAssignment assignment = map_channel(
+          plan.base_hz, plan.spacing_hz, plan.slots_per_carrier, channel_number);
+      grant.tdma = plan.slots_per_carrier > 1;
+      grant.slot = assignment.slot;
+      grant.frequency_hz = assignment.frequency_hz;
+      if (grant.tdma) {
+        ++state_.phase2_grants;
+        if (!assignment.valid) ++state_.phase2_mapping_errors;
+      }
     }
     if (!grant.valid) return;
     for (size_t i = kRecentGrantCount - 1; i > 0; --i)
@@ -1107,6 +1237,7 @@ class Receiver {
     decim_i_ = decim_q_ = 0.0f;
     decim_count_ = 0;
     have_pending_iq_byte_ = false;
+    if (phase2_enabled_) phase2_.reset(now_ms);
   }
 
   void set_modulation(Modulation modulation) {
@@ -1125,6 +1256,7 @@ class Receiver {
 
   void process(const uint8_t* iq, size_t bytes, uint32_t now_ms,
                VoiceSink sink, void* context) {
+    now_ms_ = now_ms;
     c4fm_.prepare(now_ms, selected_ == Modulation::c4fm ? sink : nullptr, context);
     cqpsk_.prepare(now_ms, selected_ == Modulation::cqpsk ? sink : nullptr, context);
     if (iq != nullptr) {
@@ -1145,11 +1277,27 @@ class Receiver {
     select_path(now_ms);
   }
 
+  void set_phase2_acquisition(bool enabled, uint32_t now_ms) {
+    phase2_enabled_ = enabled;
+    if (enabled) phase2_.reset(now_ms);
+  }
+
+  void process_channel(float i, float q, uint32_t now_ms) {
+    if (phase2_enabled_) phase2_.process(i, q, now_ms);
+    else process_phase1_channel(i, q);
+  }
+
   Snapshot state() const {
     const Decoder& decoder = selected_ == Modulation::cqpsk ? cqpsk_ : c4fm_;
     Snapshot result = decoder.state();
     result.configured_modulation = configured_;
     result.selected_modulation = selected_;
+    const Phase2State& phase2 = phase2_.state();
+    result.phase2_acquisition = phase2_enabled_;
+    result.phase2_symbols = phase2.symbols;
+    result.phase2_sync_words = phase2.sync_words;
+    result.phase2_last_sync_ms = phase2.last_sync_ms;
+    result.phase2_best_sync_errors = phase2.best_sync_errors;
     return result;
   }
 
@@ -1174,6 +1322,10 @@ class Receiver {
     const float q = decim_q_ / kInputDecimation;
     decim_i_ = decim_q_ = 0.0f;
     decim_count_ = 0;
+    process_channel(i, q, now_ms_);
+  }
+
+  void process_phase1_channel(float i, float q) {
     if (selected_ == Modulation::auto_detect || selected_ == Modulation::c4fm)
       c4fm_.process_c4fm_sample(i, q);
     if (selected_ == Modulation::auto_detect || selected_ == Modulation::cqpsk)
@@ -1214,6 +1366,9 @@ class Receiver {
   size_t decim_count_ = 0;
   uint8_t pending_iq_byte_ = 0;
   bool have_pending_iq_byte_ = false;
+  uint32_t now_ms_ = 0;
+  bool phase2_enabled_ = false;
+  Phase2Acquirer phase2_{};
 };
 
 Receiver g_receiver;
@@ -1243,6 +1398,28 @@ void process_cu8(const uint8_t* iq, size_t bytes, uint32_t now_ms,
 }
 
 Snapshot snapshot() { return g_receiver.state(); }
+
+ChannelAssignment map_channel(uint64_t base_hz, uint32_t spacing_hz,
+                              uint8_t slots_per_carrier,
+                              uint16_t channel_number) {
+  ChannelAssignment result;
+  if (spacing_hz == 0 || slots_per_carrier == 0) return result;
+  const uint64_t carrier = base_hz +
+      static_cast<uint64_t>(channel_number / slots_per_carrier) * spacing_hz;
+  if (carrier > UINT32_MAX) return result;
+  result.valid = true;
+  result.frequency_hz = static_cast<uint32_t>(carrier);
+  result.slot = static_cast<uint8_t>(channel_number % slots_per_carrier);
+  return result;
+}
+
+void set_phase2_acquisition(bool enabled, uint32_t now_ms) {
+  g_receiver.set_phase2_acquisition(enabled, now_ms);
+}
+
+void process_channel_iq(float i, float q, uint32_t now_ms) {
+  g_receiver.process_channel(i, q, now_ms);
+}
 
 bool decode_ldu2_encryption(const uint8_t* payload, size_t dibits,
                             EncryptionSync* result) {

--- a/apps/orcsdr-tab5/ui/p25_decoder_core.hpp
+++ b/apps/orcsdr-tab5/ui/p25_decoder_core.hpp
@@ -31,14 +31,28 @@ struct VoiceFrame {
   EncryptionSync encryption{};
 };
 
+struct ChannelAssignment {
+  bool valid = false;
+  uint32_t frequency_hz = 0;
+  uint8_t slot = 0;
+};
+
 struct Grant {
   bool valid = false;
   bool encrypted = false;
   bool emergency = false;
   bool tdma = false;
+  uint8_t service_options = 0;
+  uint8_t channel_id = 0;
+  uint16_t channel_number = 0;
+  uint8_t slot = 0;
   uint16_t talkgroup = 0;
   uint32_t source_id = 0;
   uint32_t frequency_hz = 0;
+  uint32_t wacn = 0;
+  uint16_t system_id = 0;
+  uint8_t rfss = 0;
+  uint8_t site = 0;
   uint32_t seen_ms = 0;
 };
 
@@ -58,6 +72,14 @@ struct Snapshot {
   uint32_t nid_corrected_bits = 0;
   uint32_t tsbk_good = 0;
   uint32_t tsbk_failed = 0;
+  uint32_t phase2_band_plans = 0;
+  uint32_t phase2_grants = 0;
+  uint32_t phase2_mapping_errors = 0;
+  bool phase2_acquisition = false;
+  uint32_t phase2_symbols = 0;
+  uint32_t phase2_sync_words = 0;
+  uint32_t phase2_last_sync_ms = 0;
+  uint8_t phase2_best_sync_errors = 40;
   uint32_t voice_ldus = 0;
   uint32_t voice_frames = 0;
   uint32_t voice_queue_drops = 0;
@@ -93,7 +115,16 @@ Modulation modulation();
 const char* modulation_name(Modulation modulation);
 void process_cu8(const uint8_t* iq, size_t bytes, uint32_t now_ms,
                  VoiceSink voice_sink = nullptr, void* voice_context = nullptr);
+void set_phase2_acquisition(bool enabled, uint32_t now_ms);
+// Test/replay seam for the shared 48 kS/s complex channel stream.
+void process_channel_iq(float i, float q, uint32_t now_ms);
 Snapshot snapshot();
+
+// Map a logical channel number to its physical RF carrier and TDMA slot.
+// Phase II uses two logical channels per carrier; FDMA uses one.
+ChannelAssignment map_channel(uint64_t base_hz, uint32_t spacing_hz,
+                              uint8_t slots_per_carrier,
+                              uint16_t channel_number);
 
 // Decode the six 40-bit Encryption Sync fields from an LDU2 payload. The
 // input is the 1,568 payload bits after the NID, stored as 784 dibits.

--- a/docs/API_SERIAL_CLI.md
+++ b/docs/API_SERIAL_CLI.md
@@ -513,7 +513,10 @@ configured control channel, so it cannot contain a followed voice call.
 
 | Command | Auth | Reply | Notes |
 |---|---|---|---|
-| `RTL_P25_STATUS` | no | `RTL_P25_STATUS configured=... profile_id=... survey=... hold=... hold_tg=... auto_follow=... encryption_skip=... frame_sync=...` | Includes active-profile and operator-control state, recent grants, session-level followed grant events, NID/TSBK, routed, unrouted and rejected voice frames, IMBE/PCM, LDU2 encryption, heap, stack-headroom, USB, IQ, and audio-drop counters. Identity fields come from decoded over-the-air data. |
+| `RTL_P25_STATUS` | no | `RTL_P25_STATUS configured=... profile_id=... survey=... frame_sync=... p2_grants=... p2_sync_words=...` | Includes active-profile and operator-control state, recent grants, Phase I voice, Phase II mapping/probe, heap, stack-headroom, USB, IQ, and audio-drop counters. Identity fields come from decoded over-the-air data. |
+| `RTL_P25_PHASE2_STATUS` | no | `RTL_P25_PHASE2_STATUS trace=... active=... tg=... carrier_hz=... slot=... sync_words=...` | Reports the last TDMA grant mapping and the fixed-memory 6,000-symbol/s traffic burst detector. It does not claim Phase II MAC or audio decode. |
+| `RTL_P25_PHASE2_TRACE` | no | `RTL_P25_PHASE2_TRACE enabled=0\|1` | Reports whether the diagnostic one-call transport probe is enabled. The default is off. |
+| `RTL_P25_PHASE2_TRACE ON\|OFF` | yes | `RTL_P25_PHASE2_TRACE_OK enabled=0\|1` | When enabled, a clear TDMA grant is briefly tuned for burst-sync evidence and then returned to the control channel. Encrypted grants are reported but never probed for audio or decrypted. |
 | `RTL_P25_PROFILE_LIST` | no | `RTL_P25_PROFILE_LIST_BEGIN`, zero or more `RTL_P25_PROFILE`, then `_DONE` | Lists the bounded SD profile store and marks the active system. |
 | `RTL_P25_PROFILE_SELECT <id>` | yes | `RTL_P25_PROFILE_OK operation=select ...` | Validates and selects `/orcsdr/p25/<id>/profile.cfg`. |
 | `RTL_P25_PROFILE_IMPORT <path> <id>` | yes | `RTL_P25_PROFILE_OK operation=import ...` | Imports a valid version-1 or version-2 file under a new safe profile ID and preserves the source. Duplicate IDs are rejected; the `p25_` prefix is reserved for signed catalog packs. |
@@ -545,6 +548,17 @@ encrypted LDU2 detection, muted voice frames, and an immediate return to the
 control channel. `-Modulation AUTO|C4FM|CQPSK` selects the demodulator for the
 run and restores the previous setting afterward. For deterministic on-device
 replay without waiting for live traffic:
+
+Add `-WatchTalkgroup <TGID>[,<TGID>...]` to enable Phase II trace temporarily
+and print the local watchlist. Any live Phase II talkgroup can satisfy the gate,
+but its grant, traffic-channel retune, burst synchronization, control return,
+and control relock must all match the same TGID. The result records whether the
+observed TGID was on the supplied watchlist. The runner restores the previous
+trace state afterward. This validates transport only; it does not require IMBE
+or PCM. Add `-UseExistingSession` when the requested control channel is already
+locked and restarting it would invoke the normal saved-profile fallback survey;
+the runner still verifies that the live frequency and decoded control state
+match `-ControlFrequencyHz` before collecting evidence.
 
 ```powershell
 apps/orcsdr-tab5/tools/run-p25-validation.ps1 `

--- a/docs/P25_PHASE2_WORKPHASE.md
+++ b/docs/P25_PHASE2_WORKPHASE.md
@@ -1,0 +1,81 @@
+# P25 Phase II work phase
+
+This work adds clear-voice P25 Phase II in small, independently testable pull
+requests while preserving the working Phase I receiver. Public status remains
+**P25 WIP** until live Phase II audio passes.
+
+## Current pull request: grant transport
+
+Branch: `codex/p25-phase2-transport`
+
+This pull request corrects TDMA carrier/slot mapping, preserves the decoded
+grant and system identity, and adds a fixed-memory 6,000-symbol/s traffic
+burst detector. Normal operation reports a Phase II grant and remains on the
+control channel. Authenticated trace mode performs a three-second transport
+probe, reports burst synchronization or rejection, and returns to control. It
+does not decode Phase II MAC or audio.
+
+The shared 960 kS/s to 48 kS/s channelizer was already inside
+`p25_decoder_core`; no structural move was needed. Phase I C4FM/CQPSK and IMBE
+paths remain unchanged.
+
+## Evidence ledger
+
+| Gate | Result |
+| --- | --- |
+| Pre-change optimized and sanitizer host tests | Passed 2026-09-06 |
+| TDMA carrier/slot and 6,000-symbol/s sync host tests | Passed 2026-09-06 |
+| Native ESP-IDF 5.5.4 build | Passed 2026-09-06; 2,263,696-byte app image, 46% app partition free; no C6 image embedded |
+| Exact image flashed to COM17 | Passed 2026-09-06; SHA-256 `FEB7C8B6626F6A4EFE92716D88EEB626F60782AA45271255D02497F7B275B32B`; flash verification and normal boot passed |
+| Boot memory regression | Caught before acceptance: the first candidate exhausted the internal DMA reserve. Moving the existing 2,376-byte P25 waterfall scratch row to configured PSRAM restored the reserve; the final exact image boots normally. |
+| Dashboard and driver regression | Passed 2026-09-06; full UI workflow and driver 0.7.9 checks passed with zero USB, IQ, and audio drops |
+| OSRP control-channel identity | Passed 2026-09-06 at observed Quarry Hill control `770.66875 MHz`: WACN `9254A`, SYSID `00A`, RFSS/site `6/6`; the frequency is observed evidence, not a permanent hard-coded assignment |
+| Real OSRP TDMA grant and correct carrier/slot | Passed 2026-09-06: TGID `38130`, channel ID `8`, observed carriers including `773.28125 MHz`, slot `0`, zero mapping errors |
+| Traffic-channel burst sync and control return | Passed 2026-09-06: live 38130 burst synchronized after 614 symbols with zero sync-word bit errors; control return and relock passed |
+| Continued Phase I technical path | Passed 2026-09-06 on Lane County: 20 grant events, 528 IMBE frames, 506,880 PCM samples, repeated control returns/relocks, stable heap, adequate stack headroom, encrypted-call mute/return, and zero USB/IQ/audio drops |
+| Exact-image Phase I audio and visual acceptance | Passed 2026-09-06: user confirmed clear audio on TGIDs `20203` and `20391` (`LCF Firecom 1`); supplied photos show the P25 Monitor rendering normally while following both calls |
+
+The 90-second OSRP acceptance run used the local watchlist `38130`, `40253`,
+`38131`, `40251`, `40252`, `40254`, `40255`, and `20165`, while allowing any
+live Phase II talkgroup to satisfy the transport gate. The selected grant,
+acquisition, synchronization, return, and relock were required to use the same
+TGID. The result was `PASS` with a 22,930,276-byte heap floor and no USB, IQ,
+audio, or voice-queue drops. Local frequencies, aliases, and raw traffic IQ
+remain untracked.
+
+## Standards, source, and legal record
+
+The official TIA TR-8 documents named in the approved implementation plan are
+the normative source. Their PDFs were not present locally on 2026-09-06, so
+this repository records their identifiers and links without claiming revision
+hashes or redistributing copyrighted files. Exact revisions and SHA-256 hashes
+will be added after the project owner obtains the PDFs through TIA's terms.
+
+OP25 commit `71abcd0ead32f86f51615ea6cc8a6a4dba4c949a` was consulted for TDMA
+channel-to-carrier behavior and the 40-bit synchronization constant. The
+reviewed files are GPL-3.0-or-later. DSD-FME commit
+`cd5f0f4a8e285aafd7d39194cb7c3e423375a0f8` was consulted to cross-check the
+6,000-symbol/s framing model; its `COPYRIGHT` describes ISC terms for most code
+and GPL-2.0 for named inherited files. OrcSDR incorporates no source code from
+either project in this work; the small receiver implementation and tests were
+written independently.
+
+The project owner confirmed on 2026-09-06 that the separate legal gate for
+Phase II audio distribution is approved. This engineering record does not
+identify the reviewer or reproduce legal advice, so it does not claim an
+independent legal opinion. Encryption remains detection-and-mute only; this
+work adds no keys, key storage, affiliation, transmission, or decryption.
+
+## Later pull requests
+
+1. A hardware-independent Phase II protocol core: slot/superframe tracking,
+   ISCH, scrambling, FEC, MAC, ESS, and bounded 72-bit vocoder frames.
+2. Clear AMBE+2 synthesis through the existing bounded PCM callback.
+3. Update every P25 dashboard view for Phase II. The monitor, spectrum/RF
+   health, talkgroup, and status views must show Phase I or Phase II, TDMA slot,
+   carrier, talkgroup/source identity, clear/encrypted state, decode quality,
+   audio state, and the reason a call was not followed. Hold, skip, follow, and
+   return-to-control behavior must work consistently for both phases. Remove the
+   temporary `Phase II call detected` transport message only after live Phase II
+   audio and dashboard acceptance pass.
+4. Location-neutral P25 system discovery and confirmed profile saving.

--- a/docs/P25_PHASE2_WORKPHASE.md
+++ b/docs/P25_PHASE2_WORKPHASE.md
@@ -33,7 +33,7 @@ paths remain unchanged.
 | Real OSRP TDMA grant and correct carrier/slot | Passed 2026-09-06: TGID `38130`, channel ID `8`, observed carriers including `773.28125 MHz`, slot `0`, zero mapping errors |
 | Traffic-channel burst sync and control return | Passed 2026-09-06: live 38130 burst synchronized after 614 symbols with zero sync-word bit errors; control return and relock passed |
 | Continued Phase I technical path | Passed 2026-09-06 on Lane County: 20 grant events, 528 IMBE frames, 506,880 PCM samples, repeated control returns/relocks, stable heap, adequate stack headroom, encrypted-call mute/return, and zero USB/IQ/audio drops |
-| Exact-image Phase I audio and visual acceptance | Passed 2026-09-06: user confirmed clear audio on TGIDs `20203` and `20391` (`LCF Firecom 1`); supplied photos show the P25 Monitor rendering normally while following both calls |
+| Exact-image Phase I audio and visual acceptance | Passed 2026-09-06: user confirmed clear audio on TGIDs `20203`, `20391` (`LCF Firecom 1`), and `38130`; supplied photos show the P25 Monitor rendering normally while following the calls |
 
 The 90-second OSRP acceptance run used the local watchlist `38130`, `40253`,
 `38131`, `40251`, `40252`, `40254`, `40255`, and `20165`, while allowing any
@@ -42,6 +42,12 @@ acquisition, synchronization, return, and relock were required to use the same
 TGID. The result was `PASS` with a 22,930,276-byte heap floor and no USB, IQ,
 audio, or voice-queue drops. Local frequencies, aliases, and raw traffic IQ
 remain untracked.
+
+The Lane County receiver also presented numeric TGID `38130` as clear Phase I
+voice at `453.2375 MHz`, while OSRP presented numeric TGID `38130` in a live
+Phase II grant. This confirms that a talkgroup number must always be associated
+with its decoded system identity and call mode; the number alone is not a
+globally unique identity.
 
 ## Standards, source, and legal record
 

--- a/docs/P25_PHASE2_WORKPHASE.md
+++ b/docs/P25_PHASE2_WORKPHASE.md
@@ -25,8 +25,8 @@ paths remain unchanged.
 | --- | --- |
 | Pre-change optimized and sanitizer host tests | Passed 2026-09-06 |
 | TDMA carrier/slot and 6,000-symbol/s sync host tests | Passed 2026-09-06 |
-| Native ESP-IDF 5.5.4 build | Passed 2026-09-06; 2,263,696-byte app image, 46% app partition free; no C6 image embedded |
-| Exact image flashed to COM17 | Passed 2026-09-06; SHA-256 `FEB7C8B6626F6A4EFE92716D88EEB626F60782AA45271255D02497F7B275B32B`; flash verification and normal boot passed |
+| Native ESP-IDF 5.5.4 build | Passed 2026-09-06; final reviewed app image is 2,263,840 bytes with 46% app partition free; no C6 image embedded |
+| Exact image flashed to COM17 | Passed 2026-09-06; final reviewed image SHA-256 `B491F9B3E5B7DA482DA25B36066AF0F31E2B5D214AE2E12133DE5F9DE669ECF0`; flash verification, normal boot, dashboard regression, and live control-channel status passed |
 | Boot memory regression | Caught before acceptance: the first candidate exhausted the internal DMA reserve. Moving the existing 2,376-byte P25 waterfall scratch row to configured PSRAM restored the reserve; the final exact image boots normally. |
 | Dashboard and driver regression | Passed 2026-09-06; full UI workflow and driver 0.7.9 checks passed with zero USB, IQ, and audio drops |
 | OSRP control-channel identity | Passed 2026-09-06 at observed Quarry Hill control `770.66875 MHz`: WACN `9254A`, SYSID `00A`, RFSS/site `6/6`; the frequency is observed evidence, not a permanent hard-coded assignment |
@@ -34,6 +34,11 @@ paths remain unchanged.
 | Traffic-channel burst sync and control return | Passed 2026-09-06: live 38130 burst synchronized after 614 symbols with zero sync-word bit errors; control return and relock passed |
 | Continued Phase I technical path | Passed 2026-09-06 on Lane County: 20 grant events, 528 IMBE frames, 506,880 PCM samples, repeated control returns/relocks, stable heap, adequate stack headroom, encrypted-call mute/return, and zero USB/IQ/audio drops |
 | Exact-image Phase I audio and visual acceptance | Passed 2026-09-06: user confirmed clear audio on TGIDs `20203`, `20391` (`LCF Firecom 1`), and `38130`; supplied photos show the P25 Monitor rendering normally while following the calls |
+
+The final review correction makes `RTL_P25_STATUS` report
+`follow=phase2_probe` during a diagnostic traffic-channel probe and retains the
+associated grant in the dashboard snapshot. This prevents automation and UI
+status from mistaking an active probe for a completed control-channel return.
 
 The 90-second OSRP acceptance run used the local watchlist `38130`, `40253`,
 `38131`, `40251`, `40252`, `40254`, `40255`, and `20165`, while allowing any

--- a/docs/P25_RESEARCH_AND_PROVENANCE.md
+++ b/docs/P25_RESEARCH_AND_PROVENANCE.md
@@ -1,8 +1,8 @@
 # P25 research and provenance
 
 This record distinguishes research from copied implementation. No source code
-from the projects below was copied into the P25 profile work. The OrcSDR code
-uses its existing parser, SD abstraction, signed catalog, and UI patterns.
+from the projects below was copied into the P25 profile or Phase II transport
+work. OrcSDR implements the relevant behavior independently.
 
 | Source | License or terms | What we learned | OrcSDR derivation |
 | --- | --- | --- | --- |
@@ -12,7 +12,12 @@ uses its existing parser, SD abstraction, signed catalog, and UI patterns.
 | [sdrtrunk Playlist Editor](https://github.com/DSheirer/sdrtrunk/wiki/Playlist-Editor) | GPL-3.0 | Mature receivers keep channel configurations and alias lists associated with a system. | OrcSDR stores each system separately and keeps its small aliases inside that profile for now. |
 | [Trunk Recorder](https://github.com/TrunkRecorder/trunk-recorder) | GPL-3.0 | A trunked receiver continuously follows control-channel grants; call handling is separate from system configuration. | This supports the existing OrcSDR separation between the profile store and receiver/voice state. No code was used. |
 | [boatbod OP25](https://github.com/boatbod/op25) | GPL-3.0-or-later in reviewed source headers | Its public feature list treats multi-system selection, talkgroup tags, priority, hold/skip, replay, and encryption detection as separate receiver capabilities. | These are comparison points for OrcSDR's staged roadmap, not an implementation source. |
+| [OP25 `trunking.py` and Phase II framer at `71abcd0`](https://github.com/boatbod/op25/tree/71abcd0ead32f86f51615ea6cc8a6a4dba4c949a) | GPL-3.0-or-later in each reviewed file header | A TDMA logical channel selects a physical carrier by dividing by slots per carrier, while its low bit selects one of two slots. The Phase II synchronization word is 40 bits. | Behavior was cross-checked; no GPL source was incorporated. OrcSDR's mapping and fixed-memory detector were independently written and host-tested. |
+| [DSD-FME Phase II files at `cd5f0f4`](https://github.com/lwvmobile/dsd-fme/tree/cd5f0f4a8e285aafd7d39194cb7c3e423375a0f8) | Repository `COPYRIGHT`: ISC for most code, GPL-2.0 for specifically named inherited files; individual provenance varies | Phase II traffic uses a 6,000-symbol/s TDMA framing path and 40-bit ISCH/synchronization fields. | Cross-check only; no DSD-FME source or tables were incorporated. |
 
 Reviewed 2026-09-06. Every future published P25 pack must add its own source,
 license or terms decision, retrieval date, transformation steps, hash, and
 maintainer contact to the data-source ledger.
+
+The active Phase II scope and its test/hardware evidence are maintained in
+[P25_PHASE2_WORKPHASE.md](P25_PHASE2_WORKPHASE.md).

--- a/phasing.md
+++ b/phasing.md
@@ -17,6 +17,9 @@ flashable at every step — no phase should require a multi-day broken build.
   change in this repo (`PROJECT_STATUS.md`'s evidence-label discipline
   applies to refactors too — "Build-verified" is not "Hardware-verified").
 
+The current standards-based Phase II receiver work and its evidence ledger are
+tracked in [`docs/P25_PHASE2_WORKPHASE.md`](docs/P25_PHASE2_WORKPHASE.md).
+
 ## Phase 1 — split `main.cpp` into modules
 
 Goal: continue separating DSP/session/host responsibilities from `main.cpp`

--- a/tests/p25_core_tests.cpp
+++ b/tests/p25_core_tests.cpp
@@ -2,6 +2,7 @@
 #include <array>
 #include <atomic>
 #include <cstdint>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -48,6 +49,45 @@ void test_protocol_self_check_and_bad_input() {
   CHECK(state.nid_good == 0);
   CHECK(state.tsbk_good == 0);
   CHECK(state.voice_frames == 0);
+}
+
+void test_phase2_channel_mapping() {
+  using orcsdr::p25core::map_channel;
+  const auto slot0 = map_channel(769000000, 12500, 2, 40);
+  const auto slot1 = map_channel(769000000, 12500, 2, 41);
+  CHECK(slot0.valid && slot1.valid);
+  CHECK(slot0.frequency_hz == 769250000);
+  CHECK(slot1.frequency_hz == slot0.frequency_hz);
+  CHECK(slot0.slot == 0 && slot1.slot == 1);
+
+  const auto fdma = map_channel(450000000, 12500, 1, 7);
+  CHECK(fdma.valid && fdma.frequency_hz == 450087500 && fdma.slot == 0);
+  CHECK(!map_channel(450000000, 0, 2, 1).valid);
+  CHECK(!map_channel(UINT32_MAX, 12500, 2, 2).valid);
+}
+
+void test_phase2_burst_sync() {
+  using namespace orcsdr::p25core;
+  constexpr uint64_t sync = 0x575D57F7FFULL;
+  constexpr float pi = 3.14159265358979323846f;
+  set_phase2_acquisition(true, 1);
+  float phase = 0.0f;
+  for (size_t sample = 0; sample < 8; ++sample)
+    process_channel_iq(std::cos(phase), std::sin(phase), 1);
+  for (int shift = 38, symbol = 0; shift >= 0; shift -= 2, ++symbol) {
+    const uint8_t dibit = static_cast<uint8_t>((sync >> shift) & 3u);
+    constexpr float delta[4] = {pi / 4.0f, 3.0f * pi / 4.0f,
+                                -pi / 4.0f, -3.0f * pi / 4.0f};
+    phase += delta[dibit];
+    for (size_t sample = 0; sample < 8; ++sample)
+      process_channel_iq(std::cos(phase), std::sin(phase), 2 + symbol);
+  }
+  const Snapshot state = snapshot();
+  CHECK(state.phase2_acquisition);
+  CHECK(state.phase2_symbols >= 20);
+  CHECK(state.phase2_sync_words >= 1);
+  CHECK(state.phase2_best_sync_errors <= 4);
+  set_phase2_acquisition(false, 30);
 }
 
 void test_voice_decode_bounds_and_reset() {
@@ -252,6 +292,8 @@ void operator delete[](void* memory, std::size_t) noexcept { std::free(memory); 
 int main(int argc, char** argv) {
   CHECK(argc == 2);
   test_protocol_self_check_and_bad_input();
+  test_phase2_channel_mapping();
+  test_phase2_burst_sync();
   test_voice_decode_bounds_and_reset();
   test_encryption_sync_decode();
   test_control_fixture(argv[1]);


### PR DESCRIPTION
## What this changes  OrcSDR could decode P25 Phase II channel identifiers, but it treated the logical TDMA channel number as a carrier number. On a two-slot system that points at the wrong traffic frequency and loses the slot. This PR corrects that mapping, keeps the over-the-air system and grant identity with the call, and adds a bounded diagnostic probe that can prove a real Phase II traffic burst before the later MAC and audio work begins.  Normal use does not retune for Phase II yet. The diagnostic trace is authenticated, off by default, limited to three seconds per clear TDMA grant, and always returns to the control channel. Encrypted calls remain identification-and-mute only.  ## Behavior  - Maps Phase II logical channel numbers to the shared carrier and slot using the decoded slots-per-carrier band plan. - Retains service options, channel ID/number, slot, WACN, system ID, RFSS, and site with decoded grants. - Adds a fixed-memory 48 kS/s to 6,000-symbol/s Phase II burst synchronizer with normal and reversed polarity detection. - Adds `RTL_P25_PHASE2_STATUS` and authenticated `RTL_P25_PHASE2_TRACE ON|OFF` commands. - Reports grant, acquisition, successful synchronization, rejection, and control-return events without claiming MAC or voice decode. - Extends the hardware validator to monitor a talkgroup watchlist while accepting any real Phase II talkgroup. The grant, acquisition, sync, return, and relock must all belong to the same observed TGID. - Removes the stale hard-coded Lane County identity from the monitor and displays over-the-air identity state. - Moves the existing 2,376-byte P25 waterfall scratch row to configured PSRAM. The first candidate exhausted the internal DMA reserve at boot; this fixes that regression at its source rather than weakening the reserve check. - Records the standards, research provenance, exact external reference commits/licenses, independent implementation boundary, legal approval record, evidence, and remaining work.  ## Validation actually completed  - P25 host tests passed in optimized mode and under ASan, LSan, and UBSan. - PowerShell validation runner parsed successfully under PowerShell 7. - Native ESP-IDF 5.5.4 build passed without an embedded C6 image. - Final application image: 2,263,696 bytes; SHA-256 `B491F9B3E5B7DA482DA25B36066AF0F31E2B5D214AE2E12133DE5F9DE669ECF0`. - That exact image flashed to COM17 with bootloader, partition table, and application hash verification. - Full Tab5 dashboard regression passed. - RTL-SDR driver 0.7.9 regression passed with IQ continuity and no USB overruns or drops. - Lane County Phase I acceptance produced 20 grant events, 528 IMBE frames, 506,880 PCM samples, repeated control returns and relocks, stable memory, and zero USB, IQ, audio, or voice-queue drops. - The user confirmed clear audio on TGIDs 20203, 20391 / LCF Firecom 1, and 38130; supplied photos show the P25 Monitor rendering normally. The Lane County system presented 38130 as Phase I while OSRP presented the same numeric TGID in Phase II, confirming that talkgroups must be scoped by system identity and call mode. - OrcSDR found the current Quarry Hill OSRP control at 770.66875 MHz and decoded WACN `9254A`, SYSID `00A`, RFSS/site `6/6` over the air. - A strict 90-second OSRP run decoded live Phase II TGID 38130, channel ID 8, carrier 773.28125 MHz, slot 0, and synchronized after 614 symbols with zero sync-word bit errors. Control return and relock passed. Heap floor was 22,930,276 bytes and no drop counter grew. - Failed short traffic probes were retained as explicit no-sync rejections and were not counted as passes.  ## Research and credit  The TIA TR-8 Phase II documents listed in `docs/P25_RESEARCH_AND_PROVENANCE.md` are treated as the normative source. Their PDFs were not locally available, so this PR records official identifiers and links without redistributing or inventing revision hashes.  OP25 commit `71abcd0ead32f86f51615ea6cc8a6a4dba4c949a` was consulted for channel-to-carrier behavior and the 40-bit synchronization constant; the reviewed files are GPL-3.0-or-later. DSD-FME commit `cd5f0f4a8e285aafd7d39194cb7c3e423375a0f8` was used to cross-check the 6,000-symbol/s framing model; its repository documents ISC terms for most code and GPL-2.0 for named inherited files. No source code from either project was copied into OrcSDR.  ## Remaining limitations  This PR proves grant transport and burst synchronization only. It does not decode Phase II ISCH, superframe position, scrambling, FEC, MAC, ESS, 72-bit vocoder frames, or audio. The P25 dashboards still require a later full Phase II update covering phase/slot/carrier, talkgroup/source identity, encryption and audio state, quality, failure reasons, and consistent hold/skip/follow behavior. Public status remains P25 WIP until live Phase II audio and dashboard acceptance pass.    <!-- This is an auto-generated comment: release notes by coderabbit.ai -->  ## Summary by CodeRabbit  - **New Features**   - Added P25 Phase II TDMA support, including channel/slot mapping, acquisition, synchronization detection, and diagnostic counters.   - Dashboard and status views now show Phase II grants, probing activity, synchronization, and mapping details.   - Added serial commands for Phase II status and trace control.   - Validation now supports talkgroup watchlists and reuse of an existing locked session.  - **Bug Fixes**   - Improved control-frequency validation tolerance and restoration of diagnostic trace settings.  - **Documentation**   - Updated serial CLI, Phase II workflow, research, and implementation documentation.  <!-- end of auto-generated comment: release notes by coderabbit.ai --> 
### Final local review correction

The two scheduled CodeRabbit checks showed the review still in progress, so work continued with a local correctness review as agreed. That review found and fixed one status-reporting issue: an active Phase II traffic probe had been reported as `follow=control`, which could let automation mistake acquisition for a completed return. The final code now reports `follow=phase2_probe` and retains the active grant in the dashboard snapshot.

After that correction, the optimized and sanitizer P25 tests passed, the native ESP-IDF 5.5.4 build passed, the exact final image was flashed and verified on COM17, the automated dashboard regression passed, and live Lane County control lock remained healthy with valid identity, 494 good TSBKs, stable memory, and zero USB/IQ/audio drops. The final image is 2,263,840 bytes with SHA-256 `B491F9B3E5B7DA482DA25B36066AF0F31E2B5D214AE2E12133DE5F9DE669ECF0`.