### PR TITLE
Support Japan's 76–95 MHz FM broadcast band

### DIFF
--- a/apps/orcsdr-tab5/ui/fm_config.cpp
+++ b/apps/orcsdr-tab5/ui/fm_config.cpp
@@ -7,9 +7,6 @@
 
 namespace orcsdr::fmconfig {
 namespace {
-constexpr uint32_t kFmMinHz = 87500000;
-constexpr uint32_t kFmMaxHz = 108000000;
-
 void set_error(char* error, size_t size, const char* value) {
   if (error != nullptr && size) snprintf(error, size, "%s", value);
 }
@@ -70,12 +67,12 @@ bool parse_text(const char* text, Config* config, char* error, size_t error_size
 }  // namespace
 
 bool validate(const Config& config, char* error, size_t error_size) {
-  if (config.version != kSchemaVersion || config.startup_frequency_hz < kFmMinHz ||
-      config.startup_frequency_hz > kFmMaxHz || config.preset_count > kMaxPresets) {
+  if (config.version != kSchemaVersion || config.startup_frequency_hz < kMinFrequencyHz ||
+      config.startup_frequency_hz > kMaxFrequencyHz || config.preset_count > kMaxPresets) {
     set_error(error, error_size, "invalid FM profile"); return false;
   }
   for (size_t i = 0; i < config.preset_count; ++i) {
-    if (config.presets_hz[i] < kFmMinHz || config.presets_hz[i] > kFmMaxHz) {
+    if (config.presets_hz[i] < kMinFrequencyHz || config.presets_hz[i] > kMaxFrequencyHz) {
       set_error(error, error_size, "preset range"); return false;
     }
     for (size_t j = i + 1; j < config.preset_count; ++j)
@@ -119,6 +116,17 @@ bool self_check() {
   constexpr char kGood[] = "version=1\nstartup_frequency_hz=96100000\npreset_hz=96100000\n";
   Config config{}; char error[32]{};
   if (!parse_text(kGood, &config, error, sizeof(error))) return false;
+  config.startup_frequency_hz = kMinFrequencyHz;
+  config.presets_hz[0] = kMinFrequencyHz;
+  if (!validate(config, error, sizeof(error))) return false;
+  config.startup_frequency_hz = kMinFrequencyHz - 1;
+  if (validate(config, error, sizeof(error))) return false;
+  config.startup_frequency_hz = kMaxFrequencyHz;
+  config.presets_hz[0] = kMaxFrequencyHz;
+  if (!validate(config, error, sizeof(error))) return false;
+  config.startup_frequency_hz = kMaxFrequencyHz + 1;
+  if (validate(config, error, sizeof(error))) return false;
+  config.startup_frequency_hz = kMinFrequencyHz;
   config.presets_hz[1] = config.presets_hz[0]; config.preset_count = 2;
   return !validate(config, error, sizeof(error));
 }

--- a/apps/orcsdr-tab5/ui/fm_config.hpp
+++ b/apps/orcsdr-tab5/ui/fm_config.hpp
@@ -10,6 +10,8 @@ namespace orcsdr::fmconfig {
 constexpr uint32_t kSchemaVersion = 1;
 constexpr size_t kMaxPresets = 10;
 constexpr char kPath[] = "/orcsdr/FM.cfg";
+constexpr uint32_t kMinFrequencyHz = 76000000;
+constexpr uint32_t kMaxFrequencyHz = 108000000;
 
 struct Config {
   uint32_t version = kSchemaVersion;

--- a/apps/orcsdr-tab5/ui/fm_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/fm_dashboard.cpp
@@ -1,6 +1,7 @@
 #include "fm_dashboard.hpp"
 
 #include "dashboard_audio_control.hpp"
+#include "fm_config.hpp"
 #include "orc_badge.hpp"
 
 #include <M5Unified.h>
@@ -24,8 +25,8 @@ constexpr uint16_t kGrid = 0x2945;
 constexpr int kHeaderH = 132;
 constexpr int kTabsY = 630;
 constexpr int kTabW = 256;
-constexpr uint32_t kFmMinHz = 88000000;
-constexpr uint32_t kFmMaxHz = 108000000;
+constexpr uint32_t kFmMinHz = fmconfig::kMinFrequencyHz;
+constexpr uint32_t kFmMaxHz = fmconfig::kMaxFrequencyHz;
 constexpr int kSpectrumX = 46;
 constexpr int kSpectrumY = 246;
 constexpr int kSpectrumW = 1188;
@@ -426,7 +427,7 @@ void draw_keypad() {
   char field[24];
   snprintf(field, sizeof(field), "%s%s", g_entry, g_entry[0] ? " MHz" : "");
   M5.Display.fillRoundRect(380, 205, 520, 55, 8, TFT_NAVY);
-  text(field[0] ? field : "88.0 – 108.0", 640, 233, TFT_WHITE, 3);
+  text(field[0] ? field : "76.0 – 108.0", 640, 233, TFT_WHITE, 3);
   static constexpr char keys[] = {'1','2','3','4','5','6','7','8','9','.','0','<'};
   for (int i = 0; i < 12; ++i) {
     char key[2] = {keys[i], 0};
@@ -581,7 +582,8 @@ Action handle_touch(int32_t x, int32_t y) {
     if (hit(x, y, 650, 525, 250, 55)) {
       char* end = nullptr;
       const double mhz = strtod(g_entry, &end);
-      if (end != g_entry && *end == '\0' && mhz >= 88.0 && mhz <= 108.0) {
+      if (end != g_entry && *end == '\0' &&
+          mhz >= kFmMinHz / 1000000.0 && mhz <= kFmMaxHz / 1000000.0) {
         g_keypad = false;
         const uint32_t hz = static_cast<uint32_t>(llround(mhz * 1000000.0));
         g_entry[0] = '\0';

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -557,8 +557,8 @@ constexpr uint8_t kRtlSpeakerHardwareMax = 200;
 constexpr uint8_t kRtlVolumeDefault = 128;
 constexpr uint8_t kRtlVolumeStep = 16;
 static_assert(kRtlSpeakerHardwareMax <= kRtlVolumeMax);
-constexpr uint32_t kRtlFmMinHz = 87500000;
-constexpr uint32_t kRtlFmMaxHz = 108000000;
+constexpr uint32_t kRtlFmMinHz = orcsdr::fmconfig::kMinFrequencyHz;
+constexpr uint32_t kRtlFmMaxHz = orcsdr::fmconfig::kMaxFrequencyHz;
 /* FREQ +/- coarse step. Header still shows 0.001 MHz; LO apply is 5 kHz. */
 constexpr uint32_t kRtlFmStepHz = 100000;
 constexpr uint32_t kRtlFmAutoStepHz = 800000;
@@ -639,7 +639,7 @@ constexpr RfBandGuide kRfBandGuide[] = {
     {26965000, 27405000, kCbDefaultHz, RtlBand::cb, "CB RADIO", "HF / 40-channel citizens band", true},
     {28000000, 29700000, 28400000, RtlBand::browse, "HAM RADIO", "HF / 10 m amateur", true},
     {50000000, 54000000, 52525000, RtlBand::browse, "HAM RADIO", "VHF / 6 m amateur", true},
-    {88000000, 108000000, kRtlFmDefaultHz, RtlBand::fm, "FM BROADCAST", "VHF / music and talk", true},
+    {kRtlFmMinHz, kRtlFmMaxHz, kRtlFmDefaultHz, RtlBand::fm, "FM BROADCAST", "VHF / music and talk", true},
     {108000000, 118000000, 113000000, RtlBand::browse, "AIR NAV", "VHF / aircraft navigation", false},
     {118000000, 137000000, 121500000, RtlBand::browse, "AIRBAND", "VHF / aircraft voice/emergency", true},
     {137000000, 138000000, 137500000, RtlBand::browse, "NOAA SATELLITE", "VHF / weather downlinks", true},

--- a/docs/API_SERIAL_CLI.md
+++ b/docs/API_SERIAL_CLI.md
@@ -190,7 +190,7 @@ actually broadcasts RDS.
 
 | Command | Auth | Reply |
 |---|---|---|
-| `RTL_PRESET_SCAN` | yes | `RTL_PRESET_SCAN_QUEUED` or `RTL_PRESET_SCAN_INVALID` (not on FM) | Sweeps 87.5–108 MHz, ~800 kHz steps, collects up to 10 stations by signal strength. Takes tens of seconds; poll `RTL_PRESET_LIST` afterward. |
+| `RTL_PRESET_SCAN` | yes | `RTL_PRESET_SCAN_QUEUED` or `RTL_PRESET_SCAN_INVALID` (not on FM) | Sweeps 76–108 MHz, ~800 kHz steps, collects up to 10 stations by signal strength. Takes tens of seconds; poll `RTL_PRESET_LIST` afterward. |
 | `RTL_PRESET_LIST` | no | `RTL_PRESET_LIST_BEGIN count=N` then N × `RTL_PRESET <n> frequency_hz=... level=...` then `RTL_PRESET_LIST_END` | Persists across reboots (NVS). |
 | `RTL_PRESET_TUNE <n>` | yes | `RTL_PRESET_TUNE_OK index=... frequency_hz=...` or `RTL_PRESET_TUNE_INVALID` | 1-based index, matching the on-screen list numbering. |
 

--- a/docs/API_SERIAL_CLI.md
+++ b/docs/API_SERIAL_CLI.md
@@ -190,7 +190,7 @@ actually broadcasts RDS.
 
 | Command | Auth | Reply |
 |---|---|---|
-| `RTL_PRESET_SCAN` | yes | `RTL_PRESET_SCAN_QUEUED` or `RTL_PRESET_SCAN_INVALID` (not on FM) | Sweeps 76–108 MHz, ~800 kHz steps, collects up to 10 stations by signal strength. Takes tens of seconds; poll `RTL_PRESET_LIST` afterward. |
+| `RTL_PRESET_SCAN` | yes | `RTL_PRESET_SCAN_QUEUED` or `RTL_PRESET_SCAN_INVALID` (not on FM). Sweeps 76–108 MHz in ~800 kHz steps and collects up to 10 stations by signal strength. Takes tens of seconds; poll `RTL_PRESET_LIST` afterward. |
 | `RTL_PRESET_LIST` | no | `RTL_PRESET_LIST_BEGIN count=N` then N × `RTL_PRESET <n> frequency_hz=... level=...` then `RTL_PRESET_LIST_END` | Persists across reboots (NVS). |
 | `RTL_PRESET_TUNE <n>` | yes | `RTL_PRESET_TUNE_OK index=... frequency_hz=...` or `RTL_PRESET_TUNE_INVALID` | 1-based index, matching the on-screen list numbering. |
 

--- a/docs/RADIO_CONFIGURATION.md
+++ b/docs/RADIO_CONFIGURATION.md
@@ -62,5 +62,5 @@ preset_hz=101700000
 
 FM presets can be entered here or found with **FM → Settings → Scan Presets**.
 The scan result is saved back to `FM.cfg`. Frequencies must be within the
-87.5-108 MHz broadcast band. The previous saved file is retained as
-`FM.cfg.bak`.
+76-108 MHz broadcast band, including Japan's 76-95 MHz allocation. The
+previous saved file is retained as `FM.cfg.bak`.


### PR DESCRIPTION
Issue #56 identified that OrcSDR rejected Japan's 76–95 MHz FM broadcast band because different parts of the firmware enforced either an 87.5 MHz or 88 MHz lower limit. This change gives the FM receiver one shared 76–108 MHz range, so Japanese stations can be entered, saved, selected from the spectrum, and found by the existing preset scan while existing regional coverage remains available.

What changed:
- defines 76 MHz and 108 MHz once in the FM configuration interface;
- applies those limits to saved configuration, presets, keypad entry, tuning clamps, and the home-screen FM band guide;
- updates the keypad hint and documentation;
- extends the existing configuration self-check to accept both exact boundaries and reject values immediately outside them.

Validation completed before commit:
- `tools/test-radio-scan.ps1`: passed optimized tests;
- `tools/test-radio-scan.ps1`: passed ASan, LSan, and UBSan tests;
- native ESP-IDF 5.5.4 Tab5 build: passed;
- exact application image SHA-256: `CE8887CB510F63B0EE00FFFFB2F3766DC62331E2D68E66D55DBBAB68585FA2F1`;
- exact image flashed successfully to the Tab5 on COM17 with flash verification.

The local hardware gate proves that the updated firmware builds, flashes, and accepts the expanded tuning range. Actual reception of Japanese stations must still be confirmed by a tester located within Japan's broadcast coverage.

Closes #56


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded FM tuning and preset support to cover the 76–108 MHz broadcast band, including Japan’s 76–95 MHz allocation.
  * Updated tuning controls, spectrum interactions, and band guidance to use the expanded range.

* **Bug Fixes**
  * Improved validation for FM frequencies at and beyond the supported band limits.

* **Documentation**
  * Updated FM configuration and CLI documentation to reflect the 76–108 MHz range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->