### PR TITLE
release: prepare v0.2.0-beta.5

### DIFF
--- a/apps/orcsdr-tab5/tools/patches/esp-hosted-trampoline-null-delete.patch
+++ b/apps/orcsdr-tab5/tools/patches/esp-hosted-trampoline-null-delete.patch
@@ -1,7 +1,7 @@
 diff --git a/managed_components/espressif__esp_hosted/port/os/idf/src/eh_host_port_task.c b/managed_components/espressif__esp_hosted/port/os/idf/src/eh_host_port_task.c
 --- a/managed_components/espressif__esp_hosted/port/os/idf/src/eh_host_port_task.c
 +++ b/managed_components/espressif__esp_hosted/port/os/idf/src/eh_host_port_task.c
-@@ -49,11 +49,21 @@ static void trampoline(void *p)
+@@ -49,9 +49,19 @@ static void trampoline(void *p)
      } else if (t && t->exit_sem) {
          xSemaphoreGive(t->exit_sem);
      }
@@ -26,5 +26,3 @@ diff --git a/managed_components/espressif__esp_hosted/port/os/idf/src/eh_host_po
 +    (void)with_caps;
 +    vTaskDelete(NULL);
  }
-
- eh_host_port_err_t eh_host_port_task_create(const eh_host_port_task_create_cfg_t *cfg,

--- a/docs/releases/v0.2.0-beta.5.md
+++ b/docs/releases/v0.2.0-beta.5.md
@@ -1,0 +1,100 @@
+# OrcSDR v0.2.0-beta.5
+
+This beta directly addresses the USB-C-dependent boot loop reported by Tab5
+owners, substantially expands Meshtastic LoRa monitoring beyond the United
+States, and adds a native POCSAG receiver.
+
+## Battery boot and Wi-Fi
+
+Affected devices could show a light-blue screen for a second or two and reboot
+repeatedly when powered from their battery or a normal USB-C charger. Connecting
+the same device to a PC over USB-C often allowed it to boot, making the computer
+cable appear to be a power requirement. Testing traced the trigger to bringing
+up ESP-Hosted Wi-Fi during the early boot sequence, especially when Wi-Fi
+auto-connect was enabled.
+
+As a temporary mitigation, ESP-Hosted initialization no longer runs during
+`setup()`. The Tab5 reaches Home first without depending on a PC USB host. When
+Wi-Fi auto-connect is enabled, OrcSDR waits 10 seconds, pauses active SDR work,
+and then queues the saved-profile connection through the same path used by
+Settings. Manual Wi-Fi scans and connections also use the shared pause/resume
+path.
+
+Initial battery testing reached Home on all six attempts, including boots with
+no PC cable attached. Auto-connect succeeded three times, failed cleanly twice,
+and crashed once when the delayed connection started. This release therefore
+removes the consistent early-boot blocker, but it is not presented as the final
+Wi-Fi fix. Users who prioritize stability should leave Wi-Fi auto-connect
+disabled and connect manually after Home appears.
+
+## Regional Meshtastic LoRa monitoring
+
+- Restores the native decoder at the shared receiver lifecycle boundary.
+- Adds validated LongFast region and slot selection for 24 regional plans across
+  the United States, Europe, China, Japan, Australia, New Zealand, Russia,
+  Ukraine, South Korea, Taiwan, India, Thailand, Malaysia, Singapore, the
+  Philippines, Kazakhstan, Nepal, and Brazil.
+- Persists the selected region and slot and restores the derived frequency.
+- Adds pre-roll, adaptive quiet-tail capture, separate capture/decode buffers,
+  duplicate suppression, and bounded multi-packet decoding.
+- Improves message and node views with names, telemetry, positions, favorites,
+  details, public-channel messages, and bounded CSV export.
+- Keeps reception passive; keys remain local and are not written to diagnostics.
+
+Special thanks to [Hitman90210](https://github.com/Hitman90210/OrcSDR) for the
+hardware investigation that identified the decoder lifecycle failure and
+informed the channel-selection and persistence work. OrcSDR's regional
+implementation was independently developed; detailed provenance is retained in
+`docs/HITMAN90210_LORA_REVIEW.md`.
+
+## Native POCSAG receiver
+
+- Adds 512, 1200, and 2400 baud decoding with automatic or forced polarity.
+- Adds a recent-message inbox, CAPCODE directory, signal/FEC diagnostics, and a
+  RAM-only session view.
+- Adds configurable frequency-profile scanning from the SD card.
+- Adds bounded storage and host-side optimized/sanitizer validation.
+
+Live 1200-baud testing decoded repeated `TEST` pages for CAPCODE 1234560 with no
+USB or IQ drops. Live 512/2400-baud and weak-signal performance remain open
+acceptance areas.
+
+## Installation
+
+Install on an M5Stack Tab5 with an RTL-SDR Blog V4. Do not erase during a normal
+M5Burner upgrade; this preserves settings and saved Wi-Fi profiles.
+
+M5Burner writes the ESP32-P4 application. The embedded ESP-Hosted C6 3.0.6 image
+is offered separately under **Settings > Firmware & Updates** only when an
+explicit C6 update is required and confirmed.
+
+## Coming next: SHORTWAVE / AM
+
+The next receiver work will focus on expanding SHORTWAVE and AM listening. This
+is a preview of the next development area, not a claim that the full feature is
+included or hardware-validated in beta.5.
+
+## Known limits
+
+- Wi-Fi auto-connect remains intermittent and can still crash during the delayed
+  Hosted connection. Manual connection after boot is the safer path.
+- POCSAG live validation currently covers 1200 baud; 512/2400 baud are
+  host-tested but not live-validated.
+- LoRa reception depends on correct regional and channel selection.
+- P25 Phase II audio remains unimplemented.
+- USB hub support remains deferred.
+
+## Included work
+
+- [#63](https://github.com/hardcoreerik/OrcSDR/pull/63) — POCSAG dashboards and receiver
+- [#71](https://github.com/hardcoreerik/OrcSDR/pull/71) — battery/charger boot groundwork
+- [#73](https://github.com/hardcoreerik/OrcSDR/pull/73) — regional Meshtastic LoRa monitoring
+- [#74](https://github.com/hardcoreerik/OrcSDR/pull/74) — deferred Hosted/Wi-Fi startup
+
+[All source changes since beta.4](https://github.com/hardcoreerik/OrcSDR/compare/v0.2.0-beta.4...v0.2.0-beta.5)
+
+## Release evidence
+
+The exact tag, source commit, package hashes, embedded C6 provenance, private
+M5Burner installation, and exact-package device checks will be recorded after
+those gates complete.


### PR DESCRIPTION
# OrcSDR v0.2.0-beta.5

This beta directly addresses the USB-C-dependent boot loop reported by Tab5
owners, substantially expands Meshtastic LoRa monitoring beyond the United
States, and adds a native POCSAG receiver.

## Battery boot and Wi-Fi

Affected devices could show a light-blue screen for a second or two and reboot
repeatedly when powered from their battery or a normal USB-C charger. Connecting
the same device to a PC over USB-C often allowed it to boot, making the computer
cable appear to be a power requirement. Testing traced the trigger to bringing
up ESP-Hosted Wi-Fi during the early boot sequence, especially when Wi-Fi
auto-connect was enabled.

As a temporary mitigation, ESP-Hosted initialization no longer runs during
`setup()`. The Tab5 reaches Home first without depending on a PC USB host. When
Wi-Fi auto-connect is enabled, OrcSDR waits 10 seconds, pauses active SDR work,
and then queues the saved-profile connection through the same path used by
Settings. Manual Wi-Fi scans and connections also use the shared pause/resume
path.

Initial battery testing reached Home on all six attempts, including boots with
no PC cable attached. Auto-connect succeeded three times, failed cleanly twice,
and crashed once when the delayed connection started. This release therefore
removes the consistent early-boot blocker, but it is not presented as the final
Wi-Fi fix. Users who prioritize stability should leave Wi-Fi auto-connect
disabled and connect manually after Home appears.

## Regional Meshtastic LoRa monitoring

- Restores the native decoder at the shared receiver lifecycle boundary.
- Adds validated LongFast region and slot selection for 24 regional plans across
  the United States, Europe, China, Japan, Australia, New Zealand, Russia,
  Ukraine, South Korea, Taiwan, India, Thailand, Malaysia, Singapore, the
  Philippines, Kazakhstan, Nepal, and Brazil.
- Persists the selected region and slot and restores the derived frequency.
- Adds pre-roll, adaptive quiet-tail capture, separate capture/decode buffers,
  duplicate suppression, and bounded multi-packet decoding.
- Improves message and node views with names, telemetry, positions, favorites,
  details, public-channel messages, and bounded CSV export.
- Keeps reception passive; keys remain local and are not written to diagnostics.

Special thanks to [Hitman90210](https://github.com/Hitman90210/OrcSDR) for the
hardware investigation that identified the decoder lifecycle failure and
informed the channel-selection and persistence work. OrcSDR's regional
implementation was independently developed; detailed provenance is retained in
`docs/HITMAN90210_LORA_REVIEW.md`.

## Native POCSAG receiver

- Adds 512, 1200, and 2400 baud decoding with automatic or forced polarity.
- Adds a recent-message inbox, CAPCODE directory, signal/FEC diagnostics, and a
  RAM-only session view.
- Adds configurable frequency-profile scanning from the SD card.
- Adds bounded storage and host-side optimized/sanitizer validation.

Live 1200-baud testing decoded repeated `TEST` pages for CAPCODE 1234560 with no
USB or IQ drops. Live 512/2400-baud and weak-signal performance remain open
acceptance areas.

## Installation

Install on an M5Stack Tab5 with an RTL-SDR Blog V4. Do not erase during a normal
M5Burner upgrade; this preserves settings and saved Wi-Fi profiles.

M5Burner writes the ESP32-P4 application. The embedded ESP-Hosted C6 3.0.6 image
is offered separately under **Settings > Firmware & Updates** only when an
explicit C6 update is required and confirmed.

## Coming next: SHORTWAVE / AM

The next receiver work will focus on expanding SHORTWAVE and AM listening. This
is a preview of the next development area, not a claim that the full feature is
included or hardware-validated in beta.5.

## Known limits

- Wi-Fi auto-connect remains intermittent and can still crash during the delayed
  Hosted connection. Manual connection after boot is the safer path.
- POCSAG live validation currently covers 1200 baud; 512/2400 baud are
  host-tested but not live-validated.
- LoRa reception depends on correct regional and channel selection.
- P25 Phase II audio remains unimplemented.
- USB hub support remains deferred.

## Included work

- [#63](https://github.com/hardcoreerik/OrcSDR/pull/63) — POCSAG dashboards and receiver
- [#71](https://github.com/hardcoreerik/OrcSDR/pull/71) — battery/charger boot groundwork
- [#73](https://github.com/hardcoreerik/OrcSDR/pull/73) — regional Meshtastic LoRa monitoring
- [#74](https://github.com/hardcoreerik/OrcSDR/pull/74) — deferred Hosted/Wi-Fi startup

[All source changes since beta.4](https://github.com/hardcoreerik/OrcSDR/compare/v0.2.0-beta.4...v0.2.0-beta.5)

## Release evidence

The exact tag, source commit, package hashes, embedded C6 provenance, private
M5Burner installation, and exact-package device checks will be recorded after
those gates complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Tab5 startup reliability by preventing a USB-C-dependent boot loop during ESP-Hosted Wi-Fi initialization.
  - Improved task cleanup stability to avoid a potential system abort during Wi-Fi operation.

- **Documentation**
  - Added release notes for OrcSDR v0.2.0-beta.5.
  - Documented expanded regional Meshtastic LoRa monitoring, restored decoding, channel persistence, and a native POCSAG receiver.
  - Added installation guidance, known limitations, and related work references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->