### PR TITLE
Prepare OrcSDR v0.2.0-beta.3 release notes

### DIFF
--- a/docs/releases/v0.2.0-beta.3.md
+++ b/docs/releases/v0.2.0-beta.3.md
@@ -1,0 +1,94 @@
+# OrcSDR v0.2.0-beta.3
+
+This beta substantially improves OrcSDR's ADS-B and P25 receivers and adds FM tuning support for Japan. P25 now has a hardware-independent, host-tested decoder boundary, dependable Phase I clear-voice operation, encrypted-call detection and muting, CQPSK acquisition work, portable system profiles, and the first live-validated Phase II transport and burst decoder stages. ADS-B now displays only real received aircraft data and restores shared display and radio state correctly when the user changes dashboards.
+
+This remains beta firmware. The evidence below records what was actually built, flashed, decoded, heard, or cross-checked. P25 Phase II audio is not implemented in this release.
+
+## FM radio in Japan
+
+GitHub issue #56 reported that OrcSDR could not tune most Japanese FM stations because the firmware used lower limits of 87.5 or 88 MHz in different places. Japan's FM broadcast allocation extends down to 76 MHz.
+
+OrcSDR now uses one shared **76–108 MHz** FM range for manual entry, configuration files, saved presets, preset scanning, spectrum selection, tuning limits, and the Home band guide. The exact 76 and 108 MHz boundaries are covered by the existing FM configuration self-check, together with rejection immediately outside the supported range.
+
+The updated firmware was built with native ESP-IDF 5.5.4 and flashed successfully to the project Tab5. Actual reception of Japanese broadcasts remains a regional acceptance check for a tester in Japan.
+
+## ADS-B improvements
+
+ADS-B is now live-only. The old generated aircraft and demo-capture paths were removed so every aircraft, signal indicator, altitude chart, and target value shown on the dashboard comes from received data. A quiet 1090 MHz band now reports that it is waiting or searching instead of displaying sample traffic.
+
+The ADS-B exit path restores the normal display font, and returning Home restores the saved spectrum and waterfall setting. A radio-start race found during hardware testing was fixed so a stale ADS-B startup cannot retune the receiver back to 1090 MHz after the user has opened FM. SD operations also respect the queued radio-start interval.
+
+Live acceptance included aircraft **N2255H**, ICAO **A1F6A3**, which the operator compared with Flightradar24. The aircraft type, callsign, position, altitude, and speed shown by OrcSDR agreed with the live reference closely enough for operator acceptance.
+
+## P25 Phase I receiver and audio
+
+The hardware-independent P25 C4FM protocol/FEC receiver was moved into `p25_decoder_core`, and IMBE voice processing was moved into `p25_voice`. These fixed-memory modules contain no Tab5 display, USB, speaker, or FreeRTOS dependency. The Tab5 application remains responsible for radio tuning, synchronization around the core, bounded queues, and delivering PCM to the output device.
+
+The receiver can be tested on a host with explicit timestamps and replayed IQ. Authenticated serial commands now cover P25 IQ capture, replay, modulation selection, status, survey, profile operations, and live validation. The committed control-channel fixture contains no intentionally captured voice traffic.
+
+Real Phase I testing repeatedly decoded the Lane County control system, followed voice grants, tuned traffic channels, produced IMBE frames and 48 kHz PCM, returned to the control channel, and relocked. The operator confirmed clear audio on several talkgroups, including **LCF Firecom 1 / TGID 20391**, **TGID 20817**, and **TGID 38130**, through the verified 3.5 mm output path.
+
+Some police talkgroups originally sounded robotic because their control-channel grant form did not announce encryption. OrcSDR now decodes the voice-channel LDU2 Encryption Sync field, withholds audio until the encryption state is known, prevents protected frames from reaching the vocoder, and returns to the control channel when **Skip Encrypted** is enabled. OrcSDR reports the algorithm and key identifiers carried in clear signaling but does not decrypt protected calls.
+
+## CQPSK and simulcast work
+
+The existing C4FM receiver remains available. OrcSDR also includes a dedicated CQPSK acquisition path with matched filtering, timing recovery, carrier recovery, differential dibit decoding, automatic modulation selection, and serial/dashboard diagnostics for modulation, lock quality, timing error, carrier error, and decode rate.
+
+Forced CQPSK replay decodes real recorded P25 identity and traffic, but the same strong fixture still decodes better through C4FM and automatic mode correctly selects C4FM. The live receiver exercised both acquisition paths. Compatibility across a wider range of confirmed LSM simulcast sites remains work in progress, and this release does not claim that every simulcast system is supported.
+
+## Portable P25 system profiles
+
+A clean installation no longer assumes that every user lives in Lane County, Oregon. With no existing configuration, P25 reports **No P25 system configured**. An existing `/orcsdr/P25.cfg` is imported once without overwriting or deleting the original.
+
+OrcSDR can store up to 16 systems under `/orcsdr/p25/<profile-id>/profile.cfg`. The Systems screen and authenticated serial interface can list, select, import, export, rename, reload, and delete profiles with confirmation. Control-channel selection, Survey, Hold, and temporary Skip/Next operate on the active profile. A dashboard touch-routing fix also prevents rapid Survey presses from being mistaken for spectrum tuning.
+
+Signed catalog entries can describe geographically bounded P25 system packs, but no RadioReference-derived database or universal Lane County pack is bundled. Public packs still require recorded source provenance and redistribution permission. Full talkgroup catalogs, priority and avoid rules, call history, and recording remain future work.
+
+## P25 Phase II progress
+
+This release contains the first live-validated Phase II receiver stages:
+
+- correct mapping from a logical TDMA channel number to its shared carrier and slot;
+- retention of talkgroup, service options, channel, slot, WACN, system, RFSS, and site identity;
+- a bounded 6,000-symbol-per-second traffic-channel synchronizer with normal and reversed polarity detection;
+- fixed-size capture of complete 180-dibit bursts;
+- separated DUID decoding with one-bit correction;
+- classification and counters for voice, associated-control, invalid, unsupported, and truncated bursts;
+- authenticated status and temporary trace controls;
+- validation that requires the same talkgroup to produce a grant, acquisition, complete valid burst, control return, and relock.
+
+On the Oregon State Radio Project, OrcSDR decoded WACN **9254A**, system **00A**, RFSS/site **6/6**, and a live Phase II grant for TGID **38130**. It mapped that call to carrier **773.28125 MHz**, slot **0**, synchronized to real traffic, retained complete bursts, and decoded valid DUID **9 FACCH** and DUID **3 SACCH** classifications. The receiver then returned to and relocked the control channel with no recorded drop-counter growth during the passing run.
+
+This is verified Phase II transport and burst-decoder groundwork. OrcSDR does **not** yet descramble the Phase II payload, decode its complete MAC/ESS content, extract AMBE+2 voice frames, synthesize Phase II audio, or claim Phase II audio acceptance.
+
+## Testing and stability evidence
+
+The P25 host suite passed optimized builds and ASan, LSan, and UBSan runs across the receiver, voice boundary, profiles, C4FM, CQPSK, Phase II synchronization, full-burst retention, polarity handling, DUID correction, malformed input, queue bounds, and timer rollover. The release changes were repeatedly built with native ESP-IDF 5.5.4, flashed with hash verification, and exercised through authenticated dashboard and radio-driver regressions.
+
+Recorded live runs included stable Phase I control lock, grant following, clear PCM production, encrypted-call muting, control return, and relock. The Phase II acceptance run observed live OSRP signaling and complete valid bursts. The passing runs reported no panic, watchdog, out-of-memory reset, USB overrun, sustained USB/IQ/audio/voice-queue drop growth, or declining heap trend.
+
+A separate 30-minute Phosphor Persistence run with the Serial/JTAG cable disconnected remains deferred and is not claimed by this release.
+
+## Installation and ESP-Hosted C6
+
+Install this beta on an **M5Stack Tab5** with an **RTL-SDR Blog V4**. For a normal upgrade, do not erase the device; that preserves saved settings and Wi-Fi profiles.
+
+The ESP-Hosted C6 update implementation is unchanged. M5Burner writes the P4 application. If the reachable C6 is not already on Hosted 3.0.6, open **Settings → Firmware & Updates** and explicitly confirm the in-app update. The project owner previously verified the unchanged route by returning a reachable C6 to 2.14.6 and updating it back to 3.0.6 through OrcSDR.
+
+## Known limits
+
+- P25 remains Work in progress while wider-system compatibility and Phase II audio are unfinished.
+- Encrypted P25 calls are identified and muted; they are not decrypted.
+- Wider live CQPSK/LSM compatibility needs more confirmed simulcast-site evidence.
+- Clean installations contain no universal P25 system or talkgroup database.
+- Actual Japanese FM reception still needs confirmation by a tester located in Japan.
+- USB hub support remains deferred.
+- The disconnected 30-minute Phosphor Persistence stability gate remains deferred.
+
+## Source and package record
+
+Final tag, source commit, package hashes, embedded C6 provenance, private M5Burner installation, and exact-package device checks will be recorded here after those gates complete.
+
+Included work: [#50](https://github.com/hardcoreerik/OrcSDR/pull/50), [#51](https://github.com/hardcoreerik/OrcSDR/pull/51), [#52](https://github.com/hardcoreerik/OrcSDR/pull/52), [#53](https://github.com/hardcoreerik/OrcSDR/pull/53), [#54](https://github.com/hardcoreerik/OrcSDR/pull/54), [#55](https://github.com/hardcoreerik/OrcSDR/pull/55), [#57](https://github.com/hardcoreerik/OrcSDR/pull/57), and [#58](https://github.com/hardcoreerik/OrcSDR/pull/58).
+
+[All source changes since beta.2](https://github.com/hardcoreerik/OrcSDR/compare/v0.2.0-beta.2...v0.2.0-beta.3)


### PR DESCRIPTION
The public beta.2 release predates the ADS-B production cleanup, the P25 receiver and Phase II work, portable P25 profiles, and the Japan FM correction. This PR adds the source-controlled release record for the next logical version, **v0.2.0-beta.3**, before an exact tag and package are produced.

The release note explains in plain language:
- ADS-B now uses live receiver data only and restores shared font, graphics, and radio state;
- the P25 Phase I receiver and IMBE/PCM path were separated into hardware-independent, host-tested modules;
- real Phase I clear voice, encrypted-call detection and muting, CQPSK acquisition, and portable system profiles;
- the exact Phase II progress proven on live OSRP traffic: carrier/slot mapping, traffic synchronization, complete burst retention, DUID correction and classification;
- the explicit limit that Phase II audio is not implemented or claimed;
- GitHub issue #56 and the completed 76–108 MHz FM range correction for Japan;
- installation, unchanged ESP-Hosted 3.0.6 update behavior, and remaining acceptance limits.

This PR changes documentation only. It does not create the tag, release binary, GitHub release, or M5Burner listing. Those are subsequent exact-tag gates.

Validation:
- `python tools/help_media.py validate`: passed;
- `python tools/validate-help-docs.py`: passed for 45 screens;
- `git diff --check`: passed.
