### PR TITLE
fix(release): emit flash.sh with LF line endings (#65)

### DIFF
--- a/tools/release/build-m5burner.ps1
+++ b/tools/release/build-m5burner.ps1
@@ -132,14 +132,16 @@ $localManifest = [ordered]@{
   }
 }
 $localManifest | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $localRoot 'm5burner.json')
-@'
-#!/bin/bash
-esptool.py --chip esp32p4 --port /dev/${port} --baud 921600 --before default_reset --after hard_reset write_flash -z \
---flash_mode dio --flash_freq 80m --flash_size 16MB \
-0x2000 bootloader_0x2000.bin \
-0x8000 partition-table_0x8000.bin \
-0x10000 orcsdr_tab5_0x10000.bin
-'@ | Set-Content -LiteralPath (Join-Path $localFirmware 'flash.sh') -NoNewline
+$flashSh = @(
+  '#!/bin/bash',
+  'esptool.py --chip esp32p4 --port /dev/${port} --baud 921600 --before default_reset --after hard_reset write_flash -z \',
+  '--flash_mode dio --flash_freq 80m --flash_size 16MB \',
+  '0x2000 bootloader_0x2000.bin \',
+  '0x8000 partition-table_0x8000.bin \',
+  '0x10000 orcsdr_tab5_0x10000.bin',
+  ''
+) -join "`n"
+[IO.File]::WriteAllText((Join-Path $localFirmware 'flash.sh'), $flashSh, (New-Object Text.UTF8Encoding($false)))
 $localZip = Join-Path $dist "OrcSDR-Tab5-$Version-local-m5burner.zip"
 Compress-Archive -Path (Join-Path $localRoot '*') -DestinationPath $localZip -Force
 


### PR DESCRIPTION
## Summary
- The M5Burner ZIP shipped a `flash.sh` with CRLF because the PowerShell here-string in `tools/release/build-m5burner.ps1` preserved the .ps1 file's own line endings and `Set-Content` wrote them through.
- Linux users hit ``bash: ./flash.sh: /bin/bash^M: bad interpreter: No such file or directory``.
- Fix: build the script line-by-line joined with LF (`` \`n ``) and write via `[IO.File]::WriteAllText` with UTF-8 no-BOM so the packaged `flash.sh` is LF-only regardless of how the .ps1 is checked out.

Fixes #65

## Test plan
- [x] Ran the exact write pattern against a temp file: `len=284 bom=False lf=6 crlf=0 firstByte=0x23` — 6 LF, 0 CRLF, no BOM, shebang byte correct.
- [ ] Next tagged release build produces a `local-m5burner` ZIP whose `flash.sh` is LF-only (verify with `file flash.sh` → "with LF line terminators", not "CRLF").

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of the generated firmware flashing script by ensuring consistent UTF-8 encoding.
  * Added a trailing newline to the generated script for improved formatting and tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->