### PR TITLE
Prepare OrcSDR v0.2.0-beta.4 release notes

### DIFF
--- a/docs/releases/v0.2.0-beta.4.md
+++ b/docs/releases/v0.2.0-beta.4.md
@@ -1,0 +1,101 @@
+# OrcSDR v0.2.0-beta.4
+
+This beta supersedes the withdrawn beta.3 package. It substantially improves OrcSDR's ADS-B and P25 receivers, adds FM tuning support for Japan, and restores safe Tab5 main-task stack headroom after exact-package hardware testing exposed a reboot-loop risk. P25 now has a hardware-independent, host-tested decoder boundary, dependable Phase I clear-voice operation, encrypted-call detection and muting, CQPSK acquisition work, portable system profiles, and the first live-validated Phase II transport and burst decoder stages. ADS-B now displays only real received aircraft data and restores shared display and radio state correctly when the user changes dashboards.
+
+This remains beta firmware. The evidence below records what was actually built, flashed, decoded, heard, or cross-checked. P25 Phase II audio is not implemented in this release.
+
+## Why beta.3 was withdrawn
+
+The beta.3 M5Burner entry was unpublished after the exact release package failed its three-cycle dashboard smoke test. Opening LoRa after ADS-B triggered an ESP32-P4 stack-protection fault in the main task and could lead to a reboot loop. The pushed beta.3 source tag remains unchanged as a historical record, but beta.3 should not be installed or republished.
+
+Two retained flash core dumps were decoded against their exact ELF files. Both showed the 12 KiB main-task stack reaching newlib text formatting with less than 1 KiB remaining. A formatter-only diagnostic avoided that immediate call path but left only 352 bytes of measured headroom, so it was rejected as an incomplete workaround.
+
+Beta.4 raises the main-task stack to 16 KiB and makes the supported native build helper enforce that value. The LoRa decoder, dashboard behavior, and displayed frequency formatting are unchanged. On the exact flashed candidate, the full three-cycle dashboard test passed through ADS-B, Home, LoRa, P25, Settings, RF Lab, and FM. The lowest reported main-task headroom was 3,392 bytes. Normal UI restoration passed, and RTL-SDR 0.7.9 streaming remained near 949 kS/s with zero overruns and zero drops.
+## FM radio in Japan
+
+GitHub issue #56 reported that OrcSDR could not tune most Japanese FM stations because the firmware used lower limits of 87.5 or 88 MHz in different places. Japan's FM broadcast allocation extends down to 76 MHz.
+
+OrcSDR now uses one shared **76–108 MHz** FM range for manual entry, configuration files, saved presets, preset scanning, spectrum selection, tuning limits, and the Home band guide. The exact 76 and 108 MHz boundaries are covered by the existing FM configuration self-check, together with rejection immediately outside the supported range.
+
+The updated firmware was built with native ESP-IDF 5.5.4 and flashed successfully to the project Tab5. Actual reception of Japanese broadcasts remains a regional acceptance check for a tester in Japan.
+
+## ADS-B improvements
+
+ADS-B is now live-only. The old generated aircraft and demo-capture paths were removed so every aircraft, signal indicator, altitude chart, and target value shown on the dashboard comes from received data. A quiet 1090 MHz band now reports that it is waiting or searching instead of displaying sample traffic.
+
+The ADS-B exit path restores the normal display font, and returning Home restores the saved spectrum and waterfall setting. A radio-start race found during hardware testing was fixed so a stale ADS-B startup cannot retune the receiver back to 1090 MHz after the user has opened FM. SD operations also respect the queued radio-start interval.
+
+Live acceptance included aircraft **N2255H**, ICAO **A1F6A3**, which the operator compared with Flightradar24. The aircraft type, callsign, position, altitude, and speed shown by OrcSDR agreed with the live reference closely enough for operator acceptance.
+
+## P25 Phase I receiver and audio
+
+The hardware-independent P25 C4FM protocol/FEC receiver was moved into `p25_decoder_core`, and IMBE voice processing was moved into `p25_voice`. These fixed-memory modules contain no Tab5 display, USB, speaker, or FreeRTOS dependency. The Tab5 application remains responsible for radio tuning, synchronization around the core, bounded queues, and delivering PCM to the output device.
+
+The receiver can be tested on a host with explicit timestamps and replayed IQ. Authenticated serial commands now cover P25 IQ capture, replay, modulation selection, status, survey, profile operations, and live validation. The committed control-channel fixture contains no intentionally captured voice traffic.
+
+Real Phase I testing repeatedly decoded the Lane County control system, followed voice grants, tuned traffic channels, produced IMBE frames and 48 kHz PCM, returned to the control channel, and relocked. The operator confirmed clear audio on several talkgroups, including **LCF Firecom 1 / TGID 20391**, **TGID 20817**, and **TGID 38130**, through the verified 3.5 mm output path.
+
+Some police talkgroups originally sounded robotic because their control-channel grant form did not announce encryption. OrcSDR now decodes the voice-channel LDU2 Encryption Sync field, withholds audio until the encryption state is known, prevents protected frames from reaching the vocoder, and returns to the control channel when **Skip Encrypted** is enabled. OrcSDR reports the algorithm and key identifiers carried in clear signaling but does not decrypt protected calls.
+
+## CQPSK and simulcast work
+
+The existing C4FM receiver remains available. OrcSDR also includes a dedicated CQPSK acquisition path with matched filtering, timing recovery, carrier recovery, differential dibit decoding, automatic modulation selection, and serial/dashboard diagnostics for modulation, lock quality, timing error, carrier error, and decode rate.
+
+Forced CQPSK replay decodes real recorded P25 identity and traffic, but the same strong fixture still decodes better through C4FM and automatic mode correctly selects C4FM. The live receiver exercised both acquisition paths. Compatibility across a wider range of confirmed LSM simulcast sites remains work in progress, and this release does not claim that every simulcast system is supported.
+
+## Portable P25 system profiles
+
+A clean installation no longer assumes that every user lives in Lane County, Oregon. With no existing configuration, P25 reports **No P25 system configured**. An existing `/orcsdr/P25.cfg` is imported once without overwriting or deleting the original.
+
+OrcSDR can store up to 16 systems under `/orcsdr/p25/<profile-id>/profile.cfg`. The Systems screen and authenticated serial interface can list, select, import, export, rename, reload, and delete profiles with confirmation. Control-channel selection, Survey, Hold, and temporary Skip/Next operate on the active profile. A dashboard touch-routing fix also prevents rapid Survey presses from being mistaken for spectrum tuning.
+
+Signed catalog entries can describe geographically bounded P25 system packs, but no RadioReference-derived database or universal Lane County pack is bundled. Public packs still require recorded source provenance and redistribution permission. Full talkgroup catalogs, priority and avoid rules, call history, and recording remain future work.
+
+## P25 Phase II progress
+
+This release contains the first live-validated Phase II receiver stages:
+
+- correct mapping from a logical TDMA channel number to its shared carrier and slot;
+- retention of talkgroup, service options, channel, slot, WACN, system, RFSS, and site identity;
+- a bounded 6,000-symbol-per-second traffic-channel synchronizer with normal and reversed polarity detection;
+- fixed-size capture of complete 180-dibit bursts;
+- separated DUID decoding with one-bit correction;
+- classification and counters for voice, associated-control, invalid, unsupported, and truncated bursts;
+- authenticated status and temporary trace controls;
+- validation that requires the same talkgroup to produce a grant, acquisition, complete valid burst, control return, and relock.
+
+On the Oregon State Radio Project, OrcSDR decoded WACN **9254A**, system **00A**, RFSS/site **6/6**, and a live Phase II grant for TGID **38130**. It mapped that call to carrier **773.28125 MHz**, slot **0**, synchronized to real traffic, retained complete bursts, and decoded valid DUID **9 FACCH** and DUID **3 SACCH** classifications. The receiver then returned to and relocked the control channel with no recorded drop-counter growth during the passing run.
+
+This is verified Phase II transport and burst-decoder groundwork. OrcSDR does **not** yet descramble the Phase II payload, decode its complete MAC/ESS content, extract AMBE+2 voice frames, synthesize Phase II audio, or claim Phase II audio acceptance.
+
+## Testing and stability evidence
+
+The P25 host suite passed optimized builds and ASan, LSan, and UBSan runs across the receiver, voice boundary, profiles, C4FM, CQPSK, Phase II synchronization, full-burst retention, polarity handling, DUID correction, malformed input, queue bounds, and timer rollover. The release changes were repeatedly built with native ESP-IDF 5.5.4, flashed with hash verification, and exercised through authenticated dashboard and radio-driver regressions.
+
+Recorded live runs included stable Phase I control lock, grant following, clear PCM production, encrypted-call muting, control return, and relock. The Phase II acceptance run observed live OSRP signaling and complete valid bursts. The passing runs reported no panic, watchdog, out-of-memory reset, USB overrun, sustained USB/IQ/audio/voice-queue drop growth, or declining heap trend.
+
+A separate 30-minute Phosphor Persistence run with the Serial/JTAG cable disconnected remains deferred and is not claimed by this release.
+
+## Installation and ESP-Hosted C6
+
+Install this beta on an **M5Stack Tab5** with an **RTL-SDR Blog V4**. For a normal upgrade, do not erase the device; that preserves saved settings and Wi-Fi profiles.
+
+The ESP-Hosted C6 update implementation is unchanged. M5Burner writes the P4 application. If the reachable C6 is not already on Hosted 3.0.6, open **Settings → Firmware & Updates** and explicitly confirm the in-app update. The project owner previously verified the unchanged route by returning a reachable C6 to 2.14.6 and updating it back to 3.0.6 through OrcSDR.
+
+## Known limits
+
+- P25 remains Work in progress while wider-system compatibility and Phase II audio are unfinished.
+- Encrypted P25 calls are identified and muted; they are not decrypted.
+- Wider live CQPSK/LSM compatibility needs more confirmed simulcast-site evidence.
+- Clean installations contain no universal P25 system or talkgroup database.
+- Actual Japanese FM reception still needs confirmation by a tester located in Japan.
+- USB hub support remains deferred.
+- The disconnected 30-minute Phosphor Persistence stability gate remains deferred.
+
+## Source and package record
+
+Final tag, source commit, package hashes, embedded C6 provenance, private M5Burner installation, and exact-package device checks will be recorded here after those gates complete.
+
+Included work: [#50](https://github.com/hardcoreerik/OrcSDR/pull/50), [#51](https://github.com/hardcoreerik/OrcSDR/pull/51), [#52](https://github.com/hardcoreerik/OrcSDR/pull/52), [#53](https://github.com/hardcoreerik/OrcSDR/pull/53), [#54](https://github.com/hardcoreerik/OrcSDR/pull/54), [#55](https://github.com/hardcoreerik/OrcSDR/pull/55), [#57](https://github.com/hardcoreerik/OrcSDR/pull/57), [#58](https://github.com/hardcoreerik/OrcSDR/pull/58), and [#60](https://github.com/hardcoreerik/OrcSDR/pull/60).
+
+[All source changes since beta.2](https://github.com/hardcoreerik/OrcSDR/compare/v0.2.0-beta.2...v0.2.0-beta.4)

--- a/docs/releases/v0.2.0-beta.4.md
+++ b/docs/releases/v0.2.0-beta.4.md
@@ -11,6 +11,7 @@ The beta.3 M5Burner entry was unpublished after the exact release package failed
 Two retained flash core dumps were decoded against their exact ELF files. Both showed the 12 KiB main-task stack reaching newlib text formatting with less than 1 KiB remaining. A formatter-only diagnostic avoided that immediate call path but left only 352 bytes of measured headroom, so it was rejected as an incomplete workaround.
 
 Beta.4 raises the main-task stack to 16 KiB and makes the supported native build helper enforce that value. The LoRa decoder, dashboard behavior, and displayed frequency formatting are unchanged. On the exact flashed candidate, the full three-cycle dashboard test passed through ADS-B, Home, LoRa, P25, Settings, RF Lab, and FM. The lowest reported main-task headroom was 3,392 bytes. Normal UI restoration passed, and RTL-SDR 0.7.9 streaming remained near 949 kS/s with zero overruns and zero drops.
+
 ## FM radio in Japan
 
 GitHub issue #56 reported that OrcSDR could not tune most Japanese FM stations because the firmware used lower limits of 87.5 or 88 MHz in different places. Japan's FM broadcast allocation extends down to 76 MHz.


### PR DESCRIPTION
## Purpose

Prepare the public release notes for `v0.2.0-beta.4`, which will supersede the withdrawn beta.3 package.

Beta.3 was unpublished from M5Burner after its exact release package exposed a reproducible main-task stack-protection fault during the three-cycle dashboard smoke test. The pushed beta.3 tag remains immutable as a historical record. PR #60 corrected the root condition by increasing the Tab5 main-task stack from 12 KiB to 16 KiB while leaving the LoRa implementation and displayed formatting unchanged.

## What these notes cover

- Why beta.3 was withdrawn and should not be republished.
- The two retained core-dump findings and the formatter-only diagnostic that was rejected because it left only 352 bytes of headroom.
- The passing beta.4 hotfix candidate evidence: native ESP-IDF 5.5.4 build, exact-image flash, three-cycle dashboard regression, normal UI restoration, and RTL-SDR 0.7.9 streaming near 949 kS/s with zero overruns or drops.
- The full P25 Phase I, encrypted-call handling, CQPSK, portable-system-profile, and Phase II transport/burst-decoder work accumulated since beta.2.
- ADS-B live-only behavior, state restoration, and live aircraft cross-check evidence.
- The GitHub issue #56 correction that expands the supported FM range to 76–108 MHz for Japan.
- Remaining limits, including unfinished Phase II audio, wider CQPSK/LSM evidence, Japanese reception acceptance, USB hubs, and the deferred disconnected Phosphor Persistence run.

## Validation

This PR changes one Markdown file only. `git diff --check` passes. No firmware was rebuilt or flashed for this documentation-only change. The firmware evidence quoted in the notes comes from the exact candidate already built and tested for PR #60.

## Publication boundary

This PR does not create a tag, build a package, publish GitHub release assets, or publish an M5Burner listing. After merge, `v0.2.0-beta.4` must be tagged from the merged revision, rebuilt by the exact-tag release tool, validated, privately installed through M5Burner, and accepted on hardware before public publication.
