### PR TITLE
feat: deliver AM broadcast reception and 2.4 MS/s station finder

### DIFF
--- a/apps/orcsdr-tab5/dependencies.lock
+++ b/apps/orcsdr-tab5/dependencies.lock
@@ -1,6 +1,6 @@
 dependencies:
   esp_rtl_sdr:
-    component_hash: 6aae50446fc97072cddf67171f48c0fe9e6b90c8c1bb4ee115b024ba5ea0350d
+    component_hash: d1db82ec3f1189fe3589d7a1e4e3771ac8778f83d8739aeca000fa4fb791a8e8
     dependencies:
     - name: idf
       version: '>=5.5.0'
@@ -10,7 +10,7 @@ dependencies:
       type: git
     targets:
     - esp32p4
-    version: 69e61848008ed0fce5a823ad370aee5cb81d65da
+    version: 1cd19d1363daea49b013c2d28a25750fcbfcff78
   espressif/eppp_link:
     component_hash: c1369b37f2b0b427b198ae14e07e7547d3da92b95fe4dc7f949e5de560b35f21
     dependencies:
@@ -142,6 +142,6 @@ direct_dependencies:
 - idf
 - m5stack/m5gfx
 - m5stack/m5unified
-manifest_hash: 4323b745690c774037c05160a94f7e466b6a040ee24f2852f5c3653628f7045a
+manifest_hash: e11585eb70d8db80495fe1015198b304b6fe13c5989db257746b1469db779f6f
 target: esp32p4
 version: 2.0.0

--- a/apps/orcsdr-tab5/main/CMakeLists.txt
+++ b/apps/orcsdr-tab5/main/CMakeLists.txt
@@ -21,6 +21,7 @@ idf_component_register(
         "../ui/main.cpp"
         "../ui/orcsdr_splash.cpp"
         "../ui/orcsdr_storage.cpp"
+        "../ui/am_dashboard.cpp"
         "../ui/adsb_dashboard.cpp"
         "../ui/adsb_decoder.cpp"
         "../ui/atc_presets.cpp"

--- a/apps/orcsdr-tab5/main/CMakeLists.txt
+++ b/apps/orcsdr-tab5/main/CMakeLists.txt
@@ -22,6 +22,7 @@ idf_component_register(
         "../ui/orcsdr_splash.cpp"
         "../ui/orcsdr_storage.cpp"
         "../ui/am_dashboard.cpp"
+        "../ui/am_finder.cpp"
         "../ui/adsb_dashboard.cpp"
         "../ui/adsb_decoder.cpp"
         "../ui/atc_presets.cpp"

--- a/apps/orcsdr-tab5/main/idf_component.yml
+++ b/apps/orcsdr-tab5/main/idf_component.yml
@@ -11,7 +11,7 @@ dependencies:
     version: "^1.2.3"
   esp_rtl_sdr:
     git: https://github.com/hardcoreerik/esp-rtl-sdr.git
-    version: v0.7.14
+    version: 1cd19d1363daea49b013c2d28a25750fcbfcff78
   m5stack/m5unified:
     version: "0.2.20"
   m5stack/m5gfx:

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -25,6 +25,7 @@ param(
   [switch]$DataOnly,
   [switch]$C6Update,
   [switch]$RadioScan,
+  [switch]$AmBroadcast,
   [switch]$InstallLaneMap,
   [string]$LocationQuery = '97401',
   [switch]$RequireWifiConnection,
@@ -169,16 +170,16 @@ function Connect-Authenticated {
 
 function Get-UiState {
   $line = Send-And-Wait 'RTL_UI STATUS' '^RTL_UI_STATUS '
-  if ($line -notmatch 'screen=(\S+) band=(\S+) frequency_hz=(\d+) settings=([01]) fm=([01]) p25=([01]) adsb=([01]) lora=([01]) rf24=([01]) home_font=([01]) graphics=([01])') {
+  if ($line -notmatch 'screen=(\S+) band=(\S+) frequency_hz=(\d+) settings=([01]) fm=([01]) am=([01]) p25=([01]) adsb=([01]) lora=([01]) rf24=([01]) home_font=([01]) graphics=([01])') {
     throw "Malformed UI status: $line"
   }
   return [pscustomobject]@{
     Screen = $Matches[1].ToUpperInvariant()
     Band = $Matches[2].ToUpperInvariant()
     Frequency = [uint32]$Matches[3]
-    Active = @([int]$Matches[4], [int]$Matches[5], [int]$Matches[6], [int]$Matches[7], [int]$Matches[8], [int]$Matches[9])
-    HomeFont = [int]$Matches[10]
-    Graphics = [int]$Matches[11]
+    Active = @([int]$Matches[4], [int]$Matches[5], [int]$Matches[6], [int]$Matches[7], [int]$Matches[8], [int]$Matches[9], [int]$Matches[10])
+    HomeFont = [int]$Matches[11]
+    Graphics = [int]$Matches[12]
   }
 }
 
@@ -186,17 +187,18 @@ function Test-ExclusiveScreen($State, [string]$Screen) {
   # RF24 is an overlay: FM remains active so the receiver/audio stream continues.
   if ($Screen -eq 'WIFI_ANALYSIS') {
     return $State.Active[0] -eq 0 -and $State.Active[1] -eq 1 -and
-           $State.Active[2] -eq 0 -and
-           $State.Active[3] -eq 0 -and $State.Active[4] -eq 0 -and
-           $State.Active[5] -eq 1
+           $State.Active[2] -eq 0 -and $State.Active[3] -eq 0 -and
+           $State.Active[4] -eq 0 -and $State.Active[5] -eq 0 -and
+           $State.Active[6] -eq 1
   }
   $expected = switch ($Screen) {
-    'FM' { @(0,1,0,0,0,0) }
-    'P25' { @(0,0,1,0,0,0) }
-    'ADSB' { @(0,0,0,1,0,0) }
-    'LORA' { @(0,0,0,0,1,0) }
-    'SETTINGS' { @(1,0,0,0,0,0) }
-    'HOME' { @(0,0,0,0,0,0) }
+    'FM' { @(0,1,0,0,0,0,0) }
+    'AM' { @(0,0,1,0,0,0,0) }
+    'P25' { @(0,0,0,1,0,0,0) }
+    'ADSB' { @(0,0,0,0,1,0,0) }
+    'LORA' { @(0,0,0,0,0,1,0) }
+    'SETTINGS' { @(1,0,0,0,0,0,0) }
+    'HOME' { @(0,0,0,0,0,0,0) }
     default { return $true }
   }
   return ($State.Active -join ',') -eq ($expected -join ',')
@@ -234,6 +236,29 @@ function Watch-Responsive([int]$Seconds, [string]$Screen, [string]$Band) {
 function Get-AudioStatus {
   $line = Send-And-Wait 'RTL_AUDIO_TEST STATUS' '^\{"type":"rtl_audio_test"'
   try { return $line | ConvertFrom-Json } catch { throw "Malformed audio status: $line" }
+}
+
+function ConvertFrom-SignalStatus([string]$Line) {
+  if ($line -notmatch '^RTL_SIGNAL_STATUS band=(\S+) frequency_hz=(\d+) signal_dbfs_tenths=(-?\d+) .*filter_hz=(\d+) lo_nudge=(-?\d+)$') {
+    throw "Malformed signal status: $line"
+  }
+  return [pscustomobject]@{
+    Band = $Matches[1]
+    Frequency = [uint32]$Matches[2]
+    SignalTenths = [int]$Matches[3]
+    FilterHz = [uint32]$Matches[4]
+    Line = $line
+  }
+}
+
+function Get-SignalStatus {
+  for ($attempt = 0; $attempt -lt 3; $attempt++) {
+    $line = Send-And-Wait 'RTL_SIGNAL' '^RTL_SIGNAL_STATUS '
+    try { return ConvertFrom-SignalStatus $line } catch {
+      if ($attempt -eq 2) { throw }
+      Start-Sleep -Milliseconds 100
+    }
+  }
 }
 
 function Assert-FmAudioProgress {
@@ -692,25 +717,31 @@ function Invoke-SelfCheck {
   if (Test-FatalLine 'RTL_UI_STATUS screen=home band=FM frequency_hz=96144000') {
     throw 'Fatal parser rejected healthy telemetry.'
   }
-  $audio = '{"type":"rtl_audio_test","speaker_enabled":1,"speaker_running":1,"audio_chunks":42}' | ConvertFrom-Json
-  if ($audio.speaker_running -ne 1 -or $audio.audio_chunks -ne 42) { throw 'Audio parser failed.' }
+  $audio = '{"type":"rtl_audio_test","speaker_enabled":1,"speaker_running":1,"headphone_connected":1,"internal_speaker_muted":1,"audio_chunks":42}' | ConvertFrom-Json
+  if ($audio.speaker_running -ne 1 -or $audio.audio_chunks -ne 42 -or
+      $audio.headphone_connected -ne 1 -or $audio.internal_speaker_muted -ne 1) {
+    throw 'Audio parser failed.'
+  }
   $coex = 'RTL_WIFI_COEX_STATUS station=1 scanning=0 connecting=0 connected=1 connect_pause=0 rtl_ready=1 capture_state=3 capture_requested=0 band=FM frequency_hz=96100000 audio_enabled=1 speaker_running=1 audio_chunks=42 audio_drops=0'
   if ($coex -notmatch 'connect_pause=0.*rtl_ready=1.*capture_state=3.*band=FM.*speaker_running=1') { throw 'Coexistence parser failed.' }
   $c6 = 'RTL_WIFI_C6_STATUS host=3.0.6 coprocessor=2.12.6 transport=1 embedded=1 state=ready percent=0 stage=version match=0'
   if ($c6 -notmatch '^RTL_WIFI_C6_STATUS host=\S+ coprocessor=\S+ transport=1 embedded=1 state=ready percent=0 stage=\S+ match=0$') {
     throw 'C6 update parser failed.'
   }
-  if (-not (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,0,0,1,0,0) }) 'ADSB')) {
+  if (-not (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,0,0,0,1,0,0) }) 'ADSB')) {
     throw 'Exclusive dashboard check rejected valid ADS-B state.'
   }
-  if (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,1,0,1,0,0) }) 'ADSB') {
+  if (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,1,0,0,1,0,0) }) 'ADSB') {
     throw 'Exclusive dashboard check accepted stale FM state.'
   }
-  if (-not (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,1,0,0,0,1) }) 'WIFI_ANALYSIS')) {
+  if (-not (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,1,0,0,0,0,1) }) 'WIFI_ANALYSIS')) {
     throw 'RF24 overlay check rejected active FM.'
   }
-  if (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,1,1,0,0,1) }) 'WIFI_ANALYSIS') {
+  if (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,1,0,1,0,0,1) }) 'WIFI_ANALYSIS') {
     throw 'RF24 overlay check accepted an active P25 dashboard.'
+  }
+  if (-not (Test-ExclusiveScreen ([pscustomobject]@{ Active = @(0,0,1,0,0,0,0) }) 'AM')) {
+    throw 'Exclusive dashboard check rejected valid AM state.'
   }
   $health = ConvertFrom-HealthStatus 'RTL_HEALTH_STATUS uptime_ms=123 free_heap=456 min_free_heap=400 dma_free=300 dma_min=250 dma_largest=200 tasks=12 main_stack_hwm=2048 reset_reason=1'
   Assert-HealthStatus $health
@@ -727,12 +758,17 @@ function Invoke-SelfCheck {
       $frequency.Mode -ne 'P25 C4FM') {
     throw 'Radio frequency parser failed.'
   }
+  $signal = ConvertFrom-SignalStatus 'RTL_SIGNAL_STATUS band=AM frequency_hz=590000 signal_dbfs_tenths=-321 stereo_locked=0 left_dbfs_tenths=-400 right_dbfs_tenths=-400 rds_carrier=0 rds_signal_tenths=-900 pilot_env_thou=0 filter_hz=6000 lo_nudge=0'
+  if ($signal.Band -ne 'AM' -or $signal.Frequency -ne 590000 -or
+      $signal.SignalTenths -ne -321 -or $signal.FilterHz -ne 6000) {
+    throw 'AM signal parser failed.'
+  }
   Write-SoakLine 'RTL_UI_SOAK_SELF_CHECK pass=1'
 }
 
 if ($SelfCheck) { Invoke-SelfCheck; exit 0 }
-if (@($Run, $Soak, $Driver079, $WifiOnly, $WifiCoexistence, $WifiCoexistenceDiagnostic, $DataOnly, $C6Update, $RadioScan).Where({ $_ }).Count -gt 1) {
-  throw 'Choose only one of -Run, -Soak, -Driver079, -WifiOnly, -WifiCoexistence, -WifiCoexistenceDiagnostic, -DataOnly, -C6Update, or -RadioScan.'
+if (@($Run, $Soak, $Driver079, $WifiOnly, $WifiCoexistence, $WifiCoexistenceDiagnostic, $DataOnly, $C6Update, $RadioScan, $AmBroadcast).Where({ $_ }).Count -gt 1) {
+  throw 'Choose only one of -Run, -Soak, -Driver079, -WifiOnly, -WifiCoexistence, -WifiCoexistenceDiagnostic, -DataOnly, -C6Update, -RadioScan, or -AmBroadcast.'
 }
 
 function Get-C6UpdateStatus {
@@ -782,6 +818,84 @@ function Get-DriverStatus {
     Bias = [int]$Matches[10]; Bytes = [uint64]$Matches[11]; Blocks = [uint64]$Matches[12]
     EffectiveSps = [uint32]$Matches[13]; Overruns = [uint32]$Matches[14]
     Drops = [uint32]$Matches[15]; ShadowOk = [int]$Matches[16]; MetricsOk = [int]$Matches[17]
+  }
+}
+
+function Set-AmFilter([uint32]$TargetHz) {
+  for ($attempt = 0; $attempt -lt 4; $attempt++) {
+    $signal = Get-SignalStatus
+    if ($signal.Band -eq 'AM' -and $signal.FilterHz -eq $TargetHz) { return $signal }
+    [void](Send-And-Wait 'RTL_UI ACTION AM FILTER' '^RTL_UI_ACTION_OK$')
+    Start-Sleep -Milliseconds 150
+  }
+  $signal = Get-SignalStatus
+  throw "AM filter did not reach $TargetHz Hz: $($signal.Line)"
+}
+
+function Invoke-AmBroadcastTest {
+  Wait-DeviceReady 60 11000
+  Connect-Authenticated
+  $initial = $null
+  $initialSignal = $null
+  $initialVerbosity = $null
+  try {
+    $verbosity = Send-And-Wait 'RTL_SERIAL VERBOSITY' '^RTL_SERIAL_VERBOSITY mode=(QUIET|NORMAL|DEBUG|TRACE)$'
+    $initialVerbosity = $verbosity.Split('=')[-1]
+    [void](Send-And-Wait 'RTL_SERIAL VERBOSITY QUIET' '^RTL_SERIAL_VERBOSITY_OK mode=QUIET$')
+    Drain-SerialOutput
+    $initial = Get-UiState
+    $initialSignal = Get-SignalStatus
+    [void](Open-Ui 'AM' 'AM')
+    $audio = Get-AudioStatus
+    if ($audio.headphone_connected -eq 1 -and $audio.internal_speaker_muted -ne 1) {
+      throw 'Headphones detected but internal speaker is not muted.'
+    }
+    $driver = Get-DriverStatus
+    if ($driver.State -ne 'STREAMING') {
+      throw "AM test requires active IQ streaming; state=$($driver.State)"
+    }
+    $lastBytes = $driver.Bytes
+    foreach ($frequency in @(590000, 1120000, 1280000)) {
+      [void](Send-And-Wait "RTL_UI ACTION AM TUNE $frequency" '^RTL_UI_ACTION_OK$')
+      foreach ($filter in @(4000, 6000, 10000)) {
+        [void](Set-AmFilter $filter)
+        Start-Sleep -Seconds $DwellSeconds
+        $signal = Get-SignalStatus
+        if ($signal.Band -ne 'AM' -or $signal.Frequency -ne $frequency -or
+            $signal.FilterHz -ne $filter) {
+          throw "AM state mismatch: $($signal.Line)"
+        }
+        $driver = Get-DriverStatus
+        if ($driver.State -ne 'STREAMING' -or $driver.Bytes -le $lastBytes -or
+            $driver.EffectiveSps -eq 0) {
+          throw "AM IQ did not progress at frequency=$frequency filter=$filter state=$($driver.State) bytes=$($driver.Bytes) effective_sps=$($driver.EffectiveSps)"
+        }
+        $lastBytes = $driver.Bytes
+        Write-SoakLine "RTL_AM_REGRESSION_SAMPLE pass=1 frequency_hz=$frequency filter_hz=$filter signal_dbfs_tenths=$($signal.SignalTenths) bytes=$($driver.Bytes) effective_sps=$($driver.EffectiveSps) overruns=$($driver.Overruns) drops=$($driver.Drops)"
+      }
+      Assert-Health
+    }
+    Write-SoakLine 'RTL_AM_REGRESSION_RESULT pass=1 frequencies=3 filters=3 samples=9'
+  } finally {
+    try {
+      if ($null -ne $initial -and
+          $initial.Band -in @('FM','AM','WX','CB','LORA','BROWSE','ADSB','P25')) {
+        [void](Send-And-Wait "RTL_TUNE $($initial.Band) $($initial.Frequency)" '^RTL_TUNE_(?:OK|UNAVAILABLE|INVALID)')
+      }
+      if ($null -ne $initial -and $null -ne $initialSignal -and
+          $initial.Band -eq 'AM' -and $initialSignal.FilterHz -in @(4000, 6000, 10000)) {
+        [void](Open-Ui 'AM' 'AM')
+        [void](Set-AmFilter $initialSignal.FilterHz)
+      }
+      if ($null -ne $initial) {
+        [void](Send-And-Wait "RTL_UI OPEN $($initial.Screen)" '^RTL_UI_OPEN_(?:OK|INVALID)')
+      }
+      if ($null -ne $initialVerbosity) {
+        [void](Send-And-Wait "RTL_SERIAL VERBOSITY $initialVerbosity" "^RTL_SERIAL_VERBOSITY_OK mode=$initialVerbosity$")
+      }
+    } catch {
+      Write-Warning "Could not restore initial AM test state: $($_.Exception.Message)"
+    }
   }
 }
 
@@ -953,6 +1067,7 @@ try {
   }
   if ($C6Update) { Invoke-C6UpdateTest; exit 0 }
   if ($RadioScan) { Invoke-RadioScanTest; exit 0 }
+  if ($AmBroadcast) { Invoke-AmBroadcastTest; exit 0 }
 
   if ($Profile) {
     $commit = (& git -C (Join-Path $PSScriptRoot '..\..\..') rev-parse --short HEAD 2>$null)

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -914,6 +914,15 @@ function Invoke-AmBroadcastTest {
       }
     }
     Write-SoakLine 'RTL_AM_GAIN_REGRESSION pass=1 auto=lowest_usable manual_range_tenth_db=0-496'
+    [void](Open-Ui 'HOME' 'AM')
+    [void](Open-Ui 'FM' 'FM')
+    Start-Sleep -Milliseconds 500
+    $fmDriver = Get-DriverStatus
+    if ($fmDriver.State -ne 'STREAMING' -or $fmDriver.Mode -ne 'AUTO') {
+      throw "AM to FM transition did not restore FM tuner state: state=$($fmDriver.State) mode=$($fmDriver.Mode)"
+    }
+    [void](Open-Ui 'AM' 'AM')
+    Write-SoakLine 'RTL_AM_FM_TRANSITION_REGRESSION pass=1 fm_gain_mode=AUTO'
     [void](Send-And-Wait 'RTL_UI ACTION AM SCAN' '^RTL_UI_ACTION_OK$')
     $scanDeadline = [DateTime]::UtcNow.AddSeconds(3)
     do {

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -832,11 +832,23 @@ function Set-AmFilter([uint32]$TargetHz) {
   throw "AM filter did not reach $TargetHz Hz: $($signal.Line)"
 }
 
+function Get-AmScanStatus {
+  $line = Send-And-Wait 'RTL_AM_SCAN STATUS' '^RTL_AM_SCAN_STATUS '
+  if ($line -notmatch '^RTL_AM_SCAN_STATUS active=([01]) step=(\d+) total=(\d+) found=(\d+) frequency_hz=(\d+)$') {
+    throw "Malformed AM scan status: $line"
+  }
+  [pscustomobject]@{
+    Active = [int]$Matches[1]; Step = [int]$Matches[2]; Total = [int]$Matches[3]
+    Found = [int]$Matches[4]; Frequency = [uint32]$Matches[5]
+  }
+}
+
 function Invoke-AmBroadcastTest {
   Wait-DeviceReady 60 11000
   Connect-Authenticated
   $initial = $null
   $initialSignal = $null
+  $initialDriver = $null
   $initialVerbosity = $null
   try {
     $verbosity = Send-And-Wait 'RTL_SERIAL VERBOSITY' '^RTL_SERIAL_VERBOSITY mode=(QUIET|NORMAL|DEBUG|TRACE)$'
@@ -846,18 +858,24 @@ function Invoke-AmBroadcastTest {
     $initial = Get-UiState
     $initialSignal = Get-SignalStatus
     [void](Open-Ui 'AM' 'AM')
-    $audio = Get-AudioStatus
+    $routeDeadline = [DateTime]::UtcNow.AddSeconds(3)
+    do {
+      $audio = Get-AudioStatus
+      if ($audio.headphone_connected -ne 1 -or $audio.internal_speaker_muted -eq 1) { break }
+      Start-Sleep -Milliseconds 250
+    } while ([DateTime]::UtcNow -lt $routeDeadline)
     if ($audio.headphone_connected -eq 1 -and $audio.internal_speaker_muted -ne 1) {
       throw 'Headphones detected but internal speaker is not muted.'
     }
     $driver = Get-DriverStatus
+    $initialDriver = $driver
     if ($driver.State -ne 'STREAMING') {
       throw "AM test requires active IQ streaming; state=$($driver.State)"
     }
     $lastBytes = $driver.Bytes
     foreach ($frequency in @(590000, 1120000, 1280000)) {
       [void](Send-And-Wait "RTL_UI ACTION AM TUNE $frequency" '^RTL_UI_ACTION_OK$')
-      foreach ($filter in @(4000, 6000, 10000)) {
+      foreach ($filter in @(4000, 6000, 8000, 10000)) {
         [void](Set-AmFilter $filter)
         Start-Sleep -Seconds $DwellSeconds
         $signal = Get-SignalStatus
@@ -875,7 +893,50 @@ function Invoke-AmBroadcastTest {
       }
       Assert-Health
     }
-    Write-SoakLine 'RTL_AM_REGRESSION_RESULT pass=1 frequencies=3 filters=3 samples=9'
+    [void](Open-Ui 'HOME' 'AM')
+    [void](Open-Ui 'AM' 'AM')
+    $signal = Get-SignalStatus
+    if ($signal.Frequency -ne 1280000) {
+      throw "AM dashboard entry changed the current station: $($signal.Line)"
+    }
+    Write-SoakLine 'RTL_AM_ENTRY_REGRESSION pass=1 preserved_frequency_hz=1280000'
+    [void](Send-And-Wait 'RTL_UI ACTION AM GAIN_AUTO' '^RTL_UI_ACTION_OK$')
+    Start-Sleep -Milliseconds 300
+    $driver = Get-DriverStatus
+    $auto = Send-And-Wait 'RTL_AM_GAIN STATUS' '^RTL_AM_GAIN_STATUS '
+    if ($driver.Mode -ne 'MANUAL' -or
+        $auto -notmatch 'mode=AUTO selecting=1 gain_tenth_db=0 target_dbfs=-24\.0') {
+      throw "AM bounded auto gain failed: driver_mode=$($driver.Mode) status=$auto"
+    }
+    foreach ($gain in @(0, 496)) {
+      [void](Send-And-Wait "RTL_UI ACTION AM GAIN $gain" '^RTL_UI_ACTION_OK$')
+      Start-Sleep -Milliseconds 300
+      $driver = Get-DriverStatus
+      if ($driver.Mode -ne 'MANUAL' -or $driver.Gain -ne $gain) {
+        throw "AM manual gain action failed: requested=$gain mode=$($driver.Mode) gain=$($driver.Gain)"
+      }
+    }
+    Write-SoakLine 'RTL_AM_GAIN_REGRESSION pass=1 auto=lowest_usable manual_range_tenth_db=0-496'
+    [void](Send-And-Wait 'RTL_UI ACTION AM SCAN' '^RTL_UI_ACTION_OK$')
+    $scanDeadline = [DateTime]::UtcNow.AddSeconds(3)
+    do {
+      $scan = Get-AmScanStatus
+      if ($scan.Active -eq 1) { break }
+      Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $scanDeadline)
+    if ($scan.Active -ne 1 -or $scan.Total -lt 100) {
+      throw "AM scan did not start: $($scan | ConvertTo-Json -Compress)"
+    }
+    [void](Send-And-Wait 'RTL_UI ACTION AM SCAN' '^RTL_UI_ACTION_OK$')
+    $scanDeadline = [DateTime]::UtcNow.AddSeconds(3)
+    do {
+      $scan = Get-AmScanStatus
+      if ($scan.Active -eq 0) { break }
+      Start-Sleep -Milliseconds 100
+    } while ([DateTime]::UtcNow -lt $scanDeadline)
+    if ($scan.Active -ne 0) { throw 'AM scan did not cancel.' }
+    Write-SoakLine "RTL_AM_SCAN_REGRESSION pass=1 action=start+cancel channels=$($scan.Total)"
+    Write-SoakLine 'RTL_AM_REGRESSION_RESULT pass=1 frequencies=3 filters=4 samples=12'
   } finally {
     try {
       if ($null -ne $initial -and
@@ -883,9 +944,16 @@ function Invoke-AmBroadcastTest {
         [void](Send-And-Wait "RTL_TUNE $($initial.Band) $($initial.Frequency)" '^RTL_TUNE_(?:OK|UNAVAILABLE|INVALID)')
       }
       if ($null -ne $initial -and $null -ne $initialSignal -and
-          $initial.Band -eq 'AM' -and $initialSignal.FilterHz -in @(4000, 6000, 10000)) {
+          $initial.Band -eq 'AM' -and $initialSignal.FilterHz -in @(4000, 6000, 8000, 10000)) {
         [void](Open-Ui 'AM' 'AM')
         [void](Set-AmFilter $initialSignal.FilterHz)
+      }
+      if ($null -ne $initialDriver) {
+        if ($initialDriver.Mode -eq 'AUTO') {
+          [void](Send-And-Wait 'RTL_UI ACTION AM GAIN_AUTO' '^RTL_UI_ACTION_OK$')
+        } else {
+          [void](Send-And-Wait "RTL_UI ACTION AM GAIN $($initialDriver.Gain)" '^RTL_UI_ACTION_OK$')
+        }
       }
       if ($null -ne $initial) {
         [void](Send-And-Wait "RTL_UI OPEN $($initial.Screen)" '^RTL_UI_OPEN_(?:OK|INVALID)')

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -846,6 +846,7 @@ function Invoke-AmBroadcastTest {
   $initial = $null
   $initialSignal = $null
   $initialDriver = $null
+  $initialAmGainAuto = $null
   $initialVerbosity = $null
   try {
     $verbosity = Send-And-Wait 'RTL_SERIAL VERBOSITY' '^RTL_SERIAL_VERBOSITY mode=(QUIET|NORMAL|DEBUG|TRACE)$'
@@ -866,6 +867,7 @@ function Invoke-AmBroadcastTest {
     }
     $driver = Get-DriverStatus
     $initialDriver = $driver
+    $initialAmGainAuto = (Send-And-Wait 'RTL_AM_GAIN STATUS' '^RTL_AM_GAIN_STATUS mode=(AUTO|MANUAL) ').Contains('mode=AUTO')
     if ($driver.State -ne 'STREAMING') {
       throw "AM test requires active IQ streaming; state=$($driver.State)"
     }
@@ -967,8 +969,8 @@ function Invoke-AmBroadcastTest {
         [void](Open-Ui 'AM' 'AM')
         [void](Set-AmFilter $initialSignal.FilterHz)
       }
-      if ($null -ne $initialDriver) {
-        if ($initialDriver.Mode -eq 'AUTO') {
+      if ($null -ne $initialDriver -and $null -ne $initialAmGainAuto) {
+        if ($initialAmGainAuto) {
           [void](Send-And-Wait 'RTL_UI ACTION AM GAIN_AUTO' '^RTL_UI_ACTION_OK$')
         } else {
           [void](Send-And-Wait "RTL_UI ACTION AM GAIN $($initialDriver.Gain)" '^RTL_UI_ACTION_OK$')

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -822,13 +822,10 @@ function Get-DriverStatus {
 }
 
 function Set-AmFilter([uint32]$TargetHz) {
-  for ($attempt = 0; $attempt -lt 4; $attempt++) {
-    $signal = Get-SignalStatus
-    if ($signal.Band -eq 'AM' -and $signal.FilterHz -eq $TargetHz) { return $signal }
-    [void](Send-And-Wait 'RTL_UI ACTION AM FILTER' '^RTL_UI_ACTION_OK$')
-    Start-Sleep -Milliseconds 150
-  }
+  [void](Send-And-Wait "RTL_UI ACTION AM FILTER $TargetHz" '^RTL_UI_ACTION_OK$')
+  Start-Sleep -Milliseconds 150
   $signal = Get-SignalStatus
+  if ($signal.Band -eq 'AM' -and $signal.FilterHz -eq $TargetHz) { return $signal }
   throw "AM filter did not reach $TargetHz Hz: $($signal.Line)"
 }
 
@@ -875,7 +872,7 @@ function Invoke-AmBroadcastTest {
     $lastBytes = $driver.Bytes
     foreach ($frequency in @(590000, 1120000, 1280000)) {
       [void](Send-And-Wait "RTL_UI ACTION AM TUNE $frequency" '^RTL_UI_ACTION_OK$')
-      foreach ($filter in @(4000, 6000, 8000, 10000)) {
+      foreach ($filter in @(3000, 6000, 10000, 30000)) {
         [void](Set-AmFilter $filter)
         Start-Sleep -Seconds $DwellSeconds
         $signal = Get-SignalStatus
@@ -927,15 +924,27 @@ function Invoke-AmBroadcastTest {
     if ($scan.Active -ne 1 -or $scan.Total -lt 100) {
       throw "AM scan did not start: $($scan | ConvertTo-Json -Compress)"
     }
-    [void](Send-And-Wait 'RTL_UI ACTION AM SCAN' '^RTL_UI_ACTION_OK$')
-    $scanDeadline = [DateTime]::UtcNow.AddSeconds(3)
+    $widebandDeadline = [DateTime]::UtcNow.AddSeconds(12)
+    do {
+      $driver = Get-DriverStatus
+      if ($driver.State -eq 'STREAMING' -and
+          $driver.EffectiveSps -ge 2200000 -and $driver.EffectiveSps -le 2600000) { break }
+      Start-Sleep -Milliseconds 250
+    } while ([DateTime]::UtcNow -lt $widebandDeadline)
+    if ($driver.State -ne 'STREAMING' -or
+        $driver.EffectiveSps -lt 2200000 -or $driver.EffectiveSps -gt 2600000) {
+      throw "AM finder did not reach 2.4 MS/s: state=$($driver.State) effective_sps=$($driver.EffectiveSps)"
+    }
+    $scanDeadline = [DateTime]::UtcNow.AddSeconds(12)
     do {
       $scan = Get-AmScanStatus
       if ($scan.Active -eq 0) { break }
-      Start-Sleep -Milliseconds 100
+      Start-Sleep -Milliseconds 250
     } while ([DateTime]::UtcNow -lt $scanDeadline)
-    if ($scan.Active -ne 0) { throw 'AM scan did not cancel.' }
-    Write-SoakLine "RTL_AM_SCAN_REGRESSION pass=1 action=start+cancel channels=$($scan.Total)"
+    if ($scan.Active -ne 0 -or $scan.Step -ne $scan.Total -or $scan.Found -lt 1) {
+      throw "AM scan did not populate candidates: $($scan | ConvertTo-Json -Compress)"
+    }
+    Write-SoakLine "RTL_AM_SCAN_REGRESSION pass=1 action=2.4MS+populate channels=$($scan.Total) found=$($scan.Found) effective_sps=$($driver.EffectiveSps)"
     Write-SoakLine 'RTL_AM_REGRESSION_RESULT pass=1 frequencies=3 filters=4 samples=12'
   } finally {
     try {
@@ -944,7 +953,8 @@ function Invoke-AmBroadcastTest {
         [void](Send-And-Wait "RTL_TUNE $($initial.Band) $($initial.Frequency)" '^RTL_TUNE_(?:OK|UNAVAILABLE|INVALID)')
       }
       if ($null -ne $initial -and $null -ne $initialSignal -and
-          $initial.Band -eq 'AM' -and $initialSignal.FilterHz -in @(4000, 6000, 8000, 10000)) {
+          $initial.Band -eq 'AM' -and $initialSignal.FilterHz -ge 3000 -and
+          $initialSignal.FilterHz -le 30000) {
         [void](Open-Ui 'AM' 'AM')
         [void](Set-AmFilter $initialSignal.FilterHz)
       }

--- a/apps/orcsdr-tab5/ui/am_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/am_dashboard.cpp
@@ -1,0 +1,416 @@
+#include "am_dashboard.hpp"
+
+#include "dashboard_audio_control.hpp"
+#include "orc_badge.hpp"
+#include "receiver_band_plan.hpp"
+#include "nvs_store.hpp"
+
+#include <M5Unified.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <iterator>
+
+namespace orcsdr::am {
+namespace {
+
+constexpr uint16_t kBg = TFT_BLACK;
+constexpr uint16_t kPanel = 0x0841;
+constexpr uint16_t kCyan = 0x2e7f;
+constexpr uint16_t kGreen = 0x6fe8;
+constexpr uint16_t kYellow = 0xff24;
+constexpr uint16_t kMuted = 0x8c71;
+constexpr uint16_t kGrid = 0x2945;
+constexpr int kHeaderH = 132;
+constexpr int kTabsY = 630;
+constexpr int kTabW = 1280 / static_cast<int>(View::count);
+constexpr int kSpectrumX = 46;
+constexpr int kSpectrumY = 246;
+constexpr int kSpectrumW = 1188;
+constexpr int kSpectrumH = 145;
+constexpr int kWaterfallY = 420;
+constexpr int kWaterfallH = 130;
+
+Snapshot g_snapshot{};
+View g_view = View::listen;
+bool g_active = false;
+uint32_t g_last_dynamic_ms = 0;
+EXT_RAM_BSS_ATTR uint16_t g_waterfall_row[kSpectrumW]{};
+audio_header::Control g_audio_control{};
+NvsStore* g_store = nullptr;
+uint32_t g_saved_frequency = receiver_bands::kAmBroadcast.default_hz;
+uint32_t g_channel_step = receiver_bands::kAmBroadcast.default_step_hz;
+uint32_t g_presets[6]{};
+uint8_t g_preset_count = 0;
+
+bool hit(int32_t x, int32_t y, int bx, int by, int bw, int bh) {
+  return x >= bx && x < bx + bw && y >= by && y < by + bh;
+}
+
+void text(const char* value, int x, int y, uint16_t color = TFT_WHITE,
+          int size = 2, textdatum_t datum = middle_center) {
+  M5.Display.setTextDatum(datum);
+  M5.Display.setTextSize(size);
+  M5.Display.setTextColor(color);
+  M5.Display.drawString(value, x, y);
+}
+
+void card(int x, int y, int w, int h) {
+  M5.Display.fillRoundRect(x, y, w, h, 12, kPanel);
+  M5.Display.drawRoundRect(x, y, w, h, 12, kCyan);
+}
+
+void button(int x, int y, int w, int h, const char* title, uint16_t color = kCyan,
+            bool selected = false) {
+  M5.Display.fillRoundRect(x, y, w, h, 10, selected ? 0x1264 : kPanel);
+  M5.Display.drawRoundRect(x, y, w, h, 10, color);
+  text(title, x + w / 2, y + h / 2, selected ? color : TFT_WHITE, 2);
+}
+
+void draw_header() {
+  M5.Display.fillRect(0, 0, 1280, kHeaderH, kBg);
+  M5.Display.drawFastHLine(8, kHeaderH - 1, 1264, kCyan);
+  if (!badge::draw(18, 13, 104)) M5.Display.drawRoundRect(18, 13, 104, 104, 18, kGreen);
+  text("OrcSDR", 142, 38, TFT_WHITE, 4, middle_left);
+  text("AM Broadcast", 142, 82, kCyan, 2, middle_left);
+  M5.Display.drawFastVLine(365, 25, 82, kCyan);
+  text("AM RADIO", 415, 66, TFT_WHITE, 4, middle_left);
+  M5.Display.drawFastVLine(865, 25, 82, kCyan);
+  audio_header::draw(g_audio_control, g_snapshot.volume, g_snapshot.sound_enabled,
+                     g_snapshot.battery_percent);
+  audio_header::draw_home_button();
+  audio_header::draw_mute_button(g_snapshot.sound_enabled);
+  audio_header::draw_visualizer_button(g_snapshot.running);
+  audio_header::draw_settings_button();
+}
+
+void draw_tabs() {
+  static constexpr const char* names[] = {"LISTEN", "SPECTRUM", "SETTINGS"};
+  for (uint8_t i = 0; i < static_cast<uint8_t>(View::count); ++i) {
+    const int x = i * kTabW;
+    const bool selected = i == static_cast<uint8_t>(g_view);
+    M5.Display.fillRect(x, kTabsY, kTabW, 90, selected ? 0x0a43 : kPanel);
+    M5.Display.drawRect(x, kTabsY, kTabW, 90, selected ? kGreen : kGrid);
+    text(names[i], x + kTabW / 2, kTabsY + 45, selected ? kGreen : TFT_WHITE, 3);
+  }
+}
+
+void draw_meter(int x, int y, int w, float dbfs) {
+  const int segments = 18;
+  const int lit = static_cast<int>(std::clamp((dbfs + 90.0f) / 70.0f, 0.0f, 1.0f) * segments);
+  const int gap = 3;
+  const int sw = (w - (segments - 1) * gap) / segments;
+  for (int i = 0; i < segments; ++i)
+    M5.Display.fillRect(x + i * (sw + gap), y, sw, 30,
+                        i < lit ? (i >= 14 ? kYellow : kGreen) : kGrid);
+}
+
+void draw_listen_static() {
+  card(24, 150, 820, 230);
+  card(860, 150, 396, 230);
+  text("RELATIVE SIGNAL", 884, 178, kCyan, 2, top_left);
+  button(24, 398, 190, 76, "STEP -");
+  button(224, 398, 190, 76, "STEP +");
+  button(424, 398, 190, 76, "9 / 10 kHz");
+  button(624, 398, 220, 76, "BANDWIDTH");
+  for (int i = 0; i < 6; ++i) button(24 + i * 166, 494, 154, 70, "EMPTY", kGrid);
+  button(1020, 494, 236, 70, "SAVE CURRENT", kGreen);
+  text("PRESETS", 24, 582, kCyan, 2, middle_left);
+  text("520–1710 kHz", 1256, 582, kMuted, 2, middle_right);
+}
+
+void draw_listen_dynamic() {
+  char value[40];
+  M5.Display.fillRect(45, 175, 775, 180, kPanel);
+  snprintf(value, sizeof(value), "%lu", static_cast<unsigned long>(g_snapshot.frequency_hz / 1000));
+  text(value, 390, 245, TFT_WHITE, 8);
+  text("kHz", 690, 260, TFT_WHITE, 4);
+  snprintf(value, sizeof(value), "STEP %lu kHz   BW %lu kHz",
+           static_cast<unsigned long>(g_snapshot.step_hz / 1000),
+           static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000));
+  text(value, 430, 330, kCyan, 3);
+  M5.Display.fillRect(882, 215, 350, 130, kPanel);
+  draw_meter(884, 220, 330, g_snapshot.relative_dbfs);
+  snprintf(value, sizeof(value), "%.1f dBFS  %s", static_cast<double>(g_snapshot.relative_dbfs),
+           g_snapshot.running ? "RECEIVING" : "STOPPED");
+  text(value, 1058, 295, g_snapshot.running ? kGreen : TFT_RED, 3);
+  for (int i = 0; i < 6; ++i) {
+    char preset[20];
+    if (i < g_snapshot.preset_count && g_snapshot.presets_hz[i])
+      snprintf(preset, sizeof(preset), "%lu", static_cast<unsigned long>(g_snapshot.presets_hz[i] / 1000));
+    else
+      snprintf(preset, sizeof(preset), "EMPTY");
+    button(24 + i * 166, 494, 154, 70, preset,
+           i == g_snapshot.selected_preset ? kGreen : kGrid,
+           i == g_snapshot.selected_preset);
+  }
+}
+
+void draw_spectrum_static() {
+  card(24, 140, 1232, 470);
+  text("AM CHANNEL SPECTRUM", 46, 158, kCyan, 2, top_left);
+  for (int i = 0; i <= 4; ++i) {
+    M5.Display.drawFastVLine(kSpectrumX + i * kSpectrumW / 4, kSpectrumY, kSpectrumH, kGrid);
+    if (i) M5.Display.drawFastHLine(kSpectrumX, kSpectrumY + i * kSpectrumH / 4,
+                                    kSpectrumW, kGrid);
+  }
+  M5.Display.drawRect(kSpectrumX, kWaterfallY, kSpectrumW, kWaterfallH, kCyan);
+  M5.Display.setScrollRect(kSpectrumX + 1, kWaterfallY + 1, kSpectrumW - 2,
+                           kWaterfallH - 2, kBg);
+  button(390, 565, 70, 42, "-");
+  button(820, 565, 70, 42, "+");
+  text("SPAN", 55, 585, kCyan, 2, middle_left);
+  text("TAP SPECTRUM TO TUNE", 1040, 585, TFT_WHITE, 2);
+}
+
+void draw_spectrum_dynamic() {
+  char value[64];
+  M5.Display.fillRect(45, 184, 1190, 58, kPanel);
+  snprintf(value, sizeof(value), "%lu kHz", static_cast<unsigned long>(g_snapshot.frequency_hz / 1000));
+  text(value, 55, 214, TFT_WHITE, 5, middle_left);
+  snprintf(value, sizeof(value), "STEP %lu kHz   BW %lu kHz   SPAN %lu kHz",
+           static_cast<unsigned long>(g_snapshot.step_hz / 1000),
+           static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000),
+           static_cast<unsigned long>(g_snapshot.span_hz / 1000));
+  text(value, 1220, 214, kGreen, 3, middle_right);
+}
+
+void draw_settings_static() {
+  card(24, 150, 1232, 450);
+  text("AM AUDIO & TUNING", 48, 174, kCyan, 2, top_left);
+  button(48, 220, 250, 70, "SOUND", kGreen);
+  button(320, 220, 180, 70, "VOL -");
+  button(520, 220, 180, 70, "VOL +");
+  button(48, 310, 310, 70, "CHANNEL SPACING");
+  button(380, 310, 310, 70, "FILTER WIDTH");
+  button(48, 400, 310, 70, "SPECTRUM");
+  button(380, 400, 310, 70, "RECORD AUDIO", TFT_RED);
+  button(720, 220, 512, 70, "DEVICE SETTINGS");
+  button(720, 310, 512, 70, "HOME", kGreen, true);
+  text("AM keeps playing while controls are adjusted", 976, 445, kMuted, 2);
+}
+
+void draw_settings_dynamic() {
+  char value[96];
+  M5.Display.fillRect(48, 500, 1184, 70, kPanel);
+  snprintf(value, sizeof(value), "VOL %u   SPACING %lu kHz   BW %lu kHz   GRAPHICS %s   RECORD %s",
+           g_snapshot.volume, static_cast<unsigned long>(g_snapshot.step_hz / 1000),
+           static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000),
+           g_snapshot.graphics_enabled ? "ON" : "OFF", g_snapshot.recording ? "ON" : "OFF");
+  text(value, 640, 535, TFT_WHITE, 2);
+}
+
+void draw_view() {
+  M5.Display.clearScrollRect();
+  M5.Display.fillRect(0, kHeaderH, 1280, 720 - kHeaderH, kBg);
+  if (g_view == View::listen) draw_listen_static();
+  else if (g_view == View::spectrum) draw_spectrum_static();
+  else draw_settings_static();
+  draw_tabs();
+}
+
+void draw_dynamic() {
+  if (g_view == View::listen) draw_listen_dynamic();
+  else if (g_view == View::spectrum) draw_spectrum_dynamic();
+  else draw_settings_dynamic();
+}
+
+uint16_t waterfall_color(float level) {
+  level = std::clamp(level, 0.0f, 1.0f);
+  const uint8_t r = level < 0.55f ? 0 : static_cast<uint8_t>((level - 0.55f) * 566);
+  const uint8_t g = level < 0.2f ? 0 : static_cast<uint8_t>(std::min(255.0f, (level - 0.2f) * 510));
+  const uint8_t b = level < 0.65f ? static_cast<uint8_t>((0.65f - level) * 390) : 0;
+  return M5.Display.color565(r, g, b);
+}
+
+}  // namespace
+
+void enter(const Snapshot& snapshot) {
+  g_snapshot = snapshot;
+  g_view = View::listen;
+  g_active = true;
+  audio_header::reset(g_audio_control);
+  draw();
+}
+
+void leave() {
+  M5.Display.clearScrollRect();
+  g_active = false;
+}
+
+void draw() {
+  if (!g_active) return;
+  M5.Display.fillScreen(kBg);
+  draw_header();
+  draw_view();
+  draw_dynamic();
+}
+
+void update(const Snapshot& snapshot) {
+  if (!g_active) return;
+  const bool header_changed = snapshot.battery_percent != g_snapshot.battery_percent ||
+                              snapshot.volume != g_snapshot.volume ||
+                              snapshot.sound_enabled != g_snapshot.sound_enabled;
+  g_snapshot = snapshot;
+  const uint32_t now = millis();
+  if (header_changed || audio_header::service_timeout(g_audio_control, now))
+    audio_header::draw(g_audio_control, g_snapshot.volume, g_snapshot.sound_enabled,
+                       g_snapshot.battery_percent);
+  if (now - g_last_dynamic_ms < 150) return;
+  g_last_dynamic_ms = now;
+  draw_dynamic();
+}
+
+void draw_spectrum(const float* levels, size_t first_bin, size_t visible_bins, float floor) {
+  if (!spectrum_active() || levels == nullptr || visible_bins < 2) return;
+  M5.Display.startWrite();
+  M5.Display.fillRect(kSpectrumX + 1, kSpectrumY + 1, kSpectrumW - 2, kSpectrumH - 2, kBg);
+  int px = kSpectrumX;
+  int py = kSpectrumY + kSpectrumH - 2;
+  for (size_t i = 0; i < visible_bins; ++i) {
+    const float normalized = std::clamp((levels[first_bin + i] - floor) / 48.0f, 0.0f, 1.0f);
+    const int x = kSpectrumX + static_cast<int>(i * (kSpectrumW - 1) / (visible_bins - 1));
+    const int y = kSpectrumY + kSpectrumH - 2 - static_cast<int>(normalized * (kSpectrumH - 4));
+    if (i) M5.Display.drawLine(px, py, x, y, kGreen);
+    px = x;
+    py = y;
+    const int x0 = static_cast<int>(i * kSpectrumW / visible_bins);
+    const int x1 = static_cast<int>((i + 1) * kSpectrumW / visible_bins);
+    for (int p = x0; p < x1; ++p) g_waterfall_row[p] = waterfall_color(normalized);
+  }
+  const int center = kSpectrumX + kSpectrumW / 2;
+  const int half_filter = std::clamp(static_cast<int>(
+      static_cast<uint64_t>(g_snapshot.filter_bandwidth_hz) * kSpectrumW /
+      (2u * (g_snapshot.span_hz ? g_snapshot.span_hz : 1u))), 3, kSpectrumW / 2 - 2);
+  M5.Display.drawFastVLine(center, kSpectrumY, kSpectrumH, kCyan);
+  M5.Display.drawFastVLine(center - half_filter, kSpectrumY, kSpectrumH, kYellow);
+  M5.Display.drawFastVLine(center + half_filter, kSpectrumY, kSpectrumH, kYellow);
+  M5.Display.scroll(0, -1);
+  M5.Display.pushImage(kSpectrumX, kWaterfallY + kWaterfallH - 2, kSpectrumW, 1,
+                       g_waterfall_row);
+  M5.Display.drawFastVLine(center, kWaterfallY, kWaterfallH, kCyan);
+  M5.Display.endWrite();
+}
+
+Action handle_touch(int32_t x, int32_t y) {
+  if (!g_active) return {};
+  const auto audio_action = audio_header::handle_touch(g_audio_control, x, y, millis());
+  if (audio_action != audio_header::Action::none) {
+    if (audio_action == audio_header::Action::opened || audio_action == audio_header::Action::closed) {
+      audio_header::draw(g_audio_control, g_snapshot.volume, g_snapshot.sound_enabled,
+                         g_snapshot.battery_percent);
+      return {};
+    }
+    if (audio_action == audio_header::Action::volume_down) return {ActionKind::volume_down};
+    if (audio_action == audio_header::Action::sound_toggle) return {ActionKind::sound_toggle};
+    return {ActionKind::volume_up};
+  }
+  if (audio_header::settings_hit(x, y)) return {ActionKind::open_device_settings};
+  if (y >= kTabsY) {
+    const uint8_t next = std::min<uint8_t>(x / kTabW, static_cast<uint8_t>(View::count) - 1);
+    if (next != static_cast<uint8_t>(g_view)) {
+      g_view = static_cast<View>(next);
+      draw();
+    }
+    return {};
+  }
+  if (g_view == View::listen) {
+    if (hit(x, y, 24, 398, 190, 76)) return {ActionKind::step_down};
+    if (hit(x, y, 224, 398, 190, 76)) return {ActionKind::step_up};
+    if (hit(x, y, 424, 398, 190, 76)) return {ActionKind::spacing_toggle};
+    if (hit(x, y, 624, 398, 220, 76)) return {ActionKind::filter_cycle};
+    for (uint32_t i = 0; i < 6; ++i)
+      if (hit(x, y, 24 + static_cast<int>(i) * 166, 494, 154, 70))
+        return {ActionKind::preset_recall, i};
+    if (hit(x, y, 1020, 494, 236, 70)) return {ActionKind::preset_save};
+  } else if (g_view == View::spectrum) {
+    if (hit(x, y, 390, 565, 70, 42)) return {ActionKind::span_down};
+    if (hit(x, y, 820, 565, 70, 42)) return {ActionKind::span_up};
+    if (hit(x, y, kSpectrumX, kSpectrumY, kSpectrumW, kSpectrumH + kWaterfallH + 30)) {
+      const int64_t offset = static_cast<int64_t>(x - (kSpectrumX + kSpectrumW / 2)) *
+                             g_snapshot.span_hz / kSpectrumW;
+      const int64_t selected = static_cast<int64_t>(g_snapshot.frequency_hz) + offset;
+      return {ActionKind::tune_hz, static_cast<uint32_t>(std::clamp<int64_t>(
+          selected, receiver_bands::kAmBroadcast.min_hz, receiver_bands::kAmBroadcast.max_hz))};
+    }
+  } else {
+    if (hit(x, y, 48, 220, 250, 70)) return {ActionKind::sound_toggle};
+    if (hit(x, y, 320, 220, 180, 70)) return {ActionKind::volume_down};
+    if (hit(x, y, 520, 220, 180, 70)) return {ActionKind::volume_up};
+    if (hit(x, y, 48, 310, 310, 70)) return {ActionKind::spacing_toggle};
+    if (hit(x, y, 380, 310, 310, 70)) return {ActionKind::filter_cycle};
+    if (hit(x, y, 48, 400, 310, 70)) return {ActionKind::graphics_toggle};
+    if (hit(x, y, 380, 400, 310, 70)) return {ActionKind::recording_toggle};
+    if (hit(x, y, 720, 220, 512, 70)) return {ActionKind::open_device_settings};
+    if (hit(x, y, 720, 310, 512, 70)) return {ActionKind::exit_home};
+  }
+  return {};
+}
+
+bool active() { return g_active; }
+bool spectrum_active() { return g_active && g_view == View::spectrum; }
+View view() { return g_view; }
+
+void load(NvsStore& store) {
+  g_store = &store;
+  g_saved_frequency = std::clamp(store.get_u32("sdr_am_hz", g_saved_frequency),
+                                 receiver_bands::kAmBroadcast.min_hz,
+                                 receiver_bands::kAmBroadcast.max_hz);
+  const uint32_t step = store.get_u32("sdr_am_step", g_channel_step);
+  g_channel_step = step == 9000 ? 9000 : 10000;
+  g_preset_count = 0;
+  if (store.bytes_length("am_presets") == sizeof(g_presets) &&
+      store.get_bytes("am_presets", g_presets, sizeof(g_presets)) == sizeof(g_presets)) {
+    const uint8_t count = std::min<uint8_t>(store.get_u8("am_preset_count", 0), 6);
+    bool valid = true;
+    for (uint8_t i = 0; i < count; ++i)
+      valid &= g_presets[i] >= receiver_bands::kAmBroadcast.min_hz &&
+               g_presets[i] <= receiver_bands::kAmBroadcast.max_hz;
+    if (valid) g_preset_count = count;
+    else std::fill(std::begin(g_presets), std::end(g_presets), 0u);
+  }
+}
+
+uint32_t saved_frequency() { return g_saved_frequency; }
+uint32_t channel_step() { return g_channel_step; }
+
+void note_tuned(uint32_t frequency_hz) {
+  g_saved_frequency = std::clamp(frequency_hz, receiver_bands::kAmBroadcast.min_hz,
+                                 receiver_bands::kAmBroadcast.max_hz);
+  if (g_store) (void)g_store->put_u32("sdr_am_hz", g_saved_frequency);
+}
+
+uint32_t toggle_channel_step() {
+  g_channel_step = g_channel_step == 10000 ? 9000 : 10000;
+  if (g_store) (void)g_store->put_u32("sdr_am_step", g_channel_step);
+  return g_channel_step;
+}
+
+uint32_t preset(size_t index) { return index < g_preset_count ? g_presets[index] : 0; }
+
+void save_current_preset() {
+  for (size_t i = 0; i < g_preset_count; ++i)
+    if (g_presets[i] == g_saved_frequency) return;
+  const size_t slot = g_preset_count < std::size(g_presets) ? g_preset_count++ : 0;
+  g_presets[slot] = g_saved_frequency;
+  if (!g_store) return;
+  (void)g_store->put_bytes("am_presets", g_presets, sizeof(g_presets));
+  (void)g_store->put_u8("am_preset_count", g_preset_count);
+}
+
+void populate_presets(Snapshot& snapshot) {
+  snapshot.preset_count = g_preset_count;
+  for (size_t i = 0; i < std::size(g_presets); ++i) {
+    snapshot.presets_hz[i] = g_presets[i];
+    if (g_presets[i] == snapshot.frequency_hz) snapshot.selected_preset = static_cast<int8_t>(i);
+  }
+}
+
+bool self_check() {
+  return static_cast<uint8_t>(View::count) == 3 &&
+         receiver_bands::valid(receiver_bands::kAmBroadcast) &&
+         kSpectrumX + kSpectrumW <= 1280 && kTabsY < 720 && audio_header::self_check();
+}
+
+}  // namespace orcsdr::am

--- a/apps/orcsdr-tab5/ui/am_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/am_dashboard.cpp
@@ -8,6 +8,7 @@
 #include <M5Unified.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdio>
 #include <iterator>
@@ -37,6 +38,13 @@ constexpr int kGainAutoW = 190;
 constexpr int kGainSliderX = 280;
 constexpr int kGainSliderY = 525;
 constexpr int kGainSliderW = 900;
+constexpr int kBandwidthSliderX = 720;
+constexpr int kBandwidthSliderY = 438;
+constexpr int kBandwidthSliderW = 500;
+constexpr size_t kPresetsPerPage = 6;
+constexpr size_t kMaxPresets = 160;
+constexpr uint32_t kPresetHoldMs = 700;
+constexpr size_t kScanResultCapacity = 6;
 
 struct GainLayout {
   int auto_x;
@@ -56,9 +64,23 @@ EXT_RAM_BSS_ATTR uint16_t g_waterfall_row[kSpectrumW]{};
 audio_header::Control g_audio_control{};
 NvsStore* g_store = nullptr;
 uint32_t g_saved_frequency = receiver_bands::kAmBroadcast.default_hz;
-uint32_t g_channel_step = receiver_bands::kAmBroadcast.default_step_hz;
-uint32_t g_presets[6]{};
-uint8_t g_preset_count = 0;
+uint32_t g_tune_step = 1000;
+uint32_t g_scan_spacing = receiver_bands::kAmBroadcast.default_step_hz;
+EXT_RAM_BSS_ATTR uint32_t g_presets[kMaxPresets]{};
+uint16_t g_preset_count = 0;
+uint8_t g_preset_page = 0;
+bool g_preset_pressed = false;
+bool g_preset_press_valid = false;
+uint16_t g_pressed_preset = 0;
+uint32_t g_preset_press_ms = 0;
+bool g_preset_modal = false;
+uint16_t g_edit_preset = 0;
+EXT_RAM_BSS_ATTR uint32_t g_scan_results_hz[kScanResultCapacity]{};
+EXT_RAM_BSS_ATTR float g_scan_results_dbfs[kScanResultCapacity]{};
+EXT_RAM_BSS_ATTR bool g_scan_results_selected[kScanResultCapacity]{};
+uint8_t g_scan_result_count = 0;
+std::atomic<bool> g_scan_prompt{false};
+std::atomic<bool> g_scan_prompt_draw_pending{false};
 EXT_RAM_BSS_ATTR float g_scan_sorted[160]{};
 
 struct ScanCandidate {
@@ -68,6 +90,64 @@ struct ScanCandidate {
 
 bool hit(int32_t x, int32_t y, int bx, int by, int bw, int bh) {
   return x >= bx && x < bx + bw && y >= by && y < by + bh;
+}
+
+uint8_t preset_pages() {
+  return static_cast<uint8_t>(std::max<size_t>(
+      1, (g_preset_count + kPresetsPerPage - 1) / kPresetsPerPage));
+}
+
+void persist_presets() {
+  if (!g_store) return;
+  if (g_preset_count)
+    (void)g_store->put_bytes("am_presets", g_presets,
+                             static_cast<size_t>(g_preset_count) * sizeof(g_presets[0]));
+  else
+    (void)g_store->remove("am_presets");
+  (void)g_store->put_u16("am_preset_n", g_preset_count);
+}
+
+bool erase_preset(uint32_t* presets, size_t& count, size_t index) {
+  if (!presets || index >= count) return false;
+  std::move(presets + index + 1, presets + count, presets + index);
+  presets[--count] = 0;
+  return true;
+}
+
+uint32_t bandwidth_for_x(int32_t x) {
+  const int clamped = std::clamp<int32_t>(x, kBandwidthSliderX,
+                                          kBandwidthSliderX + kBandwidthSliderW);
+  const uint32_t hz = 3000u + static_cast<uint32_t>(clamped - kBandwidthSliderX) *
+                                  27000u / kBandwidthSliderW;
+  return ((hz + 500u) / 1000u) * 1000u;
+}
+
+void reset_scan_results() {
+  g_scan_result_count = 0;
+  g_scan_prompt = false;
+  g_scan_prompt_draw_pending = false;
+  std::fill(std::begin(g_scan_results_hz), std::end(g_scan_results_hz), 0u);
+  std::fill(std::begin(g_scan_results_selected), std::end(g_scan_results_selected), false);
+}
+
+uint8_t save_scan_results() {
+  uint8_t added = 0;
+  for (size_t i = 0; i < g_scan_result_count && g_preset_count < std::size(g_presets); ++i) {
+    if (!g_scan_results_selected[i]) continue;
+    const uint32_t frequency_hz = g_scan_results_hz[i];
+    if (std::find(g_presets, g_presets + g_preset_count, frequency_hz) !=
+        g_presets + g_preset_count)
+      continue;
+    g_presets[g_preset_count++] = frequency_hz;
+    ++added;
+  }
+  if (added) {
+    g_preset_page = static_cast<uint8_t>((g_preset_count - 1) / kPresetsPerPage);
+    persist_presets();
+  }
+  g_scan_prompt = false;
+  g_scan_prompt_draw_pending = false;
+  return added;
 }
 
 size_t select_scan_candidates(const float* levels, size_t count,
@@ -107,6 +187,13 @@ void text(const char* value, int x, int y, uint16_t color = TFT_WHITE,
   M5.Display.drawString(value, x, y);
 }
 
+void format_khz(char* value, size_t size, uint32_t frequency_hz) {
+  if (frequency_hz % 1000u == 0)
+    snprintf(value, size, "%lu", static_cast<unsigned long>(frequency_hz / 1000u));
+  else
+    snprintf(value, size, "%.1f", static_cast<double>(frequency_hz) / 1000.0);
+}
+
 void card(int x, int y, int w, int h) {
   M5.Display.fillRoundRect(x, y, w, h, 12, kPanel);
   M5.Display.drawRoundRect(x, y, w, h, 12, kCyan);
@@ -137,7 +224,7 @@ void draw_header() {
 }
 
 void draw_tabs() {
-  static constexpr const char* names[] = {"LISTEN", "SPECTRUM", "SETTINGS"};
+  static constexpr const char* names[] = {"LISTEN", "FINDER", "SPECTRUM", "SETTINGS"};
   for (uint8_t i = 0; i < static_cast<uint8_t>(View::count); ++i) {
     const int x = i * kTabW;
     const bool selected = i == static_cast<uint8_t>(g_view);
@@ -194,25 +281,58 @@ void draw_listen_static() {
   card(24, 150, 820, 230);
   card(860, 150, 396, 230);
   text("RELATIVE SIGNAL", 884, 178, kCyan, 2, top_left);
-  button(24, 398, 190, 76, "STEP -");
-  button(224, 398, 190, 76, "STEP +");
-  button(424, 398, 190, 76, "9 / 10 kHz");
-  button(624, 398, 220, 76, "BANDWIDTH");
-  button(860, 398, 396, 76, "SCAN BAND", kGreen);
+  button(24, 398, 160, 76, "TUNE -");
+  button(194, 398, 160, 76, "TUNE +");
+  button(364, 398, 210, 76, "STEP");
+  text("BANDWIDTH", 600, 420, kCyan, 2, middle_left);
   for (int i = 0; i < 6; ++i) button(24 + i * 166, 494, 154, 70, "EMPTY", kGrid);
   button(1020, 494, 236, 70, "SAVE CURRENT", kGreen);
   text("PRESETS", 24, 582, kCyan, 2, middle_left);
-  text("520–1710 kHz", 1256, 582, kMuted, 2, middle_right);
+  button(710, 570, 70, 48, "<");
+  button(930, 570, 70, 48, ">");
+}
+
+void draw_preset_modal() {
+  if (!g_preset_modal || g_edit_preset >= g_preset_count) return;
+  M5.Display.fillRoundRect(290, 205, 700, 300, 18, kPanel);
+  M5.Display.drawRoundRect(290, 205, 700, 300, 18, TFT_RED);
+  text("EDIT PRESET", 640, 250, TFT_WHITE, 4);
+  char khz[16];
+  char frequency[32];
+  format_khz(khz, sizeof(khz), g_presets[g_edit_preset]);
+  snprintf(frequency, sizeof(frequency), "%s kHz", khz);
+  text(frequency, 640, 310, kYellow, 4);
+  button(320, 400, 200, 70, "CANCEL", kCyan);
+  button(540, 400, 200, 70, "REPLACE", kGreen);
+  button(760, 400, 200, 70, "DELETE", TFT_RED);
+}
+
+void draw_bandwidth_slider() {
+  char value[16];
+  snprintf(value, sizeof(value), "%lu kHz",
+           static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000));
+  text(value, 1220, 410, kGreen, 2, middle_right);
+  M5.Display.fillRoundRect(kBandwidthSliderX, kBandwidthSliderY,
+                           kBandwidthSliderW, 18, 9, kGrid);
+  const int x = kBandwidthSliderX +
+      (static_cast<int>(std::clamp<uint32_t>(g_snapshot.filter_bandwidth_hz, 3000, 30000)) - 3000) *
+          kBandwidthSliderW / 27000;
+  M5.Display.fillRoundRect(kBandwidthSliderX, kBandwidthSliderY,
+                           std::max(9, x - kBandwidthSliderX), 18, 9, kGreen);
+  M5.Display.fillCircle(x, kBandwidthSliderY + 9, 13, kGreen);
+  text("3", kBandwidthSliderX, 468, kMuted, 1);
+  text("30", kBandwidthSliderX + kBandwidthSliderW, 468, kMuted, 1);
 }
 
 void draw_listen_dynamic() {
-  char value[40];
+  char value[48];
   M5.Display.fillRect(45, 175, 775, 180, kPanel);
-  snprintf(value, sizeof(value), "%lu", static_cast<unsigned long>(g_snapshot.frequency_hz / 1000));
+  format_khz(value, sizeof(value), g_snapshot.frequency_hz);
   text(value, 390, 245, TFT_WHITE, 8);
   text("kHz", 690, 260, TFT_WHITE, 4);
-  snprintf(value, sizeof(value), "STEP %lu kHz   BW %lu kHz",
-           static_cast<unsigned long>(g_snapshot.step_hz / 1000),
+  char step[16];
+  format_khz(step, sizeof(step), g_snapshot.step_hz);
+  snprintf(value, sizeof(value), "STEP %s kHz   BW %lu kHz", step,
            static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000));
   text(value, 430, 330, kCyan, 3);
   M5.Display.fillRect(882, 215, 350, 145, kPanel);
@@ -221,27 +341,83 @@ void draw_listen_dynamic() {
            g_snapshot.running ? "RECEIVING" : "STOPPED");
   text(value, 1058, 275, g_snapshot.running ? kGreen : TFT_RED, 2);
   draw_gain_control(true);
-  if (g_snapshot.scan_active) {
-    const unsigned percent = g_snapshot.scan_total
-        ? static_cast<unsigned>(g_snapshot.scan_step) * 100u / g_snapshot.scan_total : 0u;
-    snprintf(value, sizeof(value), "STOP  %lu kHz  %u%%",
-             static_cast<unsigned long>(g_snapshot.scan_frequency_hz / 1000), percent);
-    button(860, 398, 396, 76, value, TFT_RED, true);
-  } else {
-    snprintf(value, sizeof(value), g_snapshot.scan_found ? "SCAN BAND  +%u PRESETS" : "SCAN BAND",
-             g_snapshot.scan_found);
-    button(860, 398, 396, 76, value, kGreen);
-  }
+  snprintf(value, sizeof(value), "STEP %s kHz", step);
+  button(364, 398, 210, 76, value, kCyan);
+  draw_bandwidth_slider();
   for (int i = 0; i < 6; ++i) {
     char preset[20];
-    if (i < g_snapshot.preset_count && g_snapshot.presets_hz[i])
-      snprintf(preset, sizeof(preset), "%lu", static_cast<unsigned long>(g_snapshot.presets_hz[i] / 1000));
-    else
+    if (i < g_snapshot.preset_count && g_snapshot.presets_hz[i]) {
+      format_khz(preset, sizeof(preset), g_snapshot.presets_hz[i]);
+    } else {
       snprintf(preset, sizeof(preset), "EMPTY");
+    }
     button(24 + i * 166, 494, 154, 70, preset,
            i == g_snapshot.selected_preset ? kGreen : kGrid,
            i == g_snapshot.selected_preset);
   }
+  snprintf(value, sizeof(value), "%u/%u  %u SAVED",
+           static_cast<unsigned>(g_snapshot.preset_page + 1),
+           static_cast<unsigned>(g_snapshot.preset_pages),
+           static_cast<unsigned>(g_snapshot.preset_count));
+  button(710, 570, 70, 48, "<", g_snapshot.preset_page ? kCyan : kMuted);
+  M5.Display.fillRect(785, 570, 140, 48, kBg);
+  text(value, 855, 594, kCyan, 2);
+  button(930, 570, 70, 48, ">",
+         g_snapshot.preset_page + 1 < g_snapshot.preset_pages ? kCyan : kMuted);
+}
+
+void draw_finder_static() {
+  card(24, 150, 1232, 450);
+  text("AM STATION FINDER", 48, 174, kCyan, 2, top_left);
+  button(48, 210, 260, 70, "SCAN BAND", kGreen);
+  button(328, 210, 260, 70, "PLAN 10 kHz");
+  text("Scans the full band, ranks signals, then lets you review before saving.",
+       620, 245, TFT_WHITE, 2, middle_left);
+  button(920, 515, 290, 60, "SAVE SELECTED", kGreen);
+  button(610, 515, 290, 60, "DISCARD", TFT_RED);
+}
+
+void draw_finder_dynamic() {
+  char value[64];
+  button(328, 210, 260, 70, g_scan_spacing == 9000 ? "PLAN 9 kHz" : "PLAN 10 kHz");
+  if (g_snapshot.scan_active) {
+    const unsigned percent = g_snapshot.scan_total
+        ? static_cast<unsigned>(g_snapshot.scan_step) * 100u / g_snapshot.scan_total : 0;
+    snprintf(value, sizeof(value), "STOP  %lu kHz  %u%%",
+             static_cast<unsigned long>(g_snapshot.scan_frequency_hz / 1000), percent);
+    button(48, 210, 260, 70, value, TFT_RED, true);
+  } else {
+    button(48, 210, 260, 70, "SCAN BAND", kGreen);
+  }
+  for (size_t i = 0; i < kScanResultCapacity; ++i) {
+    const int x = 48 + static_cast<int>(i % 3) * 390;
+    const int y = 310 + static_cast<int>(i / 3) * 90;
+    if (i < g_scan_result_count) {
+      snprintf(value, sizeof(value), "%s  %lu kHz  %.1f dBFS",
+               g_scan_results_selected[i] ? "[X]" : "[ ]",
+               static_cast<unsigned long>(g_scan_results_hz[i] / 1000),
+               static_cast<double>(g_scan_results_dbfs[i]));
+      button(x, y, 370, 70, value, g_scan_results_selected[i] ? kGreen : kGrid,
+             g_scan_results_selected[i]);
+    } else {
+      button(x, y, 370, 70, "--", kGrid);
+    }
+  }
+}
+
+void draw_scan_prompt() {
+  if (!g_scan_prompt) return;
+  M5.Display.fillRoundRect(250, 190, 780, 350, 18, kPanel);
+  M5.Display.drawRoundRect(250, 190, 780, 350, 18, kGreen);
+  text("SCAN COMPLETE", 640, 245, TFT_WHITE, 4);
+  char value[64];
+  snprintf(value, sizeof(value), "%u strong station%s found",
+           static_cast<unsigned>(g_scan_result_count), g_scan_result_count == 1 ? "" : "s");
+  text(value, 640, 310, kCyan, 3);
+  text("Choose what OrcSDR should do with the results.", 640, 355, TFT_WHITE, 2);
+  button(280, 425, 220, 70, "DISCARD", TFT_RED);
+  button(530, 425, 220, 70, "REVIEW", kCyan);
+  button(780, 425, 220, 70, "SAVE TOP", kGreen);
 }
 
 void draw_spectrum_static() {
@@ -264,10 +440,13 @@ void draw_spectrum_static() {
 void draw_spectrum_dynamic() {
   char value[64];
   M5.Display.fillRect(45, 184, 1190, 58, kPanel);
-  snprintf(value, sizeof(value), "%lu kHz", static_cast<unsigned long>(g_snapshot.frequency_hz / 1000));
+  char frequency[20];
+  format_khz(frequency, sizeof(frequency), g_snapshot.frequency_hz);
+  snprintf(value, sizeof(value), "%s kHz", frequency);
   text(value, 55, 214, TFT_WHITE, 5, middle_left);
-  snprintf(value, sizeof(value), "STEP %lu kHz   BW %lu kHz   SPAN %lu kHz",
-           static_cast<unsigned long>(g_snapshot.step_hz / 1000),
+  char step[16];
+  format_khz(step, sizeof(step), g_snapshot.step_hz);
+  snprintf(value, sizeof(value), "STEP %s kHz   BW %lu kHz   SPAN %lu kHz", step,
            static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000),
            static_cast<unsigned long>(g_snapshot.span_hz / 1000));
   text(value, 1220, 214, kGreen, 3, middle_right);
@@ -280,8 +459,7 @@ void draw_settings_static() {
   button(48, 220, 250, 70, "SOUND", kGreen);
   button(320, 220, 180, 70, "VOL -");
   button(520, 220, 180, 70, "VOL +");
-  button(48, 310, 310, 70, "CHANNEL SPACING");
-  button(380, 310, 310, 70, "FILTER WIDTH");
+  button(48, 310, 310, 70, "TUNING STEP");
   button(48, 400, 310, 70, "SPECTRUM");
   button(380, 400, 310, 70, "RECORD AUDIO", TFT_RED);
   button(720, 220, 512, 70, "DEVICE SETTINGS");
@@ -290,10 +468,12 @@ void draw_settings_static() {
 
 void draw_settings_dynamic() {
   char value[96];
+  char step[16];
+  format_khz(step, sizeof(step), g_snapshot.step_hz);
   M5.Display.fillRect(48, 476, 1184, 112, kPanel);
   draw_gain_control(false);
-  snprintf(value, sizeof(value), "VOL %u   SPACING %lu kHz   BW %lu kHz   GRAPHICS %s   RECORD %s",
-           g_snapshot.volume, static_cast<unsigned long>(g_snapshot.step_hz / 1000),
+  snprintf(value, sizeof(value), "VOL %u   TUNE STEP %s kHz   BW %lu kHz   GRAPHICS %s   RECORD %s",
+           g_snapshot.volume, step,
            static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000),
            g_snapshot.graphics_enabled ? "ON" : "OFF", g_snapshot.recording ? "ON" : "OFF");
   text(value, 640, 572, TFT_WHITE, 2);
@@ -303,6 +483,7 @@ void draw_view() {
   M5.Display.clearScrollRect();
   M5.Display.fillRect(0, kHeaderH, 1280, 720 - kHeaderH, kBg);
   if (g_view == View::listen) draw_listen_static();
+  else if (g_view == View::finder) draw_finder_static();
   else if (g_view == View::spectrum) draw_spectrum_static();
   else draw_settings_static();
   draw_tabs();
@@ -310,8 +491,11 @@ void draw_view() {
 
 void draw_dynamic() {
   if (g_view == View::listen) draw_listen_dynamic();
+  else if (g_view == View::finder) draw_finder_dynamic();
   else if (g_view == View::spectrum) draw_spectrum_dynamic();
   else draw_settings_dynamic();
+  if (g_preset_modal) draw_preset_modal();
+  if (g_scan_prompt) draw_scan_prompt();
 }
 
 uint16_t waterfall_color(float level) {
@@ -328,6 +512,8 @@ void enter(const Snapshot& snapshot) {
   g_snapshot = snapshot;
   g_view = View::listen;
   g_active = true;
+  g_preset_modal = false;
+  g_preset_pressed = false;
   audio_header::reset(g_audio_control);
   draw();
 }
@@ -355,6 +541,11 @@ void update(const Snapshot& snapshot) {
   if (header_changed || audio_header::service_timeout(g_audio_control, now))
     audio_header::draw(g_audio_control, g_snapshot.volume, g_snapshot.sound_enabled,
                        g_snapshot.battery_percent);
+  if (g_scan_prompt) {
+    if (g_scan_prompt_draw_pending.exchange(false)) draw_dynamic();
+    return;
+  }
+  if (g_preset_modal) return;
   if (now - g_last_dynamic_ms < 150) return;
   g_last_dynamic_ms = now;
   draw_dynamic();
@@ -393,6 +584,16 @@ void draw_spectrum(const float* levels, size_t first_bin, size_t visible_bins, f
 
 Action handle_touch(int32_t x, int32_t y) {
   if (!g_active) return {};
+  if (g_scan_prompt) {
+    if (hit(x, y, 280, 425, 220, 70)) reset_scan_results();
+    else if (hit(x, y, 530, 425, 220, 70)) {
+      g_scan_prompt = false;
+      g_view = View::finder;
+    }
+    else if (hit(x, y, 780, 425, 220, 70)) (void)save_scan_results();
+    draw();
+    return {};
+  }
   const auto audio_action = audio_header::handle_touch(g_audio_control, x, y, millis());
   if (audio_action != audio_header::Action::none) {
     if (audio_action == audio_header::Action::opened || audio_action == audio_header::Action::closed) {
@@ -413,19 +614,49 @@ Action handle_touch(int32_t x, int32_t y) {
     }
     return {};
   }
-  const GainLayout layout = gain_layout();
-  if (hit(x, y, layout.auto_x, layout.auto_y, layout.auto_w, layout.auto_h))
-    return {ActionKind::gain_auto};
+  if (g_view != View::finder) {
+    const GainLayout layout = gain_layout();
+    if (hit(x, y, layout.auto_x, layout.auto_y, layout.auto_w, layout.auto_h))
+      return {ActionKind::gain_auto};
+  }
   if (g_view == View::listen) {
-    if (hit(x, y, 24, 398, 190, 76)) return {ActionKind::step_down};
-    if (hit(x, y, 224, 398, 190, 76)) return {ActionKind::step_up};
-    if (hit(x, y, 424, 398, 190, 76)) return {ActionKind::spacing_toggle};
-    if (hit(x, y, 624, 398, 220, 76)) return {ActionKind::filter_cycle};
-    if (hit(x, y, 860, 398, 396, 76)) return {ActionKind::scan_toggle};
-    for (uint32_t i = 0; i < 6; ++i)
-      if (hit(x, y, 24 + static_cast<int>(i) * 166, 494, 154, 70))
-        return {ActionKind::preset_recall, i};
+    if (hit(x, y, 24, 398, 160, 76)) return {ActionKind::step_down};
+    if (hit(x, y, 194, 398, 160, 76)) return {ActionKind::step_up};
+    if (hit(x, y, 364, 398, 210, 76)) return {ActionKind::step_cycle};
     if (hit(x, y, 1020, 494, 236, 70)) return {ActionKind::preset_save};
+    if (hit(x, y, 710, 570, 70, 48) && g_preset_page > 0) {
+      --g_preset_page;
+      populate_presets(g_snapshot);
+      draw();
+    } else if (hit(x, y, 930, 570, 70, 48) && g_preset_page + 1 < preset_pages()) {
+      ++g_preset_page;
+      populate_presets(g_snapshot);
+      draw();
+    }
+  } else if (g_view == View::finder) {
+    if (hit(x, y, 48, 210, 260, 70)) {
+      reset_scan_results();
+      return {ActionKind::scan_toggle};
+    }
+    if (hit(x, y, 328, 210, 260, 70)) return {ActionKind::scan_spacing_toggle};
+    for (size_t i = 0; i < g_scan_result_count; ++i) {
+      const int bx = 48 + static_cast<int>(i % 3) * 390;
+      const int by = 310 + static_cast<int>(i / 3) * 90;
+      if (!hit(x, y, bx, by, 370, 70)) continue;
+      if (x < bx + 70) {
+        g_scan_results_selected[i] = !g_scan_results_selected[i];
+        draw_finder_dynamic();
+        return {};
+      }
+      return {ActionKind::tune_hz, g_scan_results_hz[i]};
+    }
+    if (hit(x, y, 610, 515, 290, 60)) {
+      reset_scan_results();
+      draw();
+    } else if (hit(x, y, 920, 515, 290, 60)) {
+      (void)save_scan_results();
+      draw();
+    }
   } else if (g_view == View::spectrum) {
     if (hit(x, y, 390, 565, 70, 42)) return {ActionKind::span_down};
     if (hit(x, y, 820, 565, 70, 42)) return {ActionKind::span_up};
@@ -440,8 +671,7 @@ Action handle_touch(int32_t x, int32_t y) {
     if (hit(x, y, 48, 220, 250, 70)) return {ActionKind::sound_toggle};
     if (hit(x, y, 320, 220, 180, 70)) return {ActionKind::volume_down};
     if (hit(x, y, 520, 220, 180, 70)) return {ActionKind::volume_up};
-    if (hit(x, y, 48, 310, 310, 70)) return {ActionKind::spacing_toggle};
-    if (hit(x, y, 380, 310, 310, 70)) return {ActionKind::filter_cycle};
+    if (hit(x, y, 48, 310, 310, 70)) return {ActionKind::step_cycle};
     if (hit(x, y, 48, 400, 310, 70)) return {ActionKind::graphics_toggle};
     if (hit(x, y, 380, 400, 310, 70)) return {ActionKind::recording_toggle};
     if (hit(x, y, 720, 220, 512, 70)) return {ActionKind::open_device_settings};
@@ -450,9 +680,67 @@ Action handle_touch(int32_t x, int32_t y) {
   return {};
 }
 
+TouchResult handle_preset_touch(int32_t x, int32_t y, bool pressed, uint32_t now_ms) {
+  if (!g_active || g_view != View::listen) {
+    g_preset_pressed = false;
+    return {};
+  }
+  if (g_preset_modal) {
+    if (pressed && !g_preset_pressed) {
+      g_preset_pressed = true;
+      if (hit(x, y, 320, 400, 200, 70)) {
+        g_preset_modal = false;
+        draw();
+      } else if (hit(x, y, 540, 400, 200, 70)) {
+        g_preset_modal = false;
+        return {{ActionKind::preset_replace, g_edit_preset}, true};
+      } else if (hit(x, y, 760, 400, 200, 70)) {
+        g_preset_modal = false;
+        return {{ActionKind::preset_delete, g_edit_preset}, true};
+      }
+    } else if (!pressed) {
+      g_preset_pressed = false;
+    }
+    return {{}, true};
+  }
+
+  if (pressed && !g_preset_pressed) {
+    for (size_t slot = 0; slot < kPresetsPerPage; ++slot) {
+      if (!hit(x, y, 24 + static_cast<int>(slot) * 166, 494, 154, 70)) continue;
+      g_preset_pressed = true;
+      g_pressed_preset = static_cast<uint16_t>(g_preset_page * kPresetsPerPage + slot);
+      g_preset_press_valid = g_pressed_preset < g_preset_count;
+      g_preset_press_ms = now_ms;
+      return {{}, true};
+    }
+    return {};
+  }
+  if (pressed && g_preset_pressed) {
+    const size_t slot = g_pressed_preset % kPresetsPerPage;
+    if (!hit(x, y, 24 + static_cast<int>(slot) * 166, 494, 154, 70))
+      g_preset_press_valid = false;
+    if (g_preset_press_valid && now_ms - g_preset_press_ms >= kPresetHoldMs) {
+      g_preset_press_valid = false;
+      g_edit_preset = g_pressed_preset;
+      g_preset_modal = true;
+      draw_preset_modal();
+    }
+    return {{}, true};
+  }
+  if (!pressed && g_preset_pressed) {
+    g_preset_pressed = false;
+    if (g_preset_press_valid) {
+      g_preset_press_valid = false;
+      return {{ActionKind::preset_recall, g_pressed_preset}, true};
+    }
+    return {{}, true};
+  }
+  return {};
+}
+
 Action handle_gain_drag(int32_t x, int32_t y) {
   const GainLayout layout = gain_layout();
-  if (!g_active ||
+  if (!g_active || g_view == View::finder ||
       !hit(x, y, layout.slider_x - 14, layout.slider_y - 24, layout.slider_w + 28, 66) ||
       g_snapshot.gain_step_count == 0) return {};
   const int raw_index = static_cast<int>(x - layout.slider_x) *
@@ -464,6 +752,16 @@ Action handle_gain_drag(int32_t x, int32_t y) {
   return {ActionKind::gain_tenth_db, static_cast<uint32_t>(gain)};
 }
 
+Action handle_bandwidth_drag(int32_t x, int32_t y) {
+  if (!g_active || g_view != View::listen ||
+      !hit(x, y, kBandwidthSliderX - 18, kBandwidthSliderY - 24,
+           kBandwidthSliderW + 36, 66))
+    return {};
+  const uint32_t bandwidth_hz = bandwidth_for_x(x);
+  if (bandwidth_hz == g_snapshot.filter_bandwidth_hz) return {};
+  return {ActionKind::filter_bandwidth_hz, bandwidth_hz};
+}
+
 bool active() { return g_active; }
 bool spectrum_active() { return g_active && g_view == View::spectrum; }
 View view() { return g_view; }
@@ -473,14 +771,27 @@ void load(NvsStore& store) {
   g_saved_frequency = std::clamp(store.get_u32("sdr_am_hz", g_saved_frequency),
                                  receiver_bands::kAmBroadcast.min_hz,
                                  receiver_bands::kAmBroadcast.max_hz);
-  const uint32_t step = store.get_u32("sdr_am_step", g_channel_step);
-  g_channel_step = step == 9000 ? 9000 : 10000;
+  const uint32_t stored_tune_step = store.get_u32("am_tune_step", g_tune_step);
+  static constexpr uint32_t tune_steps[] = {100, 500, 1000, 5000, 9000, 10000};
+  g_tune_step = std::find(std::begin(tune_steps), std::end(tune_steps), stored_tune_step) !=
+                        std::end(tune_steps)
+                    ? stored_tune_step
+                    : 1000;
+  const uint32_t spacing = store.get_u32("sdr_am_step", g_scan_spacing);
+  g_scan_spacing = spacing == 9000 ? 9000 : 10000;
   g_preset_count = 0;
-  if (store.bytes_length("am_presets") == sizeof(g_presets) &&
-      store.get_bytes("am_presets", g_presets, sizeof(g_presets)) == sizeof(g_presets)) {
-    const uint8_t count = std::min<uint8_t>(store.get_u8("am_preset_count", 0), 6);
+  g_preset_page = 0;
+  std::fill(std::begin(g_presets), std::end(g_presets), 0u);
+  const size_t stored_bytes = store.bytes_length("am_presets");
+  if (stored_bytes > 0 && stored_bytes <= sizeof(g_presets) &&
+      stored_bytes % sizeof(g_presets[0]) == 0 &&
+      store.get_bytes("am_presets", g_presets, stored_bytes) == stored_bytes) {
+    const uint16_t legacy_count = store.get_u8("am_preset_count", 0);
+    const uint16_t count = std::min<uint16_t>(
+        store.get_u16("am_preset_n", legacy_count),
+        stored_bytes / sizeof(g_presets[0]));
     bool valid = true;
-    for (uint8_t i = 0; i < count; ++i)
+    for (uint16_t i = 0; i < count; ++i)
       valid &= g_presets[i] >= receiver_bands::kAmBroadcast.min_hz &&
                g_presets[i] <= receiver_bands::kAmBroadcast.max_hz;
     if (valid) g_preset_count = count;
@@ -489,7 +800,8 @@ void load(NvsStore& store) {
 }
 
 uint32_t saved_frequency() { return g_saved_frequency; }
-uint32_t channel_step() { return g_channel_step; }
+uint32_t tune_step() { return g_tune_step; }
+uint32_t scan_spacing() { return g_scan_spacing; }
 
 void note_tuned(uint32_t frequency_hz) {
   g_saved_frequency = std::clamp(frequency_hz, receiver_bands::kAmBroadcast.min_hz,
@@ -497,10 +809,20 @@ void note_tuned(uint32_t frequency_hz) {
   if (g_store) (void)g_store->put_u32("sdr_am_hz", g_saved_frequency);
 }
 
-uint32_t toggle_channel_step() {
-  g_channel_step = g_channel_step == 10000 ? 9000 : 10000;
-  if (g_store) (void)g_store->put_u32("sdr_am_step", g_channel_step);
-  return g_channel_step;
+uint32_t cycle_tune_step() {
+  static constexpr uint32_t steps[] = {100, 500, 1000, 5000, 9000, 10000};
+  const auto current = std::find(std::begin(steps), std::end(steps), g_tune_step);
+  g_tune_step = current == std::end(steps) || current + 1 == std::end(steps)
+                    ? steps[0]
+                    : *(current + 1);
+  if (g_store) (void)g_store->put_u32("am_tune_step", g_tune_step);
+  return g_tune_step;
+}
+
+uint32_t toggle_scan_spacing() {
+  g_scan_spacing = g_scan_spacing == 10000 ? 9000 : 10000;
+  if (g_store) (void)g_store->put_u32("sdr_am_step", g_scan_spacing);
+  return g_scan_spacing;
 }
 
 uint32_t preset(size_t index) { return index < g_preset_count ? g_presets[index] : 0; }
@@ -508,36 +830,51 @@ uint32_t preset(size_t index) { return index < g_preset_count ? g_presets[index]
 void save_current_preset() {
   for (size_t i = 0; i < g_preset_count; ++i)
     if (g_presets[i] == g_saved_frequency) return;
-  const size_t slot = g_preset_count < std::size(g_presets) ? g_preset_count++ : 0;
-  g_presets[slot] = g_saved_frequency;
-  if (!g_store) return;
-  (void)g_store->put_bytes("am_presets", g_presets, sizeof(g_presets));
-  (void)g_store->put_u8("am_preset_count", g_preset_count);
+  if (g_preset_count == std::size(g_presets)) return;
+  g_presets[g_preset_count++] = g_saved_frequency;
+  g_preset_page = static_cast<uint8_t>((g_preset_count - 1) / kPresetsPerPage);
+  persist_presets();
 }
 
-bool add_scanned_preset(uint32_t frequency_hz) {
-  for (size_t i = 0; i < g_preset_count; ++i)
-    if (g_presets[i] == frequency_hz) return false;
-  if (g_preset_count == std::size(g_presets)) return false;
-  g_presets[g_preset_count++] = frequency_hz;
-  if (g_store) {
-    (void)g_store->put_bytes("am_presets", g_presets, sizeof(g_presets));
-    (void)g_store->put_u8("am_preset_count", g_preset_count);
-  }
+bool replace_preset(size_t index) {
+  if (index >= g_preset_count) return false;
+  const auto duplicate = std::find(g_presets, g_presets + g_preset_count, g_saved_frequency);
+  if (duplicate != g_presets + g_preset_count &&
+      static_cast<size_t>(duplicate - g_presets) != index)
+    return false;
+  g_presets[index] = g_saved_frequency;
+  persist_presets();
   return true;
 }
 
-uint8_t add_scan_results(uint32_t start_hz, uint32_t step_hz,
-                         const float* levels, size_t count, float* baseline_dbfs) {
-  ScanCandidate candidates[6]{};
+bool delete_preset(size_t index) {
+  size_t count = g_preset_count;
+  if (!erase_preset(g_presets, count, index)) return false;
+  g_preset_count = static_cast<uint16_t>(count);
+  g_preset_page = std::min<uint8_t>(g_preset_page, preset_pages() - 1);
+  persist_presets();
+  return true;
+}
+
+uint8_t prepare_scan_results(uint32_t start_hz, uint32_t step_hz,
+                             const float* levels, size_t count, float* baseline_dbfs) {
+  ScanCandidate candidates[kScanResultCapacity]{};
   const size_t found = select_scan_candidates(levels, count, candidates,
                                                std::size(candidates), baseline_dbfs);
-  uint8_t added = 0;
-  for (size_t i = 0; i < found; ++i)
-    if (add_scanned_preset(start_hz + static_cast<uint32_t>(candidates[i].index) * step_hz))
-      ++added;
-  return added;
+  reset_scan_results();
+  g_scan_result_count = static_cast<uint8_t>(found);
+  for (size_t i = 0; i < found; ++i) {
+    g_scan_results_hz[i] =
+        start_hz + static_cast<uint32_t>(candidates[i].index) * step_hz;
+    g_scan_results_dbfs[i] = candidates[i].level;
+    g_scan_results_selected[i] = true;
+  }
+  g_scan_prompt = true;
+  g_scan_prompt_draw_pending = true;
+  return g_scan_result_count;
 }
+
+void clear_scan_results() { reset_scan_results(); }
 
 bool auto_gain_should_advance(float level_dbfs, size_t step, size_t step_count) {
   return step + 1 < step_count && level_dbfs < kAutoGainTargetDbfs;
@@ -545,9 +882,16 @@ bool auto_gain_should_advance(float level_dbfs, size_t step, size_t step_count) 
 
 void populate_presets(Snapshot& snapshot) {
   snapshot.preset_count = g_preset_count;
-  for (size_t i = 0; i < std::size(g_presets); ++i) {
-    snapshot.presets_hz[i] = g_presets[i];
-    if (g_presets[i] == snapshot.frequency_hz) snapshot.selected_preset = static_cast<int8_t>(i);
+  g_preset_page = std::min<uint8_t>(g_preset_page, preset_pages() - 1);
+  snapshot.preset_page = g_preset_page;
+  snapshot.preset_pages = preset_pages();
+  snapshot.selected_preset = -1;
+  const size_t first = static_cast<size_t>(g_preset_page) * kPresetsPerPage;
+  for (size_t i = 0; i < kPresetsPerPage; ++i) {
+    const size_t index = first + i;
+    snapshot.presets_hz[i] = index < g_preset_count ? g_presets[index] : 0;
+    if (snapshot.presets_hz[i] == snapshot.frequency_hz)
+      snapshot.selected_preset = static_cast<int8_t>(i);
   }
 }
 
@@ -555,7 +899,9 @@ bool self_check() {
   const float scan_levels[] = {-80.0f, -70.0f, -80.0f, -60.0f, -80.0f};
   ScanCandidate candidates[2]{};
   float baseline = 0.0f;
-  return static_cast<uint8_t>(View::count) == 3 &&
+  uint32_t presets[] = {590000, 1050000, 1280000};
+  size_t preset_count = std::size(presets);
+  return static_cast<uint8_t>(View::count) == 4 &&
          receiver_bands::valid(receiver_bands::kAmBroadcast) &&
          kSpectrumX + kSpectrumW <= 1280 && kGainSliderX + kGainSliderW <= 1280 &&
          kTabsY < 720 && audio_header::self_check() &&
@@ -564,7 +910,11 @@ bool self_check() {
           baseline == -80.0f && candidates[0].index == 1 && candidates[1].index == 3 &&
           auto_gain_should_advance(-30.0f, 0, 3) &&
           !auto_gain_should_advance(kAutoGainTargetDbfs, 0, 3) &&
-          !auto_gain_should_advance(-30.0f, 2, 3);
+          !auto_gain_should_advance(-30.0f, 2, 3) &&
+          bandwidth_for_x(kBandwidthSliderX) == 3000 &&
+          bandwidth_for_x(kBandwidthSliderX + kBandwidthSliderW) == 30000 &&
+          erase_preset(presets, preset_count, 1) && preset_count == 2 &&
+          presets[0] == 590000 && presets[1] == 1280000 && presets[2] == 0;
 }
 
 }  // namespace orcsdr::am

--- a/apps/orcsdr-tab5/ui/am_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/am_dashboard.cpp
@@ -578,7 +578,6 @@ void draw_spectrum(const float* levels, size_t first_bin, size_t visible_bins, f
   M5.Display.scroll(0, -1);
   M5.Display.pushImage(kSpectrumX, kWaterfallY + kWaterfallH - 2, kSpectrumW, 1,
                        g_waterfall_row);
-  M5.Display.drawFastVLine(center, kWaterfallY, kWaterfallH, kCyan);
   M5.Display.endWrite();
 }
 

--- a/apps/orcsdr-tab5/ui/am_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/am_dashboard.cpp
@@ -31,6 +31,22 @@ constexpr int kSpectrumW = 1188;
 constexpr int kSpectrumH = 145;
 constexpr int kWaterfallY = 420;
 constexpr int kWaterfallH = 130;
+constexpr int kGainAutoX = 48;
+constexpr int kGainAutoY = 486;
+constexpr int kGainAutoW = 190;
+constexpr int kGainSliderX = 280;
+constexpr int kGainSliderY = 525;
+constexpr int kGainSliderW = 900;
+
+struct GainLayout {
+  int auto_x;
+  int auto_y;
+  int auto_w;
+  int auto_h;
+  int slider_x;
+  int slider_y;
+  int slider_w;
+};
 
 Snapshot g_snapshot{};
 View g_view = View::listen;
@@ -43,9 +59,44 @@ uint32_t g_saved_frequency = receiver_bands::kAmBroadcast.default_hz;
 uint32_t g_channel_step = receiver_bands::kAmBroadcast.default_step_hz;
 uint32_t g_presets[6]{};
 uint8_t g_preset_count = 0;
+EXT_RAM_BSS_ATTR float g_scan_sorted[160]{};
+
+struct ScanCandidate {
+  size_t index;
+  float level;
+};
 
 bool hit(int32_t x, int32_t y, int bx, int by, int bw, int bh) {
   return x >= bx && x < bx + bw && y >= by && y < by + bh;
+}
+
+size_t select_scan_candidates(const float* levels, size_t count,
+                              ScanCandidate* candidates, size_t capacity,
+                              float* baseline_dbfs) {
+  if (!levels || !candidates || !count || count > std::size(g_scan_sorted)) return 0;
+  std::copy_n(levels, count, g_scan_sorted);
+  std::nth_element(g_scan_sorted, g_scan_sorted + count / 2, g_scan_sorted + count);
+  const float baseline = g_scan_sorted[count / 2];
+  if (baseline_dbfs) *baseline_dbfs = baseline;
+  size_t found = 0;
+  for (size_t i = 0; i < count; ++i) {
+    const float level = levels[i];
+    const float left = i ? levels[i - 1] : baseline;
+    const float right = i + 1 < count ? levels[i + 1] : baseline;
+    // ponytail: local-prominence heuristic; add audio validation if RF-only scans prove noisy.
+    if (level < baseline + 3.0f || level < left + 1.0f || level < right + 1.0f) continue;
+    size_t slot = found;
+    if (slot < capacity) ++found;
+    else if (level <= candidates[slot = capacity - 1].level) continue;
+    while (slot > 0 && level > candidates[slot - 1].level) {
+      if (slot < capacity) candidates[slot] = candidates[slot - 1];
+      --slot;
+    }
+    candidates[slot] = {i, level};
+  }
+  std::sort(candidates, candidates + found,
+            [](const ScanCandidate& a, const ScanCandidate& b) { return a.index < b.index; });
+  return found;
 }
 
 void text(const char* value, int x, int y, uint16_t color = TFT_WHITE,
@@ -106,6 +157,39 @@ void draw_meter(int x, int y, int w, float dbfs) {
                         i < lit ? (i >= 14 ? kYellow : kGreen) : kGrid);
 }
 
+GainLayout gain_layout() {
+  if (g_view == View::listen) return {1128, 304, 86, 42, 884, 338, 220};
+  if (g_view == View::spectrum) return {928, 561, 82, 44, 1024, 584, 190};
+  return {kGainAutoX, kGainAutoY, kGainAutoW, 70,
+          kGainSliderX, kGainSliderY, kGainSliderW};
+}
+
+void draw_gain_control(bool compact) {
+  const GainLayout layout = gain_layout();
+  char value[24];
+  if (g_snapshot.gain_auto)
+    snprintf(value, sizeof(value), g_snapshot.gain_auto_selecting ? "AUTO..." : "AUTO %.1f",
+             static_cast<double>(g_snapshot.gain_tenth_db) / 10.0);
+  else
+    snprintf(value, sizeof(value), "%.1f dB",
+             static_cast<double>(g_snapshot.gain_tenth_db) / 10.0);
+  button(layout.auto_x, layout.auto_y, layout.auto_w, layout.auto_h, "AUTO", kGreen,
+         g_snapshot.gain_auto);
+  text(compact ? "GAIN" : "RF GAIN", layout.slider_x,
+       layout.slider_y - (compact ? 15 : 33), kCyan, 2, middle_left);
+  text(value, layout.slider_x + layout.slider_w,
+       layout.slider_y - (compact ? 15 : 33),
+       g_snapshot.gain_auto ? kGreen : TFT_WHITE, 2, middle_right);
+  M5.Display.fillRoundRect(layout.slider_x, layout.slider_y, layout.slider_w, 18, 9, kGrid);
+  const int gain_x = layout.slider_x + std::clamp(g_snapshot.gain_tenth_db, 0, 496) *
+                                         layout.slider_w / 496;
+  if (!g_snapshot.gain_auto)
+    M5.Display.fillRoundRect(layout.slider_x, layout.slider_y,
+                             std::max(9, gain_x - layout.slider_x), 18, 9, kGreen);
+  M5.Display.fillCircle(gain_x, layout.slider_y + 9, compact ? 11 : 14,
+                        g_snapshot.gain_auto ? kMuted : kGreen);
+}
+
 void draw_listen_static() {
   card(24, 150, 820, 230);
   card(860, 150, 396, 230);
@@ -114,6 +198,7 @@ void draw_listen_static() {
   button(224, 398, 190, 76, "STEP +");
   button(424, 398, 190, 76, "9 / 10 kHz");
   button(624, 398, 220, 76, "BANDWIDTH");
+  button(860, 398, 396, 76, "SCAN BAND", kGreen);
   for (int i = 0; i < 6; ++i) button(24 + i * 166, 494, 154, 70, "EMPTY", kGrid);
   button(1020, 494, 236, 70, "SAVE CURRENT", kGreen);
   text("PRESETS", 24, 582, kCyan, 2, middle_left);
@@ -130,11 +215,23 @@ void draw_listen_dynamic() {
            static_cast<unsigned long>(g_snapshot.step_hz / 1000),
            static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000));
   text(value, 430, 330, kCyan, 3);
-  M5.Display.fillRect(882, 215, 350, 130, kPanel);
+  M5.Display.fillRect(882, 215, 350, 145, kPanel);
   draw_meter(884, 220, 330, g_snapshot.relative_dbfs);
   snprintf(value, sizeof(value), "%.1f dBFS  %s", static_cast<double>(g_snapshot.relative_dbfs),
            g_snapshot.running ? "RECEIVING" : "STOPPED");
-  text(value, 1058, 295, g_snapshot.running ? kGreen : TFT_RED, 3);
+  text(value, 1058, 275, g_snapshot.running ? kGreen : TFT_RED, 2);
+  draw_gain_control(true);
+  if (g_snapshot.scan_active) {
+    const unsigned percent = g_snapshot.scan_total
+        ? static_cast<unsigned>(g_snapshot.scan_step) * 100u / g_snapshot.scan_total : 0u;
+    snprintf(value, sizeof(value), "STOP  %lu kHz  %u%%",
+             static_cast<unsigned long>(g_snapshot.scan_frequency_hz / 1000), percent);
+    button(860, 398, 396, 76, value, TFT_RED, true);
+  } else {
+    snprintf(value, sizeof(value), g_snapshot.scan_found ? "SCAN BAND  +%u PRESETS" : "SCAN BAND",
+             g_snapshot.scan_found);
+    button(860, 398, 396, 76, value, kGreen);
+  }
   for (int i = 0; i < 6; ++i) {
     char preset[20];
     if (i < g_snapshot.preset_count && g_snapshot.presets_hz[i])
@@ -161,7 +258,7 @@ void draw_spectrum_static() {
   button(390, 565, 70, 42, "-");
   button(820, 565, 70, 42, "+");
   text("SPAN", 55, 585, kCyan, 2, middle_left);
-  text("TAP SPECTRUM TO TUNE", 1040, 585, TFT_WHITE, 2);
+  text("TAP TO TUNE", 720, 585, TFT_WHITE, 2);
 }
 
 void draw_spectrum_dynamic() {
@@ -174,6 +271,7 @@ void draw_spectrum_dynamic() {
            static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000),
            static_cast<unsigned long>(g_snapshot.span_hz / 1000));
   text(value, 1220, 214, kGreen, 3, middle_right);
+  draw_gain_control(true);
 }
 
 void draw_settings_static() {
@@ -188,17 +286,17 @@ void draw_settings_static() {
   button(380, 400, 310, 70, "RECORD AUDIO", TFT_RED);
   button(720, 220, 512, 70, "DEVICE SETTINGS");
   button(720, 310, 512, 70, "HOME", kGreen, true);
-  text("AM keeps playing while controls are adjusted", 976, 445, kMuted, 2);
 }
 
 void draw_settings_dynamic() {
   char value[96];
-  M5.Display.fillRect(48, 500, 1184, 70, kPanel);
+  M5.Display.fillRect(48, 476, 1184, 112, kPanel);
+  draw_gain_control(false);
   snprintf(value, sizeof(value), "VOL %u   SPACING %lu kHz   BW %lu kHz   GRAPHICS %s   RECORD %s",
            g_snapshot.volume, static_cast<unsigned long>(g_snapshot.step_hz / 1000),
            static_cast<unsigned long>(g_snapshot.filter_bandwidth_hz / 1000),
            g_snapshot.graphics_enabled ? "ON" : "OFF", g_snapshot.recording ? "ON" : "OFF");
-  text(value, 640, 535, TFT_WHITE, 2);
+  text(value, 640, 572, TFT_WHITE, 2);
 }
 
 void draw_view() {
@@ -315,11 +413,15 @@ Action handle_touch(int32_t x, int32_t y) {
     }
     return {};
   }
+  const GainLayout layout = gain_layout();
+  if (hit(x, y, layout.auto_x, layout.auto_y, layout.auto_w, layout.auto_h))
+    return {ActionKind::gain_auto};
   if (g_view == View::listen) {
     if (hit(x, y, 24, 398, 190, 76)) return {ActionKind::step_down};
     if (hit(x, y, 224, 398, 190, 76)) return {ActionKind::step_up};
     if (hit(x, y, 424, 398, 190, 76)) return {ActionKind::spacing_toggle};
     if (hit(x, y, 624, 398, 220, 76)) return {ActionKind::filter_cycle};
+    if (hit(x, y, 860, 398, 396, 76)) return {ActionKind::scan_toggle};
     for (uint32_t i = 0; i < 6; ++i)
       if (hit(x, y, 24 + static_cast<int>(i) * 166, 494, 154, 70))
         return {ActionKind::preset_recall, i};
@@ -346,6 +448,20 @@ Action handle_touch(int32_t x, int32_t y) {
     if (hit(x, y, 720, 310, 512, 70)) return {ActionKind::exit_home};
   }
   return {};
+}
+
+Action handle_gain_drag(int32_t x, int32_t y) {
+  const GainLayout layout = gain_layout();
+  if (!g_active ||
+      !hit(x, y, layout.slider_x - 14, layout.slider_y - 24, layout.slider_w + 28, 66) ||
+      g_snapshot.gain_step_count == 0) return {};
+  const int raw_index = static_cast<int>(x - layout.slider_x) *
+                        static_cast<int>(g_snapshot.gain_step_count) / layout.slider_w;
+  const size_t index = static_cast<size_t>(std::clamp(
+      raw_index, 0, static_cast<int>(g_snapshot.gain_step_count) - 1));
+  const int gain = g_snapshot.gain_steps_tenth_db[index];
+  if (!g_snapshot.gain_auto && gain == g_snapshot.gain_tenth_db) return {};
+  return {ActionKind::gain_tenth_db, static_cast<uint32_t>(gain)};
 }
 
 bool active() { return g_active; }
@@ -399,6 +515,34 @@ void save_current_preset() {
   (void)g_store->put_u8("am_preset_count", g_preset_count);
 }
 
+bool add_scanned_preset(uint32_t frequency_hz) {
+  for (size_t i = 0; i < g_preset_count; ++i)
+    if (g_presets[i] == frequency_hz) return false;
+  if (g_preset_count == std::size(g_presets)) return false;
+  g_presets[g_preset_count++] = frequency_hz;
+  if (g_store) {
+    (void)g_store->put_bytes("am_presets", g_presets, sizeof(g_presets));
+    (void)g_store->put_u8("am_preset_count", g_preset_count);
+  }
+  return true;
+}
+
+uint8_t add_scan_results(uint32_t start_hz, uint32_t step_hz,
+                         const float* levels, size_t count, float* baseline_dbfs) {
+  ScanCandidate candidates[6]{};
+  const size_t found = select_scan_candidates(levels, count, candidates,
+                                               std::size(candidates), baseline_dbfs);
+  uint8_t added = 0;
+  for (size_t i = 0; i < found; ++i)
+    if (add_scanned_preset(start_hz + static_cast<uint32_t>(candidates[i].index) * step_hz))
+      ++added;
+  return added;
+}
+
+bool auto_gain_should_advance(float level_dbfs, size_t step, size_t step_count) {
+  return step + 1 < step_count && level_dbfs < kAutoGainTargetDbfs;
+}
+
 void populate_presets(Snapshot& snapshot) {
   snapshot.preset_count = g_preset_count;
   for (size_t i = 0; i < std::size(g_presets); ++i) {
@@ -408,9 +552,19 @@ void populate_presets(Snapshot& snapshot) {
 }
 
 bool self_check() {
+  const float scan_levels[] = {-80.0f, -70.0f, -80.0f, -60.0f, -80.0f};
+  ScanCandidate candidates[2]{};
+  float baseline = 0.0f;
   return static_cast<uint8_t>(View::count) == 3 &&
          receiver_bands::valid(receiver_bands::kAmBroadcast) &&
-         kSpectrumX + kSpectrumW <= 1280 && kTabsY < 720 && audio_header::self_check();
+         kSpectrumX + kSpectrumW <= 1280 && kGainSliderX + kGainSliderW <= 1280 &&
+         kTabsY < 720 && audio_header::self_check() &&
+          select_scan_candidates(scan_levels, std::size(scan_levels), candidates,
+                                 std::size(candidates), &baseline) == 2 &&
+          baseline == -80.0f && candidates[0].index == 1 && candidates[1].index == 3 &&
+          auto_gain_should_advance(-30.0f, 0, 3) &&
+          !auto_gain_should_advance(kAutoGainTargetDbfs, 0, 3) &&
+          !auto_gain_should_advance(-30.0f, 2, 3);
 }
 
 }  // namespace orcsdr::am

--- a/apps/orcsdr-tab5/ui/am_dashboard.hpp
+++ b/apps/orcsdr-tab5/ui/am_dashboard.hpp
@@ -7,7 +7,7 @@ namespace orcsdr { class NvsStore; }
 
 namespace orcsdr::am {
 
-enum class View : uint8_t { listen, spectrum, settings, count };
+enum class View : uint8_t { listen, finder, spectrum, settings, count };
 
 struct Snapshot {
   uint32_t frequency_hz = 1000000;
@@ -22,7 +22,9 @@ struct Snapshot {
   bool graphics_enabled = true;
   bool recording = false;
   uint8_t volume = 0;
-  uint8_t preset_count = 0;
+  uint16_t preset_count = 0;
+  uint8_t preset_page = 0;
+  uint8_t preset_pages = 1;
   bool gain_auto = true;
   bool gain_auto_selecting = false;
   int gain_tenth_db = 0;
@@ -42,12 +44,15 @@ enum class ActionKind : uint8_t {
   tune_hz,
   step_down,
   step_up,
-  spacing_toggle,
-  filter_cycle,
+  step_cycle,
+  scan_spacing_toggle,
+  filter_bandwidth_hz,
   span_down,
   span_up,
   preset_recall,
   preset_save,
+  preset_replace,
+  preset_delete,
   sound_toggle,
   volume_down,
   volume_up,
@@ -65,26 +70,37 @@ struct Action {
   uint32_t value = 0;
 };
 
+struct TouchResult {
+  Action action{};
+  bool consumed = false;
+};
+
 void enter(const Snapshot& snapshot);
 void leave();
 void draw();
 void update(const Snapshot& snapshot);
 void draw_spectrum(const float* levels, size_t first_bin, size_t visible_bins, float floor);
 Action handle_touch(int32_t x, int32_t y);
+TouchResult handle_preset_touch(int32_t x, int32_t y, bool pressed, uint32_t now_ms);
 Action handle_gain_drag(int32_t x, int32_t y);
+Action handle_bandwidth_drag(int32_t x, int32_t y);
 bool active();
 bool spectrum_active();
 View view();
 void load(NvsStore& store);
 uint32_t saved_frequency();
-uint32_t channel_step();
+uint32_t tune_step();
+uint32_t scan_spacing();
 void note_tuned(uint32_t frequency_hz);
-uint32_t toggle_channel_step();
+uint32_t cycle_tune_step();
+uint32_t toggle_scan_spacing();
 uint32_t preset(size_t index);
 void save_current_preset();
-bool add_scanned_preset(uint32_t frequency_hz);
-uint8_t add_scan_results(uint32_t start_hz, uint32_t step_hz,
-                         const float* levels, size_t count, float* baseline_dbfs);
+bool replace_preset(size_t index);
+bool delete_preset(size_t index);
+uint8_t prepare_scan_results(uint32_t start_hz, uint32_t step_hz,
+                             const float* levels, size_t count, float* baseline_dbfs);
+void clear_scan_results();
 constexpr float kAutoGainTargetDbfs = -24.0f;
 bool auto_gain_should_advance(float level_dbfs, size_t step, size_t step_count);
 void populate_presets(Snapshot& snapshot);

--- a/apps/orcsdr-tab5/ui/am_dashboard.hpp
+++ b/apps/orcsdr-tab5/ui/am_dashboard.hpp
@@ -23,6 +23,16 @@ struct Snapshot {
   bool recording = false;
   uint8_t volume = 0;
   uint8_t preset_count = 0;
+  bool gain_auto = true;
+  bool gain_auto_selecting = false;
+  int gain_tenth_db = 0;
+  int gain_steps_tenth_db[32]{};
+  uint8_t gain_step_count = 0;
+  bool scan_active = false;
+  uint16_t scan_step = 0;
+  uint16_t scan_total = 1;
+  uint8_t scan_found = 0;
+  uint32_t scan_frequency_hz = 0;
   int8_t selected_preset = -1;
   int32_t battery_percent = -1;
 };
@@ -43,6 +53,9 @@ enum class ActionKind : uint8_t {
   volume_up,
   graphics_toggle,
   recording_toggle,
+  gain_auto,
+  gain_tenth_db,
+  scan_toggle,
   open_device_settings,
   exit_home,
 };
@@ -58,6 +71,7 @@ void draw();
 void update(const Snapshot& snapshot);
 void draw_spectrum(const float* levels, size_t first_bin, size_t visible_bins, float floor);
 Action handle_touch(int32_t x, int32_t y);
+Action handle_gain_drag(int32_t x, int32_t y);
 bool active();
 bool spectrum_active();
 View view();
@@ -68,6 +82,11 @@ void note_tuned(uint32_t frequency_hz);
 uint32_t toggle_channel_step();
 uint32_t preset(size_t index);
 void save_current_preset();
+bool add_scanned_preset(uint32_t frequency_hz);
+uint8_t add_scan_results(uint32_t start_hz, uint32_t step_hz,
+                         const float* levels, size_t count, float* baseline_dbfs);
+constexpr float kAutoGainTargetDbfs = -24.0f;
+bool auto_gain_should_advance(float level_dbfs, size_t step, size_t step_count);
 void populate_presets(Snapshot& snapshot);
 bool self_check();
 

--- a/apps/orcsdr-tab5/ui/am_dashboard.hpp
+++ b/apps/orcsdr-tab5/ui/am_dashboard.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace orcsdr { class NvsStore; }
+
+namespace orcsdr::am {
+
+enum class View : uint8_t { listen, spectrum, settings, count };
+
+struct Snapshot {
+  uint32_t frequency_hz = 1000000;
+  uint32_t step_hz = 10000;
+  uint32_t filter_bandwidth_hz = 10000;
+  uint32_t span_hz = 480000;
+  uint32_t presets_hz[6]{};
+  float relative_dbfs = -90.0f;
+  bool running = false;
+  bool driver_ready = false;
+  bool sound_enabled = true;
+  bool graphics_enabled = true;
+  bool recording = false;
+  uint8_t volume = 0;
+  uint8_t preset_count = 0;
+  int8_t selected_preset = -1;
+  int32_t battery_percent = -1;
+};
+
+enum class ActionKind : uint8_t {
+  none,
+  tune_hz,
+  step_down,
+  step_up,
+  spacing_toggle,
+  filter_cycle,
+  span_down,
+  span_up,
+  preset_recall,
+  preset_save,
+  sound_toggle,
+  volume_down,
+  volume_up,
+  graphics_toggle,
+  recording_toggle,
+  open_device_settings,
+  exit_home,
+};
+
+struct Action {
+  ActionKind kind = ActionKind::none;
+  uint32_t value = 0;
+};
+
+void enter(const Snapshot& snapshot);
+void leave();
+void draw();
+void update(const Snapshot& snapshot);
+void draw_spectrum(const float* levels, size_t first_bin, size_t visible_bins, float floor);
+Action handle_touch(int32_t x, int32_t y);
+bool active();
+bool spectrum_active();
+View view();
+void load(NvsStore& store);
+uint32_t saved_frequency();
+uint32_t channel_step();
+void note_tuned(uint32_t frequency_hz);
+uint32_t toggle_channel_step();
+uint32_t preset(size_t index);
+void save_current_preset();
+void populate_presets(Snapshot& snapshot);
+bool self_check();
+
+}  // namespace orcsdr::am

--- a/apps/orcsdr-tab5/ui/am_finder.cpp
+++ b/apps/orcsdr-tab5/ui/am_finder.cpp
@@ -75,7 +75,7 @@ bool start(uint32_t spacing_hz) {
   if ((spacing_hz != 9000 && spacing_hz != 10000) || !rf_analysis::initialize())
     return false;
   g_latest = {};
-  (void)rf_analysis::copy_snapshot(&g_latest);
+  if (!rf_analysis::copy_snapshot(&g_latest)) return false;
   rf_analysis::Config config{};
   config.center_hz = kCenterHz;
   config.span_hz = kSampleRateSps;

--- a/apps/orcsdr-tab5/ui/am_finder.cpp
+++ b/apps/orcsdr-tab5/ui/am_finder.cpp
@@ -1,0 +1,180 @@
+#include "am_finder.hpp"
+
+#include "rf_analysis.hpp"
+
+#include <esp_attr.h>
+#include <esp_timer.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <iterator>
+
+namespace orcsdr::am_finder {
+namespace {
+
+// Snapshot retains 1024 bins; two FFT bins per output preserve peak detection
+// without the multi-second 8192-point PSRAM FFT latency on Tab5.
+constexpr uint16_t kFftSize = 2048;
+constexpr uint32_t kMinimumCaptureMs = 1500;
+constexpr uint32_t kPreferredFrames = 8;
+constexpr uint32_t kSlowAnalyzerMs = 3000;
+constexpr uint32_t kFailureMs = 4000;
+constexpr uint32_t kStartFailureMs = 8000;
+
+std::atomic<bool> g_active{false};
+uint32_t g_spacing_hz = 10000;
+uint32_t g_started_ms = 0;
+std::atomic<uint32_t> g_capture_started_ms{0};
+uint32_t g_start_frame = 0;
+uint32_t g_start_drops = 0;
+uint32_t g_last_poll_ms = 0;
+EXT_RAM_BSS_ATTR rf_analysis::Snapshot g_latest{};
+
+uint32_t now_ms() {
+  return static_cast<uint32_t>(esp_timer_get_time() / 1000);
+}
+
+size_t channel_count(uint32_t spacing_hz) {
+  const uint32_t start_hz = spacing_hz == 9000 ? 531000u : kMinHz;
+  return (kMaxHz - start_hz) / spacing_hz + 1;
+}
+
+bool extract_grid_levels(const rf_analysis::Snapshot& snapshot, uint32_t spacing_hz,
+                         float* levels, size_t capacity, size_t* count) {
+  if (!levels || !count || (spacing_hz != 9000 && spacing_hz != 10000) ||
+      snapshot.bins < 32 || !snapshot.span_hz) return false;
+  const size_t needed = channel_count(spacing_hz);
+  if (needed > capacity) return false;
+  const uint32_t start_hz = spacing_hz == 9000 ? 531000u : kMinHz;
+  const double low_hz = static_cast<double>(snapshot.center_hz) - snapshot.span_hz / 2.0;
+  const double bin_hz = static_cast<double>(snapshot.span_hz) / snapshot.bins;
+  for (size_t channel = 0; channel < needed; ++channel) {
+    const double frequency_hz = start_hz + channel * static_cast<double>(spacing_hz);
+    const long nearest = lround((frequency_hz - low_hz) / bin_hz);
+    float strongest = -160.0f;
+    for (long offset = -1; offset <= 1; ++offset) {
+      const long bin = nearest + offset;
+      if (bin >= 0 && bin < snapshot.bins)
+        strongest = std::max(strongest, snapshot.average[bin]);
+    }
+    levels[channel] = strongest;
+  }
+  *count = needed;
+  return true;
+}
+
+void stop_analysis() {
+  g_active.store(false, std::memory_order_release);
+  rf_analysis::set_enabled(false);
+}
+
+}  // namespace
+
+bool start(uint32_t spacing_hz) {
+  if ((spacing_hz != 9000 && spacing_hz != 10000) || !rf_analysis::initialize())
+    return false;
+  g_latest = {};
+  (void)rf_analysis::copy_snapshot(&g_latest);
+  rf_analysis::Config config{};
+  config.center_hz = kCenterHz;
+  config.span_hz = kSampleRateSps;
+  config.sample_rate_sps = kSampleRateSps;
+  config.measurement_bandwidth_hz = kMaxHz - kMinHz;
+  config.fft_size = kFftSize;
+  config.interval_ms = 75;
+  rf_analysis::set_config(config);
+  rf_analysis::clear_average();
+  rf_analysis::clear_peak();
+  g_spacing_hz = spacing_hz;
+  g_start_frame = g_latest.frame_count;
+  g_start_drops = g_latest.input_drops;
+  g_started_ms = now_ms();
+  g_capture_started_ms.store(0, std::memory_order_release);
+  g_last_poll_ms = 0;
+  g_latest = {};
+  g_active.store(true, std::memory_order_release);
+  rf_analysis::set_enabled(true);
+  return true;
+}
+
+bool active() { return g_active.load(std::memory_order_acquire); }
+
+void offer_iq(const uint8_t* iq, size_t bytes, uint32_t sample_rate_sps) {
+  if (!active()) return;
+  if (sample_rate_sps != kSampleRateSps) return;
+  uint32_t not_started = 0;
+  (void)g_capture_started_ms.compare_exchange_strong(
+      not_started, now_ms(), std::memory_order_acq_rel);
+  rf_analysis::offer_iq(iq, bytes);
+}
+
+Poll poll() {
+  if (!active()) return Poll::failed;
+  const uint32_t now = now_ms();
+  const uint32_t capture_started = g_capture_started_ms.load(std::memory_order_acquire);
+  if (!capture_started)
+    return now - g_started_ms >= kStartFailureMs ? Poll::failed : Poll::collecting;
+  const uint32_t elapsed = now - capture_started;
+  if (elapsed < kMinimumCaptureMs || now - g_last_poll_ms < 100) return Poll::collecting;
+  g_last_poll_ms = now;
+  if (rf_analysis::copy_snapshot(&g_latest) &&
+      g_latest.center_hz == kCenterHz && g_latest.sample_rate_sps == kSampleRateSps) {
+    const uint32_t frames = g_latest.frame_count - g_start_frame;
+    if (frames >= kPreferredFrames || (frames > 0 && elapsed >= kSlowAnalyzerMs))
+      return Poll::ready;
+  }
+  return elapsed >= kFailureMs ? Poll::failed : Poll::collecting;
+}
+
+uint8_t progress_percent() {
+  if (!active()) return 0;
+  const uint32_t capture_started = g_capture_started_ms.load(std::memory_order_acquire);
+  if (!capture_started) return 5;
+  return static_cast<uint8_t>(std::min<uint32_t>(
+      95, (now_ms() - capture_started) * 95u / kSlowAnalyzerMs));
+}
+
+bool finish(float* levels, size_t capacity, size_t* count, Report* report) {
+  const bool copied = active() && rf_analysis::copy_snapshot(&g_latest);
+  const bool valid = copied && g_latest.center_hz == kCenterHz &&
+                     g_latest.sample_rate_sps == kSampleRateSps &&
+                     g_latest.frame_count > g_start_frame &&
+                     extract_grid_levels(g_latest, g_spacing_hz, levels, capacity, count);
+  if (report) {
+    report->frames = g_latest.frame_count - g_start_frame;
+    report->input_drops = g_latest.input_drops - g_start_drops;
+    report->clipping_percent = g_latest.clipping_percent;
+  }
+  stop_analysis();
+  return valid;
+}
+
+void cancel() {
+  if (active()) stop_analysis();
+}
+
+bool self_check() {
+  if ((kCenterHz - 531000u) % 9000u == 0 || (kCenterHz - 530000u) % 10000u == 0)
+    return false;
+  auto& snapshot = g_latest;
+  snapshot = {};
+  snapshot.center_hz = kCenterHz;
+  snapshot.span_hz = kSampleRateSps;
+  snapshot.sample_rate_sps = kSampleRateSps;
+  snapshot.bins = rf_analysis::kMaxBins;
+  std::fill_n(snapshot.average, snapshot.bins, -80.0f);
+  const double low_hz = snapshot.center_hz - snapshot.span_hz / 2.0;
+  const double bin_hz = static_cast<double>(snapshot.span_hz) / snapshot.bins;
+  const size_t hot_bin = static_cast<size_t>(lround((1280000.0 - low_hz) / bin_hz));
+  snapshot.average[hot_bin] = -30.0f;
+  float levels[kMaxChannels]{};
+  size_t count = 0;
+  if (!extract_grid_levels(snapshot, 10000, levels, std::size(levels), &count) ||
+      count != 119) return false;
+  const size_t hot_channel = (1280000u - kMinHz) / 10000u;
+  return levels[hot_channel] == -30.0f && levels[hot_channel - 1] == -80.0f &&
+         levels[hot_channel + 1] == -80.0f;
+}
+
+}  // namespace orcsdr::am_finder

--- a/apps/orcsdr-tab5/ui/am_finder.hpp
+++ b/apps/orcsdr-tab5/ui/am_finder.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace orcsdr::am_finder {
+
+constexpr uint32_t kSampleRateSps = 2400000;
+constexpr uint32_t kCenterHz = 1122000;
+constexpr uint32_t kMinHz = 530000;
+constexpr uint32_t kMaxHz = 1710000;
+constexpr size_t kMaxChannels = 160;
+
+enum class Poll : uint8_t { collecting, ready, failed };
+
+struct Report {
+  uint32_t frames = 0;
+  uint32_t input_drops = 0;
+  float clipping_percent = 0;
+};
+
+bool start(uint32_t spacing_hz);
+bool active();
+void offer_iq(const uint8_t* iq, size_t bytes, uint32_t sample_rate_sps);
+Poll poll();
+uint8_t progress_percent();
+bool finish(float* levels, size_t capacity, size_t* count, Report* report = nullptr);
+void cancel();
+bool self_check();
+
+}  // namespace orcsdr::am_finder

--- a/apps/orcsdr-tab5/ui/dashboard_registry.cpp
+++ b/apps/orcsdr-tab5/ui/dashboard_registry.cpp
@@ -11,6 +11,7 @@ constexpr Descriptor kEntries[] = {
     {Id::p25, "P25 RADIO", "Trunking monitor and voice follow", Category::digital, true},
     {Id::adsb, "ADS-B", "1090 MHz aircraft tracking", Category::aviation, true},
     {Id::shortwave, "SHORTWAVE", "General HF receiver workspace", Category::audio, true},
+    {Id::am, "AM RADIO", "Broadcast AM with channel-aware tuning", Category::audio, true},
     {Id::weather, "WEATHER", "NOAA weather radio", Category::audio, true},
     {Id::cb, "CB RADIO", "40-channel AM/SSB receiver", Category::audio, true},
     {Id::lora, "LORA", "LoRa and Meshtastic receive tools", Category::digital, true},
@@ -56,7 +57,7 @@ void load_recent(const uint8_t* ids, size_t count_value) {
     }
   }
   if (g_recent_count == 0) {
-    constexpr Id defaults[] = {Id::rf_lab, Id::fm, Id::p25, Id::adsb,
+    constexpr Id defaults[] = {Id::rf_lab, Id::fm, Id::am, Id::p25, Id::adsb,
                                Id::shortwave, Id::lora, Id::cb, Id::weather};
     std::copy(std::begin(defaults), std::end(defaults), g_recent.begin());
     g_recent_count = std::size(defaults);
@@ -101,7 +102,8 @@ bool self_check() {
                      g_recent[1] == Id::fm && !record_open(Id::p25);
   g_recent = saved;
   g_recent_count = saved_count;
-  return loaded && moved && std::size(kEntries) == 14 && find(Id::rf_lab) != nullptr &&
+  return loaded && moved && std::size(kEntries) == 15 && find(Id::rf_lab) != nullptr &&
+         find(Id::am) != nullptr &&
          find(Id::wifi_analysis) != nullptr && find(Id::pocsag) != nullptr;
 }
 

--- a/apps/orcsdr-tab5/ui/dashboard_registry.hpp
+++ b/apps/orcsdr-tab5/ui/dashboard_registry.hpp
@@ -22,6 +22,7 @@ enum class Id : uint8_t {
   rf_lab,
   wifi_analysis,
   pocsag,
+  am,
   count,
 };
 

--- a/apps/orcsdr-tab5/ui/fm_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/fm_dashboard.cpp
@@ -550,7 +550,6 @@ void draw_spectrum(const float* levels, size_t first_bin, size_t visible_bins, f
   M5.Display.scroll(0, -1);
   M5.Display.pushImage(kSpectrumX, kWaterfallY + kWaterfallH - 2,
                        kSpectrumW, 1, g_waterfall_row);
-  M5.Display.drawFastVLine(center, kWaterfallY, kWaterfallH, kCyan);
   M5.Display.endWrite();
 }
 

--- a/apps/orcsdr-tab5/ui/home_dashboard.cpp
+++ b/apps/orcsdr-tab5/ui/home_dashboard.cpp
@@ -111,7 +111,7 @@ void draw_menu_icon(dashboards::Id id, int x, int y, uint16_t color) {
   if (id == dashboards::Id::home) {
     M5.Display.fillTriangle(x - 14, y, x, y - 13, x + 14, y, color);
     M5.Display.drawRect(x - 10, y, 20, 15, color);
-  } else if (id == dashboards::Id::fm) {
+  } else if (id == dashboards::Id::fm || id == dashboards::Id::am) {
     M5.Display.drawRoundRect(x - 15, y - 10, 30, 22, 4, color);
     M5.Display.drawCircle(x + 7, y + 1, 5, color);
     M5.Display.drawLine(x - 10, y - 14, x + 10, y - 20, color);

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -45,6 +45,7 @@
 #include "orcsdr_splash.hpp"
 #include "orcsdr_storage.hpp"
 #include "am_dashboard.hpp"
+#include "am_finder.hpp"
 #include "adsb_dashboard.hpp"
 #include "adsb_decoder.hpp"
 #include "atc_presets.hpp"
@@ -929,7 +930,8 @@ struct RtlIqBlock {
   uint8_t slot;
   RtlBand band;
   float audio_scale;
-  bool lab_custom_rate;
+  uint32_t sample_rate_sps;
+  bool custom_rate;
 };
 static uint8_t* rtl_ring_slots[kRtlRingDepth]{};
 static QueueHandle_t rtl_free_q = nullptr;
@@ -1131,9 +1133,11 @@ EXT_RAM_BSS_ATTR static float am_scan_levels[kAmScanMaxChannels]{};
 static uint32_t am_scan_start_hz = 530000;
 static uint32_t am_scan_step_hz = 10000;
 static size_t am_scan_count = 0;
+static uint32_t am_finder_restore_hz = kRtlAmDefaultHz;
 static std::atomic<bool> rtl_am_scan_requested{false};
 static std::atomic<bool> rtl_am_scan_cancel{false};
 static std::atomic<bool> rtl_am_scan_active{false};
+static std::atomic<bool> rtl_am_scan_callback_logged{false};
 static std::atomic<uint16_t> rtl_am_scan_step{0};
 static std::atomic<uint16_t> rtl_am_scan_total{1};
 static std::atomic<uint8_t> rtl_am_scan_found{0};
@@ -1340,7 +1344,8 @@ static float rtl_session_audio_scale = 5500.0f;
 static bool rtl_session_continuous = true;
 static uint32_t rtl_session_started_ms = 0;
 static std::atomic<uint32_t> rtl_session_frequency_hz{kRtlFmDefaultHz};
-static std::atomic<uint32_t> rtl_lab_rate_override_sps{0};
+static std::atomic<uint32_t> rtl_rate_override_sps{0};
+static std::atomic<uint32_t> rtl_active_sample_rate_sps{kRtlSampleRateSps};
 // M5GFX framebuffer writes are single-task only.  The RTL worker requests a
 // repaint; loop() owns the actual draw.
 static std::atomic<bool> rtl_stream_ui_refresh_pending{false};
@@ -1637,7 +1642,8 @@ SdrNavDropdown rtl_nav_dropdown = SdrNavDropdown::None;
 bool rtl_nav_open = false;
 bool rtl_frequency_keypad_open = false;
 uint32_t rtl_fm_step_hz = kRtlFmStepHz;
-uint32_t rtl_am_step_hz = kRtlAmStepHz;
+uint32_t rtl_am_step_hz = 1000;
+uint32_t rtl_am_scan_spacing_hz = kRtlAmStepHz;
 char rtl_frequency_entry[16]{};
 std::atomic<bool> rtl_continuous_requested{false};
 std::atomic<bool> rtl_stop_requested{false};
@@ -2572,7 +2578,7 @@ uint32_t rtl_clamp_filter_hz(RtlBand band, uint32_t bandwidth_hz) {
   }
   if (band == RtlBand::p25) return kP25StepHz;
   const bool am = band == RtlBand::am;
-  const uint32_t low = band == RtlBand::cb ? 2400 : am ? 4000 : band == RtlBand::fm ? 50000 : 8000;
+  const uint32_t low = band == RtlBand::cb ? 2400 : am ? 3000 : band == RtlBand::fm ? 50000 : 8000;
   const uint32_t high = band == RtlBand::cb ? 12000 : am ? 30000 : band == RtlBand::fm ? 300000 : 100000;
   return constrain((bandwidth_hz / 1000u) * 1000u, low, high);
 }
@@ -5699,7 +5705,7 @@ void service_visualizer() {
 orcsdr::rf_lab::Runtime rf_lab_runtime() {
   orcsdr::rf_lab::Runtime runtime{};
   runtime.frequency_hz = rtl_ui_frequency_hz;
-  runtime.sample_rate_sps = rtl_lab_rate_override_sps.load(std::memory_order_relaxed);
+  runtime.sample_rate_sps = rtl_rate_override_sps.load(std::memory_order_relaxed);
   runtime.source_available =
       rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running;
   runtime.sound_enabled = rtl_audio_user_enabled.load(std::memory_order_acquire);
@@ -5837,7 +5843,7 @@ void service_rf_lab() {
       const uint32_t rate = static_cast<uint32_t>(action.value);
       if (!esp_rtl_sdr_is_rate_supported(rate)) result = ESP_ERR_INVALID_ARG;
       else {
-        rtl_lab_rate_override_sps.store(rate, std::memory_order_release);
+        rtl_rate_override_sps.store(rate, std::memory_order_release);
         uint32_t current_rate = 0;
         if (esp_rtl_sdr_get_sample_rate(g_rtl, &current_rate) != ESP_OK ||
             current_rate != rate)
@@ -7445,21 +7451,28 @@ static void on_rtl_driver_event(esp_rtl_sdr_event_t event, const void *payload, 
       const size_t n =
           iq->bytes <= sizeof(rtl_iq_processing) ? iq->bytes : sizeof(rtl_iq_processing);
       rtl_capture_bytes += n;
+      if (orcsdr::am_finder::active() &&
+          !rtl_am_scan_callback_logged.exchange(true, std::memory_order_acq_rel))
+        Serial.printf("RTL_AM_SCAN first_callback bytes=%u rate_label=%u free_slots=%u filled=%u\n",
+                      static_cast<unsigned>(n),
+                      static_cast<unsigned>(rtl_active_sample_rate_sps.load(std::memory_order_relaxed)),
+                      rtl_free_q ? static_cast<unsigned>(uxQueueMessagesWaiting(rtl_free_q)) : 0,
+                      rtl_filled_q ? static_cast<unsigned>(uxQueueMessagesWaiting(rtl_filled_q)) : 0);
       uint8_t slot = 0;
       if (!rtl_free_q || !rtl_filled_q || xQueueReceive(rtl_free_q, &slot, 0) != pdTRUE) {
         rtl_iq_pipeline_drops.fetch_add(1, std::memory_order_relaxed);
         break;
       }
       std::memcpy(rtl_ring_slots[slot], iq->data, n);
-      const uint32_t lab_rate = rtl_lab_rate_override_sps.load(std::memory_order_relaxed);
+      const uint32_t active_rate = rtl_active_sample_rate_sps.load(std::memory_order_relaxed);
       const uint32_t decoder_rate = g_stream_band == RtlBand::adsb
                                         ? ESP_RTL_SDR_RATE_2048K
                                         : ESP_RTL_SDR_RATE_960K;
       const RtlIqBlock block{
           rtl_ring_slots[slot], n,
           rtl_iq_sequence.fetch_add(1, std::memory_order_relaxed), slot, g_stream_band,
-          g_stream_audio_scale,
-          orcsdr::rf_lab::active() && lab_rate && lab_rate != decoder_rate};
+          g_stream_audio_scale, active_rate,
+          active_rate != decoder_rate};
       if (xQueueSend(rtl_filled_q, &block, 0) != pdTRUE) {
         rtl_iq_pipeline_drops.fetch_add(1, std::memory_order_relaxed);
         (void)xQueueSend(rtl_free_q, &slot, 0);
@@ -7495,8 +7508,22 @@ static void rtl_dsp_task(void *) {
   while (true) {
     if (xQueueReceive(rtl_filled_q, &block, portMAX_DELAY) != pdTRUE) continue;
     const uint32_t dsp_started_us = micros();
+    if (orcsdr::am_finder::active()) {
+      orcsdr::am_finder::offer_iq(block.data, block.bytes, block.sample_rate_sps);
+      const uint32_t elapsed_us = micros() - dsp_started_us;
+      rtl_dsp_window_us.fetch_add(elapsed_us, std::memory_order_relaxed);
+      rtl_dsp_window_blocks.fetch_add(1, std::memory_order_relaxed);
+      uint32_t previous_max = rtl_dsp_block_us_max.load(std::memory_order_relaxed);
+      while (elapsed_us > previous_max &&
+             !rtl_dsp_block_us_max.compare_exchange_weak(
+                 previous_max, elapsed_us, std::memory_order_relaxed)) {
+      }
+      (void)xQueueSend(rtl_free_q, &block.slot, portMAX_DELAY);
+      vTaskDelay(1);
+      continue;
+    }
     const bool lab_active = orcsdr::rf_lab::active();
-    if (!block.lab_custom_rate && block.band == RtlBand::adsb && adsb_iq_free &&
+    if (!block.custom_rate && block.band == RtlBand::adsb && adsb_iq_free &&
         adsb_iq_ready) {
       uint8_t index = 0;
       if (xQueueReceive(adsb_iq_free, &index, 0) == pdTRUE) {
@@ -7512,7 +7539,7 @@ static void rtl_dsp_task(void *) {
     // high-rate queue like ADS-B) -- cheap enough per raw-IQ sample (no
     // transcendental math above its internal 38.4 kS/s decimated rate) to
     // run inline in this same DSP task.
-    if (!block.lab_custom_rate && block.band == RtlBand::pocsag && pocsag_decoder_instance) {
+    if (!block.custom_rate && block.band == RtlBand::pocsag && pocsag_decoder_instance) {
       if (pocsag_config_apply_pending.exchange(false, std::memory_order_acq_rel)) {
         const uint16_t baud_bps = pocsag_baud_bps.load(std::memory_order_relaxed);
         const uint8_t polarity_mode = pocsag_polarity_mode.load(std::memory_order_relaxed);
@@ -7529,17 +7556,17 @@ static void rtl_dsp_task(void *) {
       if (g_iq_rec_kind.load(std::memory_order_relaxed) == IqCaptureKind::pocsag)
         iq_rec_append(block.data, block.bytes);
     }
-    if (!block.lab_custom_rate && block.band == RtlBand::p25)
+    if (!block.custom_rate && block.band == RtlBand::p25)
       orcsdr::p25decoder::process_cu8(block.data, block.bytes);
-    if (!block.lab_custom_rate && block.band == RtlBand::p25 &&
+    if (!block.custom_rate && block.band == RtlBand::p25 &&
         g_iq_rec_kind.load(std::memory_order_relaxed) == IqCaptureKind::p25)
       iq_rec_append(block.data, block.bytes);
     if (block.band != RtlBand::adsb || orcsdr::home::active() ||
         orcsdr::visualizer::active() || lab_active)
       spectrum_offer_iq_snapshot(block.data, block.bytes);
-    if (!block.lab_custom_rate && block.band == RtlBand::lora)
+    if (!block.custom_rate && block.band == RtlBand::lora)
       lora_iq_offer(block.data, block.bytes);
-    if (!block.lab_custom_rate && !orcsdr::visualizer::channel_audio_active() &&
+    if (!block.custom_rate && !orcsdr::visualizer::channel_audio_active() &&
         block.band != RtlBand::lora && block.band != RtlBand::p25 &&
         block.band != RtlBand::pocsag &&
         (rtl_audio_enabled.load(std::memory_order_relaxed) ||
@@ -7650,10 +7677,11 @@ static void rtl_driver_app_task(void *) {
       st.preset = ESP_RTL_SDR_PRESET_CUSTOM_HZ;
       st.frequency_hz =
           band == RtlBand::fm ? rtl_fm_command_lo_hz(frequency_hz) : frequency_hz;
-      const uint32_t lab_rate = rtl_lab_rate_override_sps.load(std::memory_order_acquire);
+      const uint32_t lab_rate = rtl_rate_override_sps.load(std::memory_order_acquire);
       st.sample_rate_sps = lab_rate ? lab_rate
                                     : band == RtlBand::adsb ? ESP_RTL_SDR_RATE_2048K
                                                             : ESP_RTL_SDR_RATE_960K;
+      rtl_active_sample_rate_sps.store(st.sample_rate_sps, std::memory_order_release);
       esp_err_t err = esp_rtl_sdr_start(g_rtl, &st);
       Serial.printf("RTL_START %s rate=%u display_hz=%u lo_hz=%u\n",
                     esp_rtl_sdr_err_to_name(err), st.sample_rate_sps, frequency_hz,
@@ -7677,9 +7705,23 @@ static void rtl_driver_app_task(void *) {
                       static_cast<unsigned>(kFmAudioDecim));
       }
       if (err != ESP_OK) {
+        rtl_active_sample_rate_sps.store(0, std::memory_order_release);
         rtl_capture_state.store(RtlCaptureState::failed, std::memory_order_release);
         set_rtl_sdr_status("RTL-SDR V4: start failed");
         rtl_stream_ui_refresh_pending.store(true, std::memory_order_release);
+        if (rtl_am_scan_active.load(std::memory_order_acquire)) {
+          if (orcsdr::am_finder::active()) orcsdr::am_finder::cancel();
+          rtl_rate_override_sps.store(0, std::memory_order_release);
+          rtl_am_scan_active.store(false, std::memory_order_release);
+          rtl_am_scan_found.store(0, std::memory_order_relaxed);
+          rtl_ui_frequency_hz = am_finder_restore_hz;
+          rtl_requested_frequency_hz.store(am_finder_restore_hz,
+                                           std::memory_order_release);
+          rtl_stop_requested.store(false, std::memory_order_release);
+          rtl_capture_requested.store(true, std::memory_order_release);
+          Serial.printf("RTL_AM_SCAN failed reason=stream_start result=%s restored_hz=%u\n",
+                        esp_rtl_sdr_err_to_name(err), am_finder_restore_hz);
+        }
         /* Stay on radio UI so power/home chrome cannot paint over controls. */
       } else {
         rtl_capture_state.store(RtlCaptureState::running, std::memory_order_release);
@@ -7959,6 +8001,7 @@ static void rtl_driver_app_task(void *) {
         rtl_auto_fm_active.store(false, std::memory_order_release);
         flush_audio_play_batch(true);
         const esp_err_t stop_err = esp_rtl_sdr_stop(g_rtl, 2000);
+        rtl_active_sample_rate_sps.store(0, std::memory_order_release);
         Serial.printf("RTL_STOP_RESULT %s\n", esp_rtl_sdr_err_to_name(stop_err));
         rtl_capture_state.store(stop_err == ESP_OK ? RtlCaptureState::complete
                                                    : RtlCaptureState::failed,
@@ -8728,19 +8771,18 @@ void handle_am_dashboard_action(const orcsdr::am::Action& action) {
     case ActionKind::tune_hz: tune(action.value); break;
     case ActionKind::step_down: tune(rtl_step_frequency(RtlBand::am, rtl_ui_frequency_hz, -1)); break;
     case ActionKind::step_up: tune(rtl_step_frequency(RtlBand::am, rtl_ui_frequency_hz, 1)); break;
-    case ActionKind::spacing_toggle:
-      rtl_am_step_hz = orcsdr::am::toggle_channel_step();
+    case ActionKind::step_cycle:
+      rtl_am_step_hz = orcsdr::am::cycle_tune_step();
       break;
-    case ActionKind::filter_cycle: {
-      static constexpr uint32_t widths[] = {4000, 6000, 8000, 10000};
-      size_t i = 0;
-      const uint32_t current = rtl_filter_bandwidth_hz.load(std::memory_order_relaxed);
-      while (i < std::size(widths) && widths[i] != current) ++i;
-      rtl_filter_bandwidth_hz.store(widths[(i + 1) % std::size(widths)], std::memory_order_relaxed);
+    case ActionKind::scan_spacing_toggle:
+      rtl_am_scan_spacing_hz = orcsdr::am::toggle_scan_spacing();
+      break;
+    case ActionKind::filter_bandwidth_hz:
+      rtl_filter_bandwidth_hz.store(
+          rtl_clamp_filter_hz(RtlBand::am, action.value), std::memory_order_relaxed);
       rtl_audio_reset_demod_filters();
       reset_spectrum_renderer();
       break;
-    }
     case ActionKind::span_down:
     case ActionKind::span_up: {
       const uint32_t current = rtl_scope_span_hz.load(std::memory_order_relaxed);
@@ -8755,6 +8797,12 @@ void handle_am_dashboard_action(const orcsdr::am::Action& action) {
       if (const uint32_t frequency = orcsdr::am::preset(action.value)) tune(frequency);
       break;
     case ActionKind::preset_save: orcsdr::am::save_current_preset(); break;
+    case ActionKind::preset_replace:
+      (void)orcsdr::am::replace_preset(action.value);
+      break;
+    case ActionKind::preset_delete:
+      (void)orcsdr::am::delete_preset(action.value);
+      break;
     case ActionKind::sound_toggle:
       set_rtl_audio_user_enabled(!rtl_audio_user_enabled.load(std::memory_order_acquire));
       break;
@@ -8790,8 +8838,10 @@ void handle_am_dashboard_action(const orcsdr::am::Action& action) {
     case ActionKind::scan_toggle:
       if (rtl_am_scan_active.load(std::memory_order_relaxed))
         rtl_am_scan_cancel.store(true, std::memory_order_relaxed);
-      else
+      else {
+        orcsdr::am::clear_scan_results();
         rtl_am_scan_requested.store(true, std::memory_order_relaxed);
+      }
       break;
     case ActionKind::open_device_settings:
       open_global_settings(orcsdr::settings::Section::radio_defaults);
@@ -9416,8 +9466,8 @@ void scan_finished(orcsdr::scan::Finish reason, void*) {
     uint8_t added = 0;
     float baseline = -120.0f;
     if (reason == orcsdr::scan::Finish::completed && am_scan_count > 0)
-      added = orcsdr::am::add_scan_results(am_scan_start_hz, am_scan_step_hz,
-                                           am_scan_levels, am_scan_count, &baseline);
+      added = orcsdr::am::prepare_scan_results(am_scan_start_hz, am_scan_step_hz,
+                                               am_scan_levels, am_scan_count, &baseline);
     rtl_am_scan_found.store(added, std::memory_order_relaxed);
     rtl_stream_ui_refresh_pending.store(true, std::memory_order_release);
     const char* outcome = reason == orcsdr::scan::Finish::completed
@@ -9510,8 +9560,76 @@ void cancel_active_scan(bool restore) {
   scan_engine.cancel(restore, scan_callbacks());
 }
 
+void finish_am_finder(bool completed, const char* outcome) {
+  orcsdr::am_finder::Report report{};
+  size_t measured = 0;
+  const bool analyzed = completed && orcsdr::am_finder::finish(
+      am_scan_levels, std::size(am_scan_levels), &measured, &report);
+  if (!analyzed) orcsdr::am_finder::cancel();
+  if (analyzed) am_scan_count = measured;
+  uint8_t added = 0;
+  float baseline = -120.0f;
+  if (analyzed)
+    added = orcsdr::am::prepare_scan_results(am_scan_start_hz, am_scan_step_hz,
+                                             am_scan_levels, am_scan_count, &baseline);
+  else
+    orcsdr::am::clear_scan_results();
+  rtl_am_scan_active.store(false, std::memory_order_release);
+  rtl_am_scan_step.store(analyzed ? static_cast<uint16_t>(am_scan_count) : 0,
+                          std::memory_order_relaxed);
+  rtl_am_scan_total.store(static_cast<uint16_t>(am_scan_count),
+                           std::memory_order_relaxed);
+  rtl_am_scan_found.store(added, std::memory_order_relaxed);
+  rtl_rate_override_sps.store(0, std::memory_order_release);
+  rtl_stream_ui_refresh_pending.store(true, std::memory_order_release);
+  Serial.printf(
+      "RTL_AM_SCAN %s mode=wideband rate=%u frames=%lu analyzer_drops=%lu "
+      "clipping_pct=%.2f added=%u baseline_dbfs=%.1f\n",
+      outcome, orcsdr::am_finder::kSampleRateSps,
+      static_cast<unsigned long>(report.frames),
+      static_cast<unsigned long>(report.input_drops),
+      static_cast<double>(report.clipping_percent), static_cast<unsigned>(added),
+      static_cast<double>(baseline));
+  queue_local_rtl_listen(RtlBand::am, am_finder_restore_hz, false);
+}
+
 void service_shared_scan(uint32_t now) {
   const auto callbacks = scan_callbacks();
+  if (rtl_am_scan_active.load(std::memory_order_acquire) &&
+      !orcsdr::am_finder::active() &&
+      rtl_active_sample_rate_sps.load(std::memory_order_acquire) ==
+          orcsdr::am_finder::kSampleRateSps &&
+      rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running) {
+    if (!orcsdr::am_finder::start(am_scan_step_hz)) {
+      finish_am_finder(false, "analyzer_start_failed");
+      return;
+    }
+    Serial.println("RTL_AM_SCAN capture_armed rate=2400000");
+  }
+  if (rtl_am_scan_active.load(std::memory_order_acquire) &&
+      !orcsdr::am_finder::active() &&
+      rtl_am_scan_cancel.exchange(false, std::memory_order_acq_rel)) {
+    finish_am_finder(false, "cancelled");
+    return;
+  }
+  if (orcsdr::am_finder::active()) {
+    if (rtl_am_scan_cancel.exchange(false, std::memory_order_acq_rel)) {
+      finish_am_finder(false, "cancelled");
+      return;
+    }
+    const uint32_t progress = orcsdr::am_finder::progress_percent();
+    rtl_am_scan_step.store(static_cast<uint16_t>(progress * am_scan_count / 100u),
+                           std::memory_order_relaxed);
+    const auto state = orcsdr::am_finder::poll();
+    if (state == orcsdr::am_finder::Poll::ready) {
+      finish_am_finder(true, "done");
+      return;
+    }
+    if (state == orcsdr::am_finder::Poll::failed) {
+      finish_am_finder(false, "failed");
+      return;
+    }
+  }
   if (cancel_scan_for_takeover.exchange(false, std::memory_order_acq_rel))
     scan_engine.cancel(false, callbacks);
   if (rtl_fm_preset_scan_cancel.exchange(false, std::memory_order_acq_rel) &&
@@ -9575,28 +9693,32 @@ void service_shared_scan(uint32_t now) {
   }
   if (!scan_engine.active() && g_stream_band == RtlBand::am &&
       rtl_am_scan_requested.exchange(false, std::memory_order_acq_rel)) {
-    am_scan_step_hz = rtl_am_step_hz;
+    am_scan_step_hz = rtl_am_scan_spacing_hz;
     am_scan_start_hz = am_scan_step_hz == 9000 ? 531000u : 530000u;
     am_scan_count = (kRtlAmMaxHz - am_scan_start_hz) / am_scan_step_hz + 1;
-    const auto session = radio_session.snapshot();
-    scan_radio_token = {session.owner, session.generation};
-    const orcsdr::scan::Plan plan{orcsdr::scan::Mode::frequency_range, nullptr, am_scan_count,
-                                  am_scan_start_hz, am_scan_step_hz,
-                                  kAmScanSettleMs, true};
-    if (am_scan_count <= kAmScanMaxChannels &&
-        scan_engine.start(plan, rtl_ui_frequency_hz, now)) {
-      active_scan = ActiveScan::am_presets;
-      std::fill_n(am_scan_levels, am_scan_count, -120.0f);
-      rtl_am_scan_active.store(true, std::memory_order_release);
-      rtl_am_scan_step.store(0, std::memory_order_relaxed);
-      rtl_am_scan_total.store(static_cast<uint16_t>(am_scan_count), std::memory_order_relaxed);
-      rtl_am_scan_found.store(0, std::memory_order_relaxed);
-      rtl_stream_ui_refresh_pending.store(true, std::memory_order_release);
-      Serial.printf("RTL_AM_SCAN start channels=%u step_hz=%lu settle_ms=%lu\n",
-                    static_cast<unsigned>(am_scan_count),
-                    static_cast<unsigned long>(am_scan_step_hz),
-                    static_cast<unsigned long>(kAmScanSettleMs));
+    if (am_scan_count > kAmScanMaxChannels ||
+        !esp_rtl_sdr_is_rate_supported(orcsdr::am_finder::kSampleRateSps)) {
+      Serial.println("RTL_AM_SCAN failed reason=rate_unsupported");
+      return;
     }
+    am_finder_restore_hz = rtl_ui_frequency_hz;
+    std::fill_n(am_scan_levels, am_scan_count, -120.0f);
+    rtl_am_scan_active.store(true, std::memory_order_release);
+    rtl_am_scan_callback_logged.store(false, std::memory_order_release);
+    rtl_am_scan_step.store(0, std::memory_order_relaxed);
+    rtl_am_scan_total.store(static_cast<uint16_t>(am_scan_count),
+                             std::memory_order_relaxed);
+    rtl_am_scan_found.store(0, std::memory_order_relaxed);
+    rtl_am_scan_freq_hz.store(orcsdr::am_finder::kCenterHz, std::memory_order_relaxed);
+    rtl_rate_override_sps.store(orcsdr::am_finder::kSampleRateSps,
+                                std::memory_order_release);
+    queue_local_rtl_listen(RtlBand::am, orcsdr::am_finder::kCenterHz, false);
+    rtl_stream_ui_refresh_pending.store(true, std::memory_order_release);
+    Serial.printf("RTL_AM_SCAN start mode=wideband rate=%u center_hz=%u channels=%u "
+                  "step_hz=%lu\n",
+                  orcsdr::am_finder::kSampleRateSps, orcsdr::am_finder::kCenterHz,
+                  static_cast<unsigned>(am_scan_count),
+                  static_cast<unsigned long>(am_scan_step_hz));
   }
   if (!scan_engine.active() && g_stream_band == RtlBand::pocsag &&
       pocsag_scan_requested.exchange(false, std::memory_order_acq_rel)) {
@@ -10174,7 +10296,7 @@ void open_dashboard(orcsdr::dashboards::Id id) {
     open_rf24_dashboard();
     return;
   }
-  rtl_lab_rate_override_sps.store(0, std::memory_order_release);
+  rtl_rate_override_sps.store(0, std::memory_order_release);
   RtlBand band = RtlBand::browse;
   uint32_t frequency = rtl_ui_frequency_hz;
   switch (id) {
@@ -10718,7 +10840,8 @@ void persist_workflow() {
 void load_state() {
   preferences.begin("orclink", false);
   orcsdr::am::load(preferences);
-  rtl_am_step_hz = orcsdr::am::channel_step();
+  rtl_am_step_hz = orcsdr::am::tune_step();
+  rtl_am_scan_spacing_hz = orcsdr::am::scan_spacing();
   const auto stored_verbosity = static_cast<SerialVerbosity>(
       std::min<uint8_t>(preferences.getUChar("serial_verb", 1), 3));
   apply_serial_verbosity(stored_verbosity);
@@ -10961,6 +11084,13 @@ bool point_in_button(int32_t x, int32_t y) {
 
 void queue_local_rtl_listen(RtlBand band, uint32_t frequency_hz,
                             bool persist_navigation) {
+  if (orcsdr::am_finder::active()) {
+    orcsdr::am_finder::cancel();
+    rtl_rate_override_sps.store(0, std::memory_order_release);
+    rtl_am_scan_active.store(false, std::memory_order_release);
+    rtl_am_scan_found.store(0, std::memory_order_relaxed);
+    Serial.println("RTL_AM_SCAN cancelled reason=navigation");
+  }
   if (band != RtlBand::p25) {
     stop_p25_automation();
   }
@@ -11023,9 +11153,10 @@ void queue_local_rtl_listen(RtlBand band, uint32_t frequency_hz,
   rtl_fm_preset_scan_requested.store(false, std::memory_order_release);
   p25_survey_requested.store(false, std::memory_order_release);
   if (orcsdr::lora_channel::survey_active()) (void)orcsdr::lora_channel::cancel_survey();
+  const uint32_t rate_override = rtl_rate_override_sps.load(std::memory_order_relaxed);
   const auto session_token = radio_session.acquire(
       orcsdr::radio::owner_for_band(band), band, frequency_hz,
-      kRtlSampleRateSps);
+      rate_override ? rate_override : kRtlSampleRateSps);
   (void)radio_session.set_state(session_token, orcsdr::radio::ReceiverState::starting);
   if (persist_navigation) {
     preferences.putUInt("last_band", static_cast<uint32_t>(band));
@@ -11171,10 +11302,10 @@ bool request_hot_retune_for(orcsdr::radio::Token token, uint32_t frequency_hz) {
     return false;
   frequency_hz = rtl_clamp_frequency(rtl_ui_band, frequency_hz);
   if (frequency_hz == 0) return false;
-  /* UI: 1 kHz display quantize. */
+  const uint32_t ui_quant_hz = rtl_ui_band == RtlBand::am ? 100u : 1000u;
   uint32_t ui_hz = rtl_ui_band == RtlBand::p25
                        ? frequency_hz
-                       : (frequency_hz / 1000u) * 1000u;
+                       : (frequency_hz / ui_quant_hz) * ui_quant_hz;
   if (rtl_ui_band == RtlBand::fm) ui_hz = rtl_fm_sanitize_display_hz(ui_hz);
   if (!radio_session.retuned(token, ui_hz)) return false;
   const bool ui_changed = (ui_hz != rtl_ui_frequency_hz);
@@ -11192,6 +11323,8 @@ bool request_hot_retune_for(orcsdr::radio::Token token, uint32_t frequency_hz) {
   }
   const uint32_t lo_hz = rtl_ui_band == RtlBand::p25
                              ? frequency_hz
+                             : rtl_ui_band == RtlBand::am
+                                   ? ui_hz
                              : rtl_ui_band == RtlBand::fm
                                    ? rtl_fm_command_lo_hz(ui_hz)
                                    : (frequency_hz / kRtlHotRetuneQuantHz) *
@@ -11261,10 +11394,32 @@ void poll_sdr_touch(bool from_stream) {
   }
 
   if (pressed && rtl_ui_band == RtlBand::am && orcsdr::am::active()) {
+    const auto preset_touch = orcsdr::am::handle_preset_touch(touch.x, touch.y, true, now);
+    if (preset_touch.consumed) {
+      if (preset_touch.action.kind != orcsdr::am::ActionKind::none)
+        handle_am_dashboard_action(preset_touch.action);
+      was_pressed = true;
+      return;
+    }
+    const auto bandwidth_action = orcsdr::am::handle_bandwidth_drag(touch.x, touch.y);
+    if (bandwidth_action.kind != orcsdr::am::ActionKind::none) {
+      handle_am_dashboard_action(bandwidth_action);
+      was_pressed = true;
+      return;
+    }
     const auto action = orcsdr::am::handle_gain_drag(touch.x, touch.y);
     if (action.kind != orcsdr::am::ActionKind::none) {
       handle_am_dashboard_action(action);
       was_pressed = true;
+      return;
+    }
+  }
+  if (!pressed && rtl_ui_band == RtlBand::am && orcsdr::am::active()) {
+    const auto preset_touch = orcsdr::am::handle_preset_touch(touch.x, touch.y, false, now);
+    if (preset_touch.consumed) {
+      if (preset_touch.action.kind != orcsdr::am::ActionKind::none)
+        handle_am_dashboard_action(preset_touch.action);
+      was_pressed = false;
       return;
     }
   }
@@ -12706,10 +12861,13 @@ void process_command(char* command) {
     } else if (strcmp(domain, "AM") == 0) {
       using K = orcsdr::am::ActionKind; K kind = K::none;
       if (!strcmp(action, "TUNE")) kind=K::tune_hz; else if (!strcmp(action, "DOWN")) kind=K::step_down;
-      else if (!strcmp(action, "UP")) kind=K::step_up; else if (!strcmp(action, "SPACING")) kind=K::spacing_toggle;
-      else if (!strcmp(action, "FILTER")) kind=K::filter_cycle; else if (!strcmp(action, "SPAN_DOWN")) kind=K::span_down;
+      else if (!strcmp(action, "UP")) kind=K::step_up; else if (!strcmp(action, "STEP")) kind=K::step_cycle;
+      else if (!strcmp(action, "SPACING")) kind=K::scan_spacing_toggle;
+      else if (!strcmp(action, "FILTER")) kind=K::filter_bandwidth_hz; else if (!strcmp(action, "SPAN_DOWN")) kind=K::span_down;
       else if (!strcmp(action, "SPAN_UP")) kind=K::span_up; else if (!strcmp(action, "PRESET")) kind=K::preset_recall;
-      else if (!strcmp(action, "SAVE")) kind=K::preset_save; else if (!strcmp(action, "SOUND")) kind=K::sound_toggle;
+      else if (!strcmp(action, "SAVE")) kind=K::preset_save; else if (!strcmp(action, "REPLACE")) kind=K::preset_replace;
+      else if (!strcmp(action, "DELETE")) kind=K::preset_delete;
+      else if (!strcmp(action, "SOUND")) kind=K::sound_toggle;
       else if (!strcmp(action, "VOL_DOWN")) kind=K::volume_down; else if (!strcmp(action, "VOL_UP")) kind=K::volume_up;
       else if (!strcmp(action, "GRAPHICS")) kind=K::graphics_toggle; else if (!strcmp(action, "RECORD")) kind=K::recording_toggle;
       else if (!strcmp(action, "GAIN_AUTO")) kind=K::gain_auto; else if (!strcmp(action, "GAIN")) kind=K::gain_tenth_db;
@@ -12721,7 +12879,8 @@ void process_command(char* command) {
         Serial.println("RTL_UI_ACTION_INVALID am_frequency_out_of_range");
         return;
       }
-      if (kind == K::preset_recall && (fields != 3 || value < 1 || value > 6)) {
+      if ((kind == K::preset_recall || kind == K::preset_replace || kind == K::preset_delete) &&
+          (fields != 3 || value < 1 || value > 160)) {
         Serial.println("RTL_UI_ACTION_INVALID am_preset_out_of_range");
         return;
       }
@@ -12729,9 +12888,15 @@ void process_command(char* command) {
         Serial.println("RTL_UI_ACTION_INVALID am_gain_out_of_range");
         return;
       }
+      if (kind == K::filter_bandwidth_hz &&
+          (fields != 3 || value < 3000 || value > 30000)) {
+        Serial.println("RTL_UI_ACTION_INVALID am_filter_out_of_range");
+        return;
+      }
       if (kind != K::none) {
         handle_am_dashboard_action({kind, static_cast<uint32_t>(
-            kind == K::preset_recall ? value - 1 : value)});
+            (kind == K::preset_recall || kind == K::preset_replace ||
+             kind == K::preset_delete) ? value - 1 : value)});
         Serial.println("RTL_UI_ACTION_OK");
         return;
       }
@@ -14598,6 +14763,10 @@ void setup() {
     Serial.println("RTL_AM_DASHBOARD_SELF_CHECK_FAIL");
   }
   Serial.println("RTL_AM_DASHBOARD_SELF_CHECK_OK");
+  if (!orcsdr::am_finder::self_check()) {
+    Serial.println("RTL_AM_FINDER_SELF_CHECK_FAIL");
+  }
+  Serial.println("RTL_AM_FINDER_SELF_CHECK_OK");
   if (!orcsdr::fmconfig::self_check()) {
     Serial.println("RTL_FM_CONFIG_SELF_CHECK_FAIL");
   }
@@ -15096,6 +15265,7 @@ void loop() {
   if (rtl_screen_transition_requested.exchange(false, std::memory_order_acq_rel) &&
       !settings_ui && orcsdr::screens::status().active != orcsdr::screens::Id::documentation &&
       orcsdr::screens::status().active != orcsdr::screens::Id::wifi_analysis &&
+      !orcsdr::screens::owns(screen_for_band(rtl_ui_band)) &&
       !orcsdr::home::active()) {
     draw_sdr_screen(rtl_ui_band, rtl_ui_frequency_hz,
                     rtl_live_volume.load(std::memory_order_acquire));

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -6135,11 +6135,19 @@ void draw_spectrum(const uint8_t* iq, size_t bytes) {
   constexpr float kPi = 3.14159265358979323846f;
   for (size_t w = 0; w < windows; ++w) {
     const uint8_t* base = local_iq + w * window_bytes;
+    float mean_i = 0.0f;
+    float mean_q = 0.0f;
+    for (size_t index = 0; index < kRtlSpectrumBins; ++index) {
+      mean_i += static_cast<float>(base[index * 2]);
+      mean_q += static_cast<float>(base[index * 2 + 1]);
+    }
+    mean_i /= kRtlSpectrumBins;
+    mean_q /= kRtlSpectrumBins;
     for (size_t index = 0; index < kRtlSpectrumBins; ++index) {
       rtl_spectrum_real[index] =
-          (static_cast<int>(base[index * 2]) - 128) * rtl_spectrum_window[index];
+          (static_cast<float>(base[index * 2]) - mean_i) * rtl_spectrum_window[index];
       rtl_spectrum_imaginary[index] =
-          (static_cast<int>(base[index * 2 + 1]) - 128) * rtl_spectrum_window[index];
+          (static_cast<float>(base[index * 2 + 1]) - mean_q) * rtl_spectrum_window[index];
     }
     for (size_t index = 1, reversed = 0; index < kRtlSpectrumBins; ++index) {
       size_t bit = kRtlSpectrumBins >> 1;
@@ -11131,6 +11139,17 @@ void queue_local_rtl_listen(RtlBand band, uint32_t frequency_hz,
   if (band != rtl_ui_band) {
     rtl_filter_bandwidth_hz.store(rtl_filter_default_hz(band), std::memory_order_relaxed);
   }
+#if !RTL_USE_LEGACY_USB
+  if (rtl_ui_band == RtlBand::am && band != RtlBand::am) {
+    rtl_am_gain_auto_selecting.store(false, std::memory_order_relaxed);
+    (void)esp_rtl_sdr_set_tuner_gain_mode(g_rtl, ESP_RTL_SDR_GAIN_MODE_AUTO);
+  } else if (rtl_ui_band != RtlBand::am && band == RtlBand::am) {
+    if (rtl_am_gain_auto_enabled.load(std::memory_order_relaxed))
+      rtl_am_gain_auto_restart.store(true, std::memory_order_release);
+    else
+      (void)esp_rtl_sdr_set_tuner_gain_mode(g_rtl, ESP_RTL_SDR_GAIN_MODE_MANUAL);
+  }
+#endif
   if (band == RtlBand::cb) {
     rtl_scope_span_hz.store(480000, std::memory_order_relaxed);
   }

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -44,6 +44,7 @@
 
 #include "orcsdr_splash.hpp"
 #include "orcsdr_storage.hpp"
+#include "am_dashboard.hpp"
 #include "adsb_dashboard.hpp"
 #include "adsb_decoder.hpp"
 #include "atc_presets.hpp"
@@ -73,6 +74,7 @@
 #include "pocsag_store.hpp"
 #include "radio_session.hpp"
 #include "radio_ui_service.hpp"
+#include "receiver_band_plan.hpp"
 #include "rf_lab.hpp"
 #include "rf_visualizer.hpp"
 #include "settings_app.hpp"
@@ -593,10 +595,10 @@ static_assert(kRtlScopeSpanMinHz < kRtlScopeSpanMaxHz);
  * 13 kHz low — 96.100 only peaked when commanded 96.113). */
 constexpr uint32_t kRtlFmDefaultHz = 96100000;
 constexpr int32_t kRtlFmLoBiasHz = 13000;
-constexpr uint32_t kRtlAmMinHz = 520000;
-constexpr uint32_t kRtlAmMaxHz = 1710000;
-constexpr uint32_t kRtlAmStepHz = 10000;
-constexpr uint32_t kRtlAmDefaultHz = 1000000;
+constexpr uint32_t kRtlAmMinHz = orcsdr::receiver_bands::kAmBroadcast.min_hz;
+constexpr uint32_t kRtlAmMaxHz = orcsdr::receiver_bands::kAmBroadcast.max_hz;
+constexpr uint32_t kRtlAmStepHz = orcsdr::receiver_bands::kAmBroadcast.default_step_hz;
+constexpr uint32_t kRtlAmDefaultHz = orcsdr::receiver_bands::kAmBroadcast.default_hz;
 constexpr uint32_t kRtlWxHz = 162400000;
 constexpr uint32_t kRtlBrowseMinHz = ESP_RTL_SDR_FREQ_MIN_HZ;
 constexpr uint32_t kRtlBrowseMaxHz = ESP_RTL_SDR_FREQ_MAX_HZ;
@@ -721,9 +723,11 @@ struct RtlAudioState {
   float previous_i = 0;
   float previous_q = 0;
   bool have_previous = false;
-  /** Complex one-pole state (pre-demod channel LPF on I/Q). */
+  /** Complex two-pole state (pre-demod AM channel LPF on I/Q). */
   float iq_i_lpf = 0;
   float iq_q_lpf = 0;
+  float iq_i_lpf2 = 0;
+  float iq_q_lpf2 = 0;
   /** Post-discriminator mono LPF (was generic channel_filter). */
   float channel_filter = 0;
   float audio_sum = 0;
@@ -879,11 +883,14 @@ void rtl_audio_reset_demod_filters() {
   rtl_audio.have_previous = false;
   rtl_audio.iq_i_lpf = 0;
   rtl_audio.iq_q_lpf = 0;
+  rtl_audio.iq_i_lpf2 = 0;
+  rtl_audio.iq_q_lpf2 = 0;
   rtl_audio.channel_filter = 0;
   rtl_audio.audio_sum = 0;
   rtl_audio.audio_phase = 0;
   rtl_audio.deemphasis = 0;
   rtl_audio.dc = 0;
+  rtl_audio.envelope_filter = 0;
   rtl_audio.ssb_cos = 1.0f;
   rtl_audio.ssb_sin = 0.0f;
   if (rtl_audio.fade_in > 48) rtl_audio.fade_in = 48;
@@ -1585,6 +1592,8 @@ std::atomic<bool> rtl_audio_user_enabled{true};
 std::atomic<bool> rtl_audio_enabled{false};
 std::atomic<bool> rtl_speaker_start_allowed{false};
 std::atomic<bool> rtl_speaker_codec_primed{false};
+std::atomic<bool> rtl_headphone_connected{false};
+std::atomic<bool> rtl_internal_speaker_muted{false};
 enum class BootInitStage : uint8_t {
   idle,
   usb_power_settle,
@@ -2198,6 +2207,8 @@ void draw_global_settings_gear();
 void draw_global_bias_warning();
 orcsdr::fm::Snapshot fm_dashboard_snapshot();
 void handle_fm_dashboard_action(const orcsdr::fm::Action& action);
+orcsdr::am::Snapshot am_dashboard_snapshot();
+void handle_am_dashboard_action(const orcsdr::am::Action& action);
 orcsdr::p25::Snapshot p25_dashboard_snapshot();
 void handle_p25_dashboard_action(const orcsdr::p25::Action& action);
 orcsdr::lora::Snapshot lora_dashboard_snapshot();
@@ -2842,6 +2853,7 @@ void resume_rtl_speaker() {
   }
   const uint8_t volume = rtl_live_volume.load(std::memory_order_acquire);
   const bool ok = ensure_speaker_running(volume);
+  if (ok) rtl_internal_speaker_muted.store(false, std::memory_order_relaxed);
   Serial.printf("RTL_SPEAKER_RESUME ok=%d running=%d playing=%u volume=%u\n",
                 ok ? 1 : 0, M5.Speaker.isRunning() ? 1 : 0,
                 static_cast<unsigned>(M5.Speaker.getPlayingChannels()), volume);
@@ -2942,6 +2954,7 @@ void rtl_audio_test_emit_status() {
   Serial.printf(
       "{\"type\":\"rtl_audio_test\",\"mode\":\"%s\",\"elapsed_ms\":%u,"
       "\"speaker_enabled\":%u,\"speaker_running\":%u,\"sample_rate\":%u,"
+      "\"headphone_connected\":%u,\"internal_speaker_muted\":%u,"
       "\"stereo\":%u,\"speaker_core\":%u,\"speaker_priority\":%u,"
       "\"ring_blocks\":%u,\"ring_overruns\":%u,\"submit_failures\":%u,"
       "\"audio_chunks\":%u,\"audio_drops\":%u,\"effective_sps\":%u,"
@@ -2949,6 +2962,8 @@ void rtl_audio_test_emit_status() {
       "\"dsp_gate_us\":13653,\"task_count\":%u,\"task_delta\":%d,\"free_heap\":%u}\n",
       rtl_audio_test_mode_name(), elapsed, M5.Speaker.isEnabled() ? 1 : 0,
       M5.Speaker.isRunning() ? 1 : 0, static_cast<unsigned>(speaker.sample_rate),
+      rtl_headphone_connected.load(std::memory_order_relaxed) ? 1 : 0,
+      rtl_internal_speaker_muted.load(std::memory_order_relaxed) ? 1 : 0,
       speaker.stereo ? 1 : 0, static_cast<unsigned>(speaker.task_pinned_core),
       static_cast<unsigned>(speaker.task_priority), static_cast<unsigned>(kRtlAudioPlayBlockCount),
       rtl_audio_ring_overruns.load(std::memory_order_relaxed),
@@ -4087,6 +4102,10 @@ bool audio_rec_stop_and_export() {
   const bool was = g_audio_rec_active.exchange(false, std::memory_order_acq_rel);
   const size_t samples = g_audio_rec_write.load(std::memory_order_acquire);
   const bool full = g_audio_rec_full.load(std::memory_order_acquire);
+  if (!was && g_audio_rec_last_path[0]) {
+    Serial.printf("RTL_REC_STOP already_saved path=%s\n", g_audio_rec_last_path);
+    return true;
+  }
   if (!was && samples == 0) {
     Serial.println("RTL_REC_STOP empty");
     return false;
@@ -4098,11 +4117,23 @@ bool audio_rec_stop_and_export() {
                 g_audio_rec_freq_hz);
   if (samples == 0 || g_audio_rec_buf == nullptr) return false;
 
-  ++g_audio_rec_file_seq;
   char path[64];
-  snprintf(path, sizeof(path), "/orcsdr/rec_%03u_%s_%u.wav",
-           static_cast<unsigned>(g_audio_rec_file_seq), rtl_band_name(g_audio_rec_band),
-           static_cast<unsigned>(g_audio_rec_freq_hz));
+  const bool sd_ready = ensure_tab5_sd() && g_sd_fs != nullptr;
+  bool free_slot = false;
+  for (size_t attempt = 0; attempt < 999; ++attempt) {
+    g_audio_rec_file_seq = g_audio_rec_file_seq % 999 + 1;
+    snprintf(path, sizeof(path), "/orcsdr/rec_%03u_%s_%u.wav",
+             static_cast<unsigned>(g_audio_rec_file_seq), rtl_band_name(g_audio_rec_band),
+             static_cast<unsigned>(g_audio_rec_freq_hz));
+    if (!sd_ready || !g_sd_fs->exists(path)) {
+      free_slot = true;
+      break;
+    }
+  }
+  if (!free_slot) {
+    Serial.println("RTL_REC_WAV_ERR no_free_slot");
+    return false;
+  }
   if (audio_rec_write_wav(path, g_audio_rec_buf, samples)) {
     strlcpy(g_audio_rec_last_path, path, sizeof(g_audio_rec_last_path));
     Serial.printf("RTL_REC_WAV ok path=%s samples=%u rate=%u channels=1 bits=16 "
@@ -5329,6 +5360,7 @@ void update_signal_level_from_iq(const uint8_t* iq, size_t bytes) {
   constexpr float kFullScale = 2.0f * 127.5f * 127.5f;
   const float dbfs = 10.0f * log10f((power / kFullScale) + 1.0e-12f);
   rtl_signal_dbfs.store(dbfs, std::memory_order_relaxed);
+  rtl_signal_dbfs_smooth = 0.88f * rtl_signal_dbfs_smooth + 0.12f * dbfs;
 }
 
 void draw_global_settings_gear() {
@@ -5488,6 +5520,14 @@ void draw_fm_dashboard(bool static_panel) {
   else if (orcsdr::fm::active()) orcsdr::fm::update(snapshot);
 }
 
+void draw_am_dashboard(bool static_panel) {
+  if (!static_panel && !orcsdr::screens::may_draw(orcsdr::screens::Id::am)) return;
+  if (!static_panel) orcsdr::screens::note_visible_update(orcsdr::screens::Id::am);
+  const auto snapshot = am_dashboard_snapshot();
+  if (static_panel) orcsdr::am::enter(snapshot);
+  else if (orcsdr::am::active()) orcsdr::am::update(snapshot);
+}
+
 void draw_p25_dashboard(bool static_panel) {
   if (!static_panel && !orcsdr::screens::may_draw(orcsdr::screens::Id::p25)) return;
   if (!static_panel) orcsdr::screens::note_visible_update(orcsdr::screens::Id::p25);
@@ -5499,6 +5539,7 @@ void draw_p25_dashboard(bool static_panel) {
 orcsdr::screens::Id screen_for_band(RtlBand band) {
   switch (band) {
     case RtlBand::fm: return orcsdr::screens::Id::fm;
+    case RtlBand::am: return orcsdr::screens::Id::am;
     case RtlBand::p25: return orcsdr::screens::Id::p25;
     case RtlBand::adsb: return orcsdr::screens::Id::adsb;
     case RtlBand::pocsag: return orcsdr::screens::Id::pocsag;
@@ -5512,6 +5553,7 @@ void refresh_active_screen() {
   switch (orcsdr::screens::status().active) {
     case Id::home: draw_home_dashboard(); break;
     case Id::fm: draw_fm_dashboard(false); break;
+    case Id::am: draw_am_dashboard(false); break;
     case Id::p25: draw_p25_dashboard(false); break;
     case Id::adsb: draw_adsb_dashboard(false); break;
     case Id::pocsag: draw_pocsag_dashboard(false); break;
@@ -5524,6 +5566,7 @@ void refresh_active_screen() {
 uint8_t active_dashboard_tab(orcsdr::screens::Id screen) {
   switch (screen) {
     case orcsdr::screens::Id::fm: return static_cast<uint8_t>(orcsdr::fm::view());
+    case orcsdr::screens::Id::am: return static_cast<uint8_t>(orcsdr::am::view());
     case orcsdr::screens::Id::p25: return static_cast<uint8_t>(orcsdr::p25::view());
     case orcsdr::screens::Id::adsb: return orcsdr::adsb::view();
     case orcsdr::screens::Id::pocsag: return orcsdr::pocsag::view();
@@ -5581,6 +5624,7 @@ void close_visualizer() {
   switch (origin) {
     case orcsdr::screens::Id::home: orcsdr::home::draw(); break;
     case orcsdr::screens::Id::fm: orcsdr::fm::draw(); break;
+    case orcsdr::screens::Id::am: orcsdr::am::draw(); break;
     case orcsdr::screens::Id::p25: orcsdr::p25::draw(); break;
     case orcsdr::screens::Id::adsb: orcsdr::adsb::draw(); break;
     case orcsdr::screens::Id::lora: orcsdr::lora::draw(); break;
@@ -5729,6 +5773,7 @@ void close_rf_lab() {
   switch (origin) {
     case orcsdr::screens::Id::home: show_home(); break;
     case orcsdr::screens::Id::fm: orcsdr::fm::draw(); break;
+    case orcsdr::screens::Id::am: orcsdr::am::draw(); break;
     case orcsdr::screens::Id::p25: orcsdr::p25::draw(); break;
     case orcsdr::screens::Id::adsb: orcsdr::adsb::draw(); break;
     case orcsdr::screens::Id::lora: orcsdr::lora::draw(); break;
@@ -5816,10 +5861,36 @@ void service_rtl_speaker_watchdog() {
   }
 }
 
+void service_headphone_speaker_route() {
+  if (!rtl_speaker_start_allowed.load(std::memory_order_acquire)) return;
+  static uint32_t last_poll_ms = 0;
+  static bool configured = false;
+  static bool last_connected = false;
+  const uint32_t now = millis();
+  if (now - last_poll_ms < 250) return;
+  last_poll_ms = now;
+  auto& audio_io = M5.getIOExpander(0);
+  if (!configured) {
+    audio_io.setDirection(7, false);  // Tab5 headphone detect.
+    configured = true;
+  }
+  const bool connected = audio_io.digitalRead(7);
+  const bool muted = rtl_internal_speaker_muted.load(std::memory_order_relaxed);
+  if (connected != last_connected || connected != muted)
+    audio_io.digitalWrite(1, !connected);  // Mute only the internal amplifier.
+  rtl_headphone_connected.store(connected, std::memory_order_relaxed);
+  rtl_internal_speaker_muted.store(connected, std::memory_order_relaxed);
+  if (connected != last_connected) {
+    Serial.printf("RTL_AUDIO_ROUTE headphone=%d internal_speaker_muted=%d\n",
+                  connected ? 1 : 0, connected ? 1 : 0);
+    last_connected = connected;
+  }
+}
+
 void draw_sdr_screen(RtlBand band, uint32_t frequency_hz, uint8_t volume) {
   // Home is the common receiver workspace until a band has its own dashboard.
   // Do not resurrect the retired generic Browse surface for AM/WX/CB/Airband.
-  if (band != RtlBand::fm && band != RtlBand::p25 && band != RtlBand::adsb &&
+  if (band != RtlBand::fm && band != RtlBand::am && band != RtlBand::p25 && band != RtlBand::adsb &&
       band != RtlBand::pocsag && band != RtlBand::lora) {
     if (adsb_atc_listening) { draw_adsb_dashboard(true); return; }
     show_home();
@@ -5831,6 +5902,7 @@ void draw_sdr_screen(RtlBand band, uint32_t frequency_hz, uint8_t volume) {
   orcsdr::rf24::leave();
   orcsdr::settings::leave();
   if (band != RtlBand::fm) orcsdr::fm::leave();
+  if (band != RtlBand::am) orcsdr::am::leave();
   if (band != RtlBand::p25) orcsdr::p25::leave();
   if (band != RtlBand::adsb) orcsdr::adsb::leave();
   if (band != RtlBand::pocsag) orcsdr::pocsag::leave();
@@ -5851,6 +5923,13 @@ void draw_sdr_screen(RtlBand band, uint32_t frequency_hz, uint8_t volume) {
     reset_spectrum_renderer();
     resume_rtl_speaker();
     draw_fm_dashboard(true);
+    orcsdr::screens::finish_transition();
+    return;
+  }
+  if (band == RtlBand::am) {
+    reset_spectrum_renderer();
+    resume_rtl_speaker();
+    draw_am_dashboard(true);
     orcsdr::screens::finish_transition();
     return;
   }
@@ -6154,6 +6233,13 @@ void draw_spectrum(const uint8_t* iq, size_t bytes) {
   }
   if (rtl_ui_band == RtlBand::fm && orcsdr::screens::owns(orcsdr::screens::Id::fm)) {
     orcsdr::fm::draw_spectrum(rtl_spectrum_levels, first_bin, visible_bins, floor);
+    rtl_spectrum_trace_last_ms = now;
+    rtl_spectrum_trace_valid = true;
+    ++rtl_spectrum_frames;
+    return;
+  }
+  if (rtl_ui_band == RtlBand::am && orcsdr::screens::owns(orcsdr::screens::Id::am)) {
+    orcsdr::am::draw_spectrum(rtl_spectrum_levels, first_bin, visible_bins, floor);
     rtl_spectrum_trace_last_ms = now;
     rtl_spectrum_trace_valid = true;
     ++rtl_spectrum_frames;
@@ -6761,8 +6847,10 @@ void demodulate_am(const uint8_t* iq, size_t bytes, float audio_scale) {
     const float q_in = static_cast<float>(static_cast<int32_t>(iq[offset + 1]) - 128);
     rtl_audio.iq_i_lpf += iq_lpf_k * (i_in - rtl_audio.iq_i_lpf);
     rtl_audio.iq_q_lpf += iq_lpf_k * (q_in - rtl_audio.iq_q_lpf);
-    rtl_audio.i_sum += rtl_audio.iq_i_lpf;
-    rtl_audio.q_sum += rtl_audio.iq_q_lpf;
+    rtl_audio.iq_i_lpf2 += iq_lpf_k * (rtl_audio.iq_i_lpf - rtl_audio.iq_i_lpf2);
+    rtl_audio.iq_q_lpf2 += iq_lpf_k * (rtl_audio.iq_q_lpf - rtl_audio.iq_q_lpf2);
+    rtl_audio.i_sum += rtl_audio.iq_i_lpf2;
+    rtl_audio.q_sum += rtl_audio.iq_q_lpf2;
     if (++rtl_audio.rf_phase != 4) continue;
 
     const float i = rtl_audio.i_sum * 0.25f;
@@ -8568,6 +8656,93 @@ void handle_fm_dashboard_action(const orcsdr::fm::Action& action) {
   refresh_active_screen();
 }
 
+orcsdr::am::Snapshot am_dashboard_snapshot() {
+  orcsdr::am::Snapshot snapshot{};
+  snapshot.frequency_hz = rtl_ui_frequency_hz;
+  snapshot.step_hz = rtl_am_step_hz;
+  snapshot.filter_bandwidth_hz = rtl_filter_bandwidth_hz.load(std::memory_order_relaxed);
+  snapshot.span_hz = rtl_scope_span_hz.load(std::memory_order_relaxed);
+  snapshot.relative_dbfs = rtl_signal_dbfs_smooth;
+  snapshot.running = rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running;
+  snapshot.driver_ready = rtl_device_ready();
+  snapshot.sound_enabled = rtl_audio_user_enabled.load(std::memory_order_relaxed);
+  snapshot.graphics_enabled = rtl_graphics_enabled.load(std::memory_order_relaxed);
+  snapshot.recording = g_audio_rec_active.load(std::memory_order_relaxed);
+  snapshot.volume = rtl_ui_volume;
+  snapshot.battery_percent = M5.Power.getBatteryLevel();
+  orcsdr::am::populate_presets(snapshot);
+  return snapshot;
+}
+
+void handle_am_dashboard_action(const orcsdr::am::Action& action) {
+  using orcsdr::am::ActionKind;
+  auto tune = [](uint32_t hz) {
+    const uint32_t frequency = rtl_clamp_frequency(RtlBand::am, hz);
+    orcsdr::am::note_tuned(frequency);
+    if (rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running) {
+      request_hot_retune(frequency);
+      reset_spectrum_renderer();
+    } else {
+      queue_local_rtl_listen(RtlBand::am, frequency);
+    }
+  };
+  switch (action.kind) {
+    case ActionKind::tune_hz: tune(action.value); break;
+    case ActionKind::step_down: tune(rtl_step_frequency(RtlBand::am, rtl_ui_frequency_hz, -1)); break;
+    case ActionKind::step_up: tune(rtl_step_frequency(RtlBand::am, rtl_ui_frequency_hz, 1)); break;
+    case ActionKind::spacing_toggle:
+      rtl_am_step_hz = orcsdr::am::toggle_channel_step();
+      break;
+    case ActionKind::filter_cycle: {
+      static constexpr uint32_t widths[] = {4000, 6000, 10000};
+      size_t i = 0;
+      const uint32_t current = rtl_filter_bandwidth_hz.load(std::memory_order_relaxed);
+      while (i < std::size(widths) && widths[i] != current) ++i;
+      rtl_filter_bandwidth_hz.store(widths[(i + 1) % std::size(widths)], std::memory_order_relaxed);
+      rtl_audio_reset_demod_filters();
+      reset_spectrum_renderer();
+      break;
+    }
+    case ActionKind::span_down:
+    case ActionKind::span_up: {
+      const uint32_t current = rtl_scope_span_hz.load(std::memory_order_relaxed);
+      rtl_scope_span_hz.store(action.kind == ActionKind::span_down
+                                  ? std::max(kRtlScopeSpanMinHz, current / 2)
+                                  : std::min(kRtlScopeSpanMaxHz, current * 2),
+                              std::memory_order_relaxed);
+      reset_spectrum_renderer();
+      break;
+    }
+    case ActionKind::preset_recall:
+      if (const uint32_t frequency = orcsdr::am::preset(action.value)) tune(frequency);
+      break;
+    case ActionKind::preset_save: orcsdr::am::save_current_preset(); break;
+    case ActionKind::sound_toggle:
+      set_rtl_audio_user_enabled(!rtl_audio_user_enabled.load(std::memory_order_acquire));
+      break;
+    case ActionKind::volume_down: adjust_rtl_volume(-static_cast<int>(kRtlVolumeStep)); break;
+    case ActionKind::volume_up: adjust_rtl_volume(static_cast<int>(kRtlVolumeStep)); break;
+    case ActionKind::graphics_toggle:
+      rtl_graphics_enabled.store(!rtl_graphics_enabled.load(std::memory_order_acquire),
+                                 std::memory_order_release);
+      reset_spectrum_renderer();
+      break;
+    case ActionKind::recording_toggle:
+      if (g_audio_rec_active.load(std::memory_order_acquire)) (void)audio_rec_stop_and_export();
+      else (void)audio_rec_start();
+      break;
+    case ActionKind::open_device_settings:
+      open_global_settings(orcsdr::settings::Section::radio_defaults);
+      break;
+    case ActionKind::exit_home:
+      orcsdr::am::leave();
+      show_home();
+      break;
+    case ActionKind::none: break;
+  }
+  refresh_active_screen();
+}
+
 orcsdr::lora::Snapshot lora_dashboard_snapshot() {
   orcsdr::lora::Snapshot snapshot{};
   const auto& channel = orcsdr::lora_channel::selection();
@@ -9648,10 +9823,6 @@ orcsdr::home::Snapshot home_dashboard_snapshot(bool demo) {
   snapshot.vbus_mv = demo ? 5000 : device.vbus_mv;
   snapshot.volume = demo ? 128 : rtl_live_volume.load(std::memory_order_acquire);
   snapshot.usb_connected = snapshot.vbus_mv >= 4000;
-  if (!demo) {
-    const float raw = rtl_signal_dbfs.load(std::memory_order_relaxed);
-    rtl_signal_dbfs_smooth = 0.88f * rtl_signal_dbfs_smooth + 0.12f * raw;
-  }
   snapshot.relative_dbfs = demo ? -32.0f : rtl_signal_dbfs_smooth;
   snapshot.wifi_connected = demo || device.wifi_connected;
   if (demo) {
@@ -9745,6 +9916,10 @@ void navigation_restore_screen(orcsdr::screens::Id restore) {
     resume_rtl_speaker();
     orcsdr::fm::draw();
     bump_rtl_ui();
+  } else if (restore == orcsdr::screens::Id::am) {
+    resume_rtl_speaker();
+    orcsdr::am::draw();
+    bump_rtl_ui();
   } else if (restore == orcsdr::screens::Id::p25) {
     resume_rtl_speaker();
     orcsdr::p25::draw();
@@ -9796,7 +9971,7 @@ orcsdr::dashboards::Id dashboard_for_band(RtlBand band, uint32_t frequency_hz) {
     case RtlBand::wx: return Id::weather;
     case RtlBand::cb: return Id::cb;
     case RtlBand::lora: return Id::lora;
-    case RtlBand::am: return Id::shortwave;
+    case RtlBand::am: return Id::am;
     case RtlBand::browse:
       if (frequency_hz >= 118000000 && frequency_hz <= 137000000) return Id::airband;
       if (frequency_hz >= 156000000 && frequency_hz <= 162025000) return Id::marine;
@@ -9844,10 +10019,14 @@ void open_dashboard(orcsdr::dashboards::Id id) {
   uint32_t frequency = rtl_ui_frequency_hz;
   switch (id) {
     case Id::fm: band = RtlBand::fm; frequency = rtl_saved_fm_hz; break;
+    case Id::am: band = RtlBand::am; frequency = orcsdr::am::saved_frequency(); break;
     case Id::p25: band = RtlBand::p25; frequency = p25_control_frequency_hz; break;
     case Id::adsb: band = RtlBand::adsb; frequency = kAdsbDefaultHz; break;
     case Id::pocsag: band = RtlBand::pocsag; frequency = pocsag_config_frequency_hz; break;
-    case Id::shortwave: band = RtlBand::browse; frequency = 7100000; break;
+    case Id::shortwave:
+      band = RtlBand::browse;
+      frequency = orcsdr::receiver_bands::kShortwave.default_hz;
+      break;
     case Id::weather: band = RtlBand::wx; frequency = kRtlWxHz; break;
     case Id::cb: band = RtlBand::cb; frequency = kCbDefaultHz; break;
     case Id::lora: band = RtlBand::lora; frequency = kLoraDefaultHz; break;
@@ -10371,6 +10550,8 @@ void persist_workflow() {
 
 void load_state() {
   preferences.begin("orclink", false);
+  orcsdr::am::load(preferences);
+  rtl_am_step_hz = orcsdr::am::channel_step();
   const auto stored_verbosity = static_cast<SerialVerbosity>(
       std::min<uint8_t>(preferences.getUChar("serial_verb", 1), 3));
   apply_serial_verbosity(stored_verbosity);
@@ -10522,6 +10703,11 @@ void load_state() {
         rtl_ui_frequency_hz = lora_config_frequency_hz;
         rtl_requested_frequency_hz.store(lora_config_frequency_hz,
                                          std::memory_order_release);
+      } else if (stored_band == RtlBand::am) {
+        rtl_ui_frequency_hz = orcsdr::am::saved_frequency();
+        rtl_requested_frequency_hz.store(rtl_ui_frequency_hz, std::memory_order_release);
+        rtl_filter_bandwidth_hz.store(rtl_filter_default_hz(stored_band),
+                                      std::memory_order_relaxed);
       }
       Serial.printf("RTL_BAND_RESTORE band=%s\n", rtl_band_name(stored_band));
     }
@@ -10651,6 +10837,9 @@ void queue_local_rtl_listen(RtlBand band, uint32_t frequency_hz,
   if (band == RtlBand::cb) {
     rtl_scope_span_hz.store(480000, std::memory_order_relaxed);
   }
+  if (band == RtlBand::am) {
+    rtl_scope_span_hz.store(480000, std::memory_order_relaxed);
+  }
   if (band == RtlBand::lora) {
     rtl_scope_span_hz.store(kRtlScopeSpanMaxHz, std::memory_order_relaxed);
   }
@@ -10659,6 +10848,9 @@ void queue_local_rtl_listen(RtlBand band, uint32_t frequency_hz,
   }
   if (band == RtlBand::fm && persist_navigation) {
     persist_fm_frequency(frequency_hz);
+  }
+  if (band == RtlBand::am && persist_navigation) {
+    orcsdr::am::note_tuned(frequency_hz);
   }
   cancel_scan_for_takeover.store(true, std::memory_order_release);
   rtl_fm_preset_scan_requested.store(false, std::memory_order_release);
@@ -10721,7 +10913,7 @@ void adjust_rtl_volume(int delta) {
 bool point_in_scope(int32_t x, int32_t y) {
   if (rtl_ui_band == RtlBand::adsb) return false;
   // Dashboard modules own their complete touch surfaces, including spectrum views.
-  if (rtl_ui_band == RtlBand::fm ||
+  if (rtl_ui_band == RtlBand::fm || rtl_ui_band == RtlBand::am ||
       (rtl_ui_band == RtlBand::p25 && orcsdr::p25::active())) return false;
   // Spectrum + waterfall hit target for pan/flick (not the control rows).
   return x >= kSpectrumX && x < kSpectrumX + spectrum_draw_width() && y >= kSpectrumY &&
@@ -11130,6 +11322,10 @@ void handle_sdr_touch(int32_t x, int32_t y) {
     handle_fm_dashboard_action(orcsdr::fm::handle_touch(x, y));
     return;
   }
+  if (rtl_ui_band == RtlBand::am && orcsdr::am::active()) {
+    handle_am_dashboard_action(orcsdr::am::handle_touch(x, y));
+    return;
+  }
   if (rtl_ui_band == RtlBand::p25 && orcsdr::p25::active()) {
     handle_p25_dashboard_action(orcsdr::p25::handle_touch(x, y));
     return;
@@ -11482,6 +11678,7 @@ void ui_doc_leave_surfaces() {
   orcsdr::home::leave();
   orcsdr::settings::leave();
   orcsdr::fm::leave();
+  orcsdr::am::leave();
   orcsdr::p25::leave();
   orcsdr::lora::leave();
   orcsdr::adsb::leave();
@@ -11958,6 +12155,7 @@ bool ui_regression_restore_screen(const UiRegressionSnapshot& before) {
       show_home();
       return true;
     case orcsdr::screens::Id::fm:
+    case orcsdr::screens::Id::am:
     case orcsdr::screens::Id::p25:
     case orcsdr::screens::Id::adsb:
     case orcsdr::screens::Id::lora:
@@ -11982,6 +12180,7 @@ void run_ui_regression(bool workflow) {
   if (workflow) {
     const bool supported_screen = before.screen == orcsdr::screens::Id::home ||
                                   before.screen == orcsdr::screens::Id::fm ||
+                                  before.screen == orcsdr::screens::Id::am ||
                                   before.screen == orcsdr::screens::Id::p25 ||
                                   before.screen == orcsdr::screens::Id::adsb ||
                                   before.screen == orcsdr::screens::Id::lora ||
@@ -11996,7 +12195,8 @@ void run_ui_regression(bool workflow) {
     show_home();
     home_font_ok = M5.Display.getFont() == &fonts::Font0;
     draw_home_dashboard();
-    const bool dashboard_band = before.band == RtlBand::fm || before.band == RtlBand::p25 ||
+    const bool dashboard_band = before.band == RtlBand::fm || before.band == RtlBand::am ||
+                                before.band == RtlBand::p25 ||
                                 before.band == RtlBand::adsb || before.band == RtlBand::lora ||
                                 before.band == RtlBand::pocsag;
     if (before.screen == orcsdr::screens::Id::home && dashboard_band) {
@@ -12215,11 +12415,12 @@ void process_command(char* command) {
     }
   }
   if (strcmp(command, "RTL_UI STATUS") == 0) {
-    Serial.printf("RTL_UI_STATUS screen=%s band=%s frequency_hz=%u settings=%d fm=%d p25=%d "
+    Serial.printf("RTL_UI_STATUS screen=%s band=%s frequency_hz=%u settings=%d fm=%d am=%d p25=%d "
                   "adsb=%d lora=%d rf24=%d home_font=%d graphics=%d\n",
                   orcsdr::screens::name(orcsdr::screens::status().active),
                   rtl_band_name(rtl_ui_band), rtl_ui_frequency_hz,
                   orcsdr::settings::active() ? 1 : 0, orcsdr::fm::active() ? 1 : 0,
+                  orcsdr::am::active() ? 1 : 0,
                   orcsdr::p25::active() ? 1 : 0, orcsdr::adsb::active() ? 1 : 0,
                   orcsdr::lora::active() ? 1 : 0,
                   orcsdr::rf24::active() ? 1 : 0,
@@ -12271,13 +12472,14 @@ void process_command(char* command) {
     using Id = orcsdr::dashboards::Id;
     if (strcmp(name, "HOME") == 0) show_home();
     else if (strcmp(name, "FM") == 0) open_dashboard(Id::fm);
+    else if (strcmp(name, "AM") == 0) open_dashboard(Id::am);
     else if (strcmp(name, "P25") == 0) open_dashboard(Id::p25);
     else if (strcmp(name, "ADSB") == 0) open_dashboard(Id::adsb);
     else if (strcmp(name, "LORA") == 0) open_dashboard(Id::lora);
     else if (strcmp(name, "RF_LAB") == 0) open_dashboard(Id::rf_lab);
     else if (strcmp(name, "WIFI_ANALYSIS") == 0) open_dashboard(Id::wifi_analysis);
     else if (strcmp(name, "SETTINGS") == 0) open_dashboard(Id::settings);
-    else { Serial.println("RTL_UI_OPEN_INVALID use HOME|FM|P25|ADSB|LORA|RF_LAB|WIFI_ANALYSIS|SETTINGS"); return; }
+    else { Serial.println("RTL_UI_OPEN_INVALID use HOME|FM|AM|P25|ADSB|LORA|RF_LAB|WIFI_ANALYSIS|SETTINGS"); return; }
     Serial.printf("RTL_UI_OPEN_OK target=%s\n", name);
     return;
   }
@@ -12307,7 +12509,7 @@ void process_command(char* command) {
     char domain[12]{}, action[24]{};
     unsigned long value = 0;
     const int fields = sscanf(command + 14, "%11s %23s %lu", domain, action, &value);
-    if (fields < 2) { Serial.println("RTL_UI_ACTION_INVALID usage: RTL_UI ACTION <FM|P25|LORA|SETTINGS> <action> [value]"); return; }
+    if (fields < 2) { Serial.println("RTL_UI_ACTION_INVALID usage: RTL_UI ACTION <FM|AM|P25|LORA|SETTINGS> <action> [value]"); return; }
     if (strcmp(domain, "FM") == 0) {
       using K = orcsdr::fm::ActionKind; K kind = K::none;
       if (!strcmp(action, "TUNE")) kind=K::tune_hz; else if (!strcmp(action, "DOWN")) kind=K::step_down;
@@ -12321,6 +12523,32 @@ void process_command(char* command) {
       else if (!strcmp(action, "SCAN")) kind=K::scan_presets; else if (!strcmp(action, "SETTINGS")) kind=K::open_device_settings;
       else if (!strcmp(action, "HOME")) kind=K::exit_to_browse;
       if (kind != K::none) { handle_fm_dashboard_action({kind, static_cast<uint32_t>(value)}); Serial.println("RTL_UI_ACTION_OK"); return; }
+    } else if (strcmp(domain, "AM") == 0) {
+      using K = orcsdr::am::ActionKind; K kind = K::none;
+      if (!strcmp(action, "TUNE")) kind=K::tune_hz; else if (!strcmp(action, "DOWN")) kind=K::step_down;
+      else if (!strcmp(action, "UP")) kind=K::step_up; else if (!strcmp(action, "SPACING")) kind=K::spacing_toggle;
+      else if (!strcmp(action, "FILTER")) kind=K::filter_cycle; else if (!strcmp(action, "SPAN_DOWN")) kind=K::span_down;
+      else if (!strcmp(action, "SPAN_UP")) kind=K::span_up; else if (!strcmp(action, "PRESET")) kind=K::preset_recall;
+      else if (!strcmp(action, "SAVE")) kind=K::preset_save; else if (!strcmp(action, "SOUND")) kind=K::sound_toggle;
+      else if (!strcmp(action, "VOL_DOWN")) kind=K::volume_down; else if (!strcmp(action, "VOL_UP")) kind=K::volume_up;
+      else if (!strcmp(action, "GRAPHICS")) kind=K::graphics_toggle; else if (!strcmp(action, "RECORD")) kind=K::recording_toggle;
+      else if (!strcmp(action, "SETTINGS")) kind=K::open_device_settings; else if (!strcmp(action, "HOME")) kind=K::exit_home;
+      if (kind == K::tune_hz &&
+          (fields != 3 || value < orcsdr::receiver_bands::kAmBroadcast.min_hz ||
+           value > orcsdr::receiver_bands::kAmBroadcast.max_hz)) {
+        Serial.println("RTL_UI_ACTION_INVALID am_frequency_out_of_range");
+        return;
+      }
+      if (kind == K::preset_recall && (fields != 3 || value < 1 || value > 6)) {
+        Serial.println("RTL_UI_ACTION_INVALID am_preset_out_of_range");
+        return;
+      }
+      if (kind != K::none) {
+        handle_am_dashboard_action({kind, static_cast<uint32_t>(
+            kind == K::preset_recall ? value - 1 : value)});
+        Serial.println("RTL_UI_ACTION_OK");
+        return;
+      }
     } else if (strcmp(domain, "P25") == 0) {
       using K = orcsdr::p25::ActionKind; K kind = K::none;
       if (!strcmp(action, "TUNE")) kind=K::tune_hz; else if (!strcmp(action, "PREV")) kind=K::previous_candidate;
@@ -12860,7 +13088,6 @@ void process_command(char* command) {
     return;
   }
   if (strcmp(command, "RTL_REC_START") == 0) {
-    if (orc_tool_current() != OrcTool::Capture) set_orc_tool(OrcTool::Capture);
     (void)audio_rec_start();
     return;
   }
@@ -13028,7 +13255,7 @@ void process_command(char* command) {
   if (strcmp(command, "RTL_HELP") == 0) {
     Serial.println("RTL_HELP_BEGIN");
     Serial.println("RTL_STATUS                    - device connection info");
-    Serial.println("RTL_DRIVER STATUS|SELF_CHECK  - v0.7.9 capabilities, shadows and stream metrics");
+    Serial.println("RTL_DRIVER STATUS|SELF_CHECK  - driver capabilities, shadows and stream metrics");
     Serial.println("RTL_DRIVER GAINMODE AUTO|MANUAL | GAIN <0..496> | RTLAGC ON|OFF | BIAS ON|OFF (auth)");
     Serial.println("RTL_HEALTH                    - heap, task and reset diagnostics");
     Serial.println("RTL_RESET                     - authenticated software reset");
@@ -13036,10 +13263,10 @@ void process_command(char* command) {
     Serial.println("RTL_SCREEN_STATUS             - active screen ownership diagnostics");
     Serial.println("RTL_UI_REGRESSION CHECK|RUN   - passive checks or Home->screen restore test");
     Serial.println("RTL_UI STATUS                  - current screen/dashboard state");
-    Serial.println("RTL_UI OPEN <HOME|FM|P25|ADSB|LORA|RF_LAB|WIFI_ANALYSIS|SETTINGS> - open dashboard (auth)");
+    Serial.println("RTL_UI OPEN <HOME|FM|AM|P25|ADSB|LORA|RF_LAB|WIFI_ANALYSIS|SETTINGS> - open dashboard (auth)");
     Serial.println("RTL_LAB OPEN|CLOSE|STATUS|PAGE|GET|SET|ACTION|SELF_CHECK - RF Lab UI/control");
     Serial.println("RTL_LAB REFERENCE|SNAPSHOT|RUN|RECIPE|RECORDS - RF Lab evidence workflow (mutations auth)");
-    Serial.println("RTL_UI ACTION <domain> <action> [value] - mirror FM/P25/LoRa/Settings touch action (auth)");
+    Serial.println("RTL_UI ACTION <domain> <action> [value] - mirror FM/AM/P25/LoRa/Settings touch action (auth)");
     Serial.println("RTL_WIFI_STATUS|C6_STATUS|COEX_STATUS|SCAN|RESULTS|PROFILES - Wi-Fi and radio coexistence state");
     Serial.println("RTL_WIFI_C6_UPDATE CONFIRM - authenticated explicit in-app C6 update");
     Serial.println("RTL_WIFI_CONNECT_SAVED [PAUSE]|DISCONNECT - connect profile 0 with a temporary SDR pause");
@@ -14163,6 +14390,10 @@ void setup() {
     Serial.println("RTL_FM_DASHBOARD_SELF_CHECK_FAIL");
   }
   Serial.println("RTL_FM_DASHBOARD_SELF_CHECK_OK");
+  if (!orcsdr::am::self_check()) {
+    Serial.println("RTL_AM_DASHBOARD_SELF_CHECK_FAIL");
+  }
+  Serial.println("RTL_AM_DASHBOARD_SELF_CHECK_OK");
   if (!orcsdr::fmconfig::self_check()) {
     Serial.println("RTL_FM_CONFIG_SELF_CHECK_FAIL");
   }
@@ -14383,6 +14614,7 @@ void loop() {
   const bool settings_ui = orcsdr::settings::active();
   const bool home_ui = orcsdr::home::active();
   const bool fm_ui = rtl_ui_band == RtlBand::fm && orcsdr::fm::active();
+  const bool am_ui = rtl_ui_band == RtlBand::am && orcsdr::am::active();
   const bool p25_ui = rtl_ui_band == RtlBand::p25 && orcsdr::p25::active();
   const bool visualizer_ui = orcsdr::visualizer::active();
   const bool rf_lab_ui = orcsdr::rf_lab::active();
@@ -14393,6 +14625,7 @@ void loop() {
   // The main UI task is the sole M5Unified/touch/display owner.
   const uint32_t m5_started_ms = millis();
   M5.update();
+  service_headphone_speaker_route();
   const uint32_t m5_elapsed_ms = millis() - m5_started_ms;
   if (m5_elapsed_ms >= 500)
     Serial.printf("RTL_MAIN_STALL stage=m5_update elapsed_ms=%u\n", m5_elapsed_ms);
@@ -14400,7 +14633,8 @@ void loop() {
   service_rf_lab();
   if (rtl_stream_spectrum_pending.exchange(false, std::memory_order_acq_rel) &&
       !orcsdr::visualizer::active() && !orcsdr::rf_lab::active() &&
-      (fm_ui || p25_ui || (rtl_ui_band == RtlBand::lora && orcsdr::lora::active()))) {
+      (fm_ui || am_ui || p25_ui ||
+       (rtl_ui_band == RtlBand::lora && orcsdr::lora::active()))) {
     draw_spectrum(nullptr, 0);
   }
   {
@@ -14498,6 +14732,7 @@ void loop() {
               const auto* entry = orcsdr::dashboards::descriptor(i);
               if (entry == nullptr) continue;
               const char* name = entry->id == orcsdr::dashboards::Id::fm ? "fm"
+                                 : entry->id == orcsdr::dashboards::Id::am ? "am"
                                  : entry->id == orcsdr::dashboards::Id::p25 ? "p25"
                                  : entry->id == orcsdr::dashboards::Id::adsb ? "adsb"
                                  : entry->id == orcsdr::dashboards::Id::shortwave ? "shortwave"
@@ -14561,6 +14796,7 @@ void loop() {
           const auto* entry = orcsdr::dashboards::find(id);
           if (entry == nullptr) continue;
           const char* name = id == orcsdr::dashboards::Id::fm           ? "fm"
+                             : id == orcsdr::dashboards::Id::am          ? "am"
                              : id == orcsdr::dashboards::Id::p25        ? "p25"
                              : id == orcsdr::dashboards::Id::adsb       ? "adsb"
                              : id == orcsdr::dashboards::Id::shortwave  ? "shortwave"
@@ -14724,7 +14960,7 @@ void loop() {
       publish_pocsag_snapshot(millis());
       refresh_active_screen();
     }
-  } else if (fm_ui || p25_ui || radio_ui) {
+  } else if (fm_ui || am_ui || p25_ui || radio_ui) {
     poll_sdr_touch(false);
   } else if (!radio_ui) {
     const auto touch = M5.Touch.getDetail(0);

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -1125,7 +1125,24 @@ static std::atomic<int> rtl_fm_preset_scan_total_steps{1};
 static std::atomic<int> rtl_fm_preset_scan_found{0};
 static std::atomic<uint32_t> rtl_fm_preset_scan_freq_hz{kRtlFmMinHz};
 
-enum class ActiveScan : uint8_t { none, fm_presets, p25_survey, pocsag_discovery };
+constexpr size_t kAmScanMaxChannels = 160;
+constexpr uint32_t kAmScanSettleMs = 220;
+EXT_RAM_BSS_ATTR static float am_scan_levels[kAmScanMaxChannels]{};
+static uint32_t am_scan_start_hz = 530000;
+static uint32_t am_scan_step_hz = 10000;
+static size_t am_scan_count = 0;
+static std::atomic<bool> rtl_am_scan_requested{false};
+static std::atomic<bool> rtl_am_scan_cancel{false};
+static std::atomic<bool> rtl_am_scan_active{false};
+static std::atomic<uint16_t> rtl_am_scan_step{0};
+static std::atomic<uint16_t> rtl_am_scan_total{1};
+static std::atomic<uint8_t> rtl_am_scan_found{0};
+static std::atomic<uint32_t> rtl_am_scan_freq_hz{kRtlAmDefaultHz};
+static std::atomic<bool> rtl_am_gain_auto_enabled{true};
+static std::atomic<bool> rtl_am_gain_auto_selecting{false};
+static std::atomic<bool> rtl_am_gain_auto_restart{true};
+
+enum class ActiveScan : uint8_t { none, fm_presets, am_presets, p25_survey, pocsag_discovery };
 orcsdr::radio::Session radio_session;
 orcsdr::scan::Engine scan_engine;
 ActiveScan active_scan = ActiveScan::none;  // Streaming task only.
@@ -2214,6 +2231,7 @@ void handle_p25_dashboard_action(const orcsdr::p25::Action& action);
 orcsdr::lora::Snapshot lora_dashboard_snapshot();
 void handle_lora_dashboard_action(const orcsdr::lora::Action& action);
 void service_shared_scan(uint32_t now);
+void service_am_auto_gain(uint32_t now);
 void service_p25_entry_probe(uint32_t now);
 void cancel_active_scan(bool restore);
 void service_p25_follow(uint32_t now);
@@ -7753,6 +7771,7 @@ static void rtl_driver_app_task(void *) {
           }
           service_p25_entry_probe(now_retune);
           service_shared_scan(now_retune);
+          service_am_auto_gain(now_retune);
           uint32_t desired_lo = rtl_hot_retune_hz.load(std::memory_order_acquire);
           const bool force_lo =
               rtl_fm_force_lo_apply.load(std::memory_order_acquire);
@@ -8670,6 +8689,25 @@ orcsdr::am::Snapshot am_dashboard_snapshot() {
   snapshot.recording = g_audio_rec_active.load(std::memory_order_relaxed);
   snapshot.volume = rtl_ui_volume;
   snapshot.battery_percent = M5.Power.getBatteryLevel();
+  snapshot.scan_active = rtl_am_scan_active.load(std::memory_order_relaxed);
+  snapshot.scan_step = rtl_am_scan_step.load(std::memory_order_relaxed);
+  snapshot.scan_total = rtl_am_scan_total.load(std::memory_order_relaxed);
+  snapshot.scan_found = rtl_am_scan_found.load(std::memory_order_relaxed);
+  snapshot.scan_frequency_hz = rtl_am_scan_freq_hz.load(std::memory_order_relaxed);
+#if !RTL_USE_LEGACY_USB
+  if (g_rtl != nullptr) {
+    snapshot.gain_auto = rtl_am_gain_auto_enabled.load(std::memory_order_relaxed);
+    snapshot.gain_auto_selecting =
+        rtl_am_gain_auto_selecting.load(std::memory_order_relaxed);
+    (void)esp_rtl_sdr_get_tuner_gain(g_rtl, &snapshot.gain_tenth_db);
+    size_t gain_count = 0;
+    if (esp_rtl_sdr_get_tuner_gains(g_rtl, snapshot.gain_steps_tenth_db,
+                                    std::size(snapshot.gain_steps_tenth_db),
+                                    &gain_count) == ESP_OK)
+      snapshot.gain_step_count = static_cast<uint8_t>(std::min(
+          gain_count, std::size(snapshot.gain_steps_tenth_db)));
+  }
+#endif
   orcsdr::am::populate_presets(snapshot);
   return snapshot;
 }
@@ -8694,7 +8732,7 @@ void handle_am_dashboard_action(const orcsdr::am::Action& action) {
       rtl_am_step_hz = orcsdr::am::toggle_channel_step();
       break;
     case ActionKind::filter_cycle: {
-      static constexpr uint32_t widths[] = {4000, 6000, 10000};
+      static constexpr uint32_t widths[] = {4000, 6000, 8000, 10000};
       size_t i = 0;
       const uint32_t current = rtl_filter_bandwidth_hz.load(std::memory_order_relaxed);
       while (i < std::size(widths) && widths[i] != current) ++i;
@@ -8730,6 +8768,30 @@ void handle_am_dashboard_action(const orcsdr::am::Action& action) {
     case ActionKind::recording_toggle:
       if (g_audio_rec_active.load(std::memory_order_acquire)) (void)audio_rec_stop_and_export();
       else (void)audio_rec_start();
+      break;
+    case ActionKind::gain_auto:
+#if !RTL_USE_LEGACY_USB
+      rtl_am_gain_auto_enabled.store(true, std::memory_order_relaxed);
+      rtl_am_gain_auto_restart.store(true, std::memory_order_release);
+      Serial.println("RTL_AM_GAIN mode=AUTO strategy=lowest_usable");
+#endif
+      break;
+    case ActionKind::gain_tenth_db:
+#if !RTL_USE_LEGACY_USB
+      rtl_am_gain_auto_enabled.store(false, std::memory_order_relaxed);
+      rtl_am_gain_auto_selecting.store(false, std::memory_order_relaxed);
+      rtl_am_gain_auto_restart.store(false, std::memory_order_relaxed);
+      if (g_rtl != nullptr)
+        Serial.printf("RTL_AM_GAIN mode=MANUAL gain_tenth_db=%lu result=%s\n",
+                      static_cast<unsigned long>(action.value), esp_rtl_sdr_err_to_name(
+                          esp_rtl_sdr_set_tuner_gain(g_rtl, static_cast<int>(action.value))));
+#endif
+      break;
+    case ActionKind::scan_toggle:
+      if (rtl_am_scan_active.load(std::memory_order_relaxed))
+        rtl_am_scan_cancel.store(true, std::memory_order_relaxed);
+      else
+        rtl_am_scan_requested.store(true, std::memory_order_relaxed);
       break;
     case ActionKind::open_device_settings:
       open_global_settings(orcsdr::settings::Section::radio_defaults);
@@ -9267,7 +9329,9 @@ void handle_lora_dashboard_action(const orcsdr::lora::Action& action) {
 }
 
 bool scan_retune(uint32_t frequency_hz, void*) {
-  if (active_scan == ActiveScan::fm_presets) reset_spectrum_renderer();
+  if (active_scan == ActiveScan::fm_presets || active_scan == ActiveScan::am_presets)
+    reset_spectrum_renderer();
+  if (active_scan == ActiveScan::am_presets) rtl_audio_reset_demod_filters();
   // Each discovery candidate must start with a clean decoder: without this,
   // stats() would accumulate across channels and scan_measure's per-channel
   // read would reflect the WHOLE scan so far, not just this one candidate.
@@ -9277,6 +9341,16 @@ bool scan_retune(uint32_t frequency_hz, void*) {
 }
 
 void scan_measure(size_t index, uint32_t frequency_hz, void*) {
+  if (active_scan == ActiveScan::am_presets) {
+    if (index < kAmScanMaxChannels)
+      am_scan_levels[index] = rtl_signal_dbfs.load(std::memory_order_relaxed);
+    rtl_am_scan_step.store(static_cast<uint16_t>(index + 1), std::memory_order_relaxed);
+    if (serial_verbosity_at(SerialVerbosity::trace))
+      Serial.printf("RTL_AM_SCAN_SAMPLE index=%u frequency_hz=%lu relative_dbfs=%.1f\n",
+                    static_cast<unsigned>(index), static_cast<unsigned long>(frequency_hz),
+                    static_cast<double>(am_scan_levels[index]));
+    return;
+  }
   if (active_scan == ActiveScan::fm_presets) {
     const float level = rtl_scope_peak_level.load(std::memory_order_relaxed);
     const int32_t offset = rtl_scope_peak_offset_hz.load(std::memory_order_relaxed);
@@ -9335,6 +9409,22 @@ void scan_finished(orcsdr::scan::Finish reason, void*) {
                               ? "done"
                               : reason == orcsdr::scan::Finish::cancelled ? "cancelled" : "failed";
     Serial.printf("RTL_PRESET_SCAN %s found=%d\n", outcome, fm_preset_count);
+    return;
+  }
+  if (finished == ActiveScan::am_presets) {
+    rtl_am_scan_active.store(false, std::memory_order_release);
+    uint8_t added = 0;
+    float baseline = -120.0f;
+    if (reason == orcsdr::scan::Finish::completed && am_scan_count > 0)
+      added = orcsdr::am::add_scan_results(am_scan_start_hz, am_scan_step_hz,
+                                           am_scan_levels, am_scan_count, &baseline);
+    rtl_am_scan_found.store(added, std::memory_order_relaxed);
+    rtl_stream_ui_refresh_pending.store(true, std::memory_order_release);
+    const char* outcome = reason == orcsdr::scan::Finish::completed
+                              ? "done"
+                              : reason == orcsdr::scan::Finish::cancelled ? "cancelled" : "failed";
+    Serial.printf("RTL_AM_SCAN %s added=%u baseline_dbfs=%.1f\n", outcome,
+                  static_cast<unsigned>(added), static_cast<double>(baseline));
     return;
   }
   if (finished == ActiveScan::pocsag_discovery) {
@@ -9427,6 +9517,9 @@ void service_shared_scan(uint32_t now) {
   if (rtl_fm_preset_scan_cancel.exchange(false, std::memory_order_acq_rel) &&
       active_scan == ActiveScan::fm_presets)
     scan_engine.cancel(true, callbacks);
+  if (rtl_am_scan_cancel.exchange(false, std::memory_order_acq_rel) &&
+      active_scan == ActiveScan::am_presets)
+    scan_engine.cancel(true, callbacks);
   if (p25_survey_cancel_requested.exchange(false, std::memory_order_acq_rel) &&
       active_scan == ActiveScan::p25_survey) {
     scan_engine.cancel(false, callbacks);
@@ -9480,6 +9573,31 @@ void service_shared_scan(uint32_t now) {
                     static_cast<unsigned>(p25_config.control_channel_count));
     }
   }
+  if (!scan_engine.active() && g_stream_band == RtlBand::am &&
+      rtl_am_scan_requested.exchange(false, std::memory_order_acq_rel)) {
+    am_scan_step_hz = rtl_am_step_hz;
+    am_scan_start_hz = am_scan_step_hz == 9000 ? 531000u : 530000u;
+    am_scan_count = (kRtlAmMaxHz - am_scan_start_hz) / am_scan_step_hz + 1;
+    const auto session = radio_session.snapshot();
+    scan_radio_token = {session.owner, session.generation};
+    const orcsdr::scan::Plan plan{orcsdr::scan::Mode::frequency_range, nullptr, am_scan_count,
+                                  am_scan_start_hz, am_scan_step_hz,
+                                  kAmScanSettleMs, true};
+    if (am_scan_count <= kAmScanMaxChannels &&
+        scan_engine.start(plan, rtl_ui_frequency_hz, now)) {
+      active_scan = ActiveScan::am_presets;
+      std::fill_n(am_scan_levels, am_scan_count, -120.0f);
+      rtl_am_scan_active.store(true, std::memory_order_release);
+      rtl_am_scan_step.store(0, std::memory_order_relaxed);
+      rtl_am_scan_total.store(static_cast<uint16_t>(am_scan_count), std::memory_order_relaxed);
+      rtl_am_scan_found.store(0, std::memory_order_relaxed);
+      rtl_stream_ui_refresh_pending.store(true, std::memory_order_release);
+      Serial.printf("RTL_AM_SCAN start channels=%u step_hz=%lu settle_ms=%lu\n",
+                    static_cast<unsigned>(am_scan_count),
+                    static_cast<unsigned long>(am_scan_step_hz),
+                    static_cast<unsigned long>(kAmScanSettleMs));
+    }
+  }
   if (!scan_engine.active() && g_stream_band == RtlBand::pocsag &&
       pocsag_scan_requested.exchange(false, std::memory_order_acq_rel)) {
     const auto session = radio_session.snapshot();
@@ -9505,7 +9623,49 @@ void service_shared_scan(uint32_t now) {
   const auto progress = scan_engine.progress();
   if (active_scan == ActiveScan::fm_presets && progress.active)
     rtl_fm_preset_scan_freq_hz.store(progress.frequency_hz, std::memory_order_relaxed);
+  if (active_scan == ActiveScan::am_presets && progress.active)
+    rtl_am_scan_freq_hz.store(progress.frequency_hz, std::memory_order_relaxed);
   scan_engine.service(now, callbacks);
+}
+
+void service_am_auto_gain(uint32_t now) {
+#if !RTL_USE_LEGACY_USB
+  static uint8_t step = 0;
+  static uint32_t sample_at_ms = 0;
+  if (g_stream_band != RtlBand::am || g_rtl == nullptr ||
+      rtl_am_scan_active.load(std::memory_order_relaxed) ||
+      !rtl_am_gain_auto_enabled.load(std::memory_order_relaxed)) return;
+
+  int gains[32]{};
+  size_t count = 0;
+  if (esp_rtl_sdr_get_tuner_gains(g_rtl, gains, std::size(gains), &count) != ESP_OK ||
+      count == 0) return;
+  count = std::min(count, std::size(gains));
+  if (rtl_am_gain_auto_restart.exchange(false, std::memory_order_acq_rel)) {
+    step = 0;
+    rtl_am_gain_auto_selecting.store(true, std::memory_order_relaxed);
+    (void)esp_rtl_sdr_set_tuner_gain(g_rtl, gains[step]);
+    sample_at_ms = now + 500;
+    Serial.printf("RTL_AM_AUTO_GAIN start gain_tenth_db=%d target_dbfs=%.1f\n",
+                  gains[step], static_cast<double>(orcsdr::am::kAutoGainTargetDbfs));
+    return;
+  }
+  if (!rtl_am_gain_auto_selecting.load(std::memory_order_relaxed) ||
+      static_cast<int32_t>(now - sample_at_ms) < 0) return;
+
+  const float level = rtl_signal_dbfs.load(std::memory_order_relaxed);
+  if (orcsdr::am::auto_gain_should_advance(level, step, count)) {
+    ++step;
+    (void)esp_rtl_sdr_set_tuner_gain(g_rtl, gains[step]);
+    sample_at_ms = now + 500;
+    return;
+  }
+  rtl_am_gain_auto_selecting.store(false, std::memory_order_relaxed);
+  Serial.printf("RTL_AM_AUTO_GAIN selected gain_tenth_db=%d level_dbfs=%.1f\n",
+                gains[step], static_cast<double>(level));
+#else
+  (void)now;
+#endif
 }
 
 void service_p25_entry_probe(uint32_t now) {
@@ -10019,7 +10179,12 @@ void open_dashboard(orcsdr::dashboards::Id id) {
   uint32_t frequency = rtl_ui_frequency_hz;
   switch (id) {
     case Id::fm: band = RtlBand::fm; frequency = rtl_saved_fm_hz; break;
-    case Id::am: band = RtlBand::am; frequency = orcsdr::am::saved_frequency(); break;
+    case Id::am:
+      band = RtlBand::am;
+      frequency = rtl_ui_band == RtlBand::am
+                      ? rtl_ui_frequency_hz
+                      : orcsdr::am::saved_frequency();
+      break;
     case Id::p25: band = RtlBand::p25; frequency = p25_control_frequency_hz; break;
     case Id::adsb: band = RtlBand::adsb; frequency = kAdsbDefaultHz; break;
     case Id::pocsag: band = RtlBand::pocsag; frequency = pocsag_config_frequency_hz; break;
@@ -10060,6 +10225,7 @@ void handle_home_action(const orcsdr::home::Action& action) {
       open_global_settings(orcsdr::settings::Section::connectivity);
       return;
     case ActionKind::tune_frequency:
+      if (rtl_ui_band == RtlBand::am) orcsdr::am::note_tuned(action.value);
       if (rtl_ui_band == RtlBand::p25) {
         cancel_p25_survey();
         tune_p25_control(action.value);
@@ -10083,6 +10249,7 @@ void handle_home_action(const orcsdr::home::Action& action) {
       const uint32_t next = rtl_step_frequency(
           rtl_ui_band, rtl_ui_frequency_hz,
           action.kind == ActionKind::step_down ? -1 : 1);
+      if (rtl_ui_band == RtlBand::am) orcsdr::am::note_tuned(next);
       if (rtl_capture_state.load(std::memory_order_acquire) == RtlCaptureState::running)
         request_hot_retune(next);
       else
@@ -11011,6 +11178,9 @@ bool request_hot_retune_for(orcsdr::radio::Token token, uint32_t frequency_hz) {
   if (rtl_ui_band == RtlBand::fm) ui_hz = rtl_fm_sanitize_display_hz(ui_hz);
   if (!radio_session.retuned(token, ui_hz)) return false;
   const bool ui_changed = (ui_hz != rtl_ui_frequency_hz);
+  if (ui_changed && rtl_ui_band == RtlBand::am &&
+      rtl_am_gain_auto_enabled.load(std::memory_order_relaxed))
+    rtl_am_gain_auto_restart.store(true, std::memory_order_release);
   if (ui_changed && rtl_ui_band == RtlBand::fm) {
     rtl_fm_lo_nudge_hz.store(0, std::memory_order_relaxed);
     rtl_fm_last_user_tune_ms.store(millis(), std::memory_order_relaxed);
@@ -11088,6 +11258,15 @@ void poll_sdr_touch(bool from_stream) {
     if (pressed && !was_pressed) handle_sdr_touch(touch.x, touch.y);
     was_pressed = pressed;
     return;
+  }
+
+  if (pressed && rtl_ui_band == RtlBand::am && orcsdr::am::active()) {
+    const auto action = orcsdr::am::handle_gain_drag(touch.x, touch.y);
+    if (action.kind != orcsdr::am::ActionKind::none) {
+      handle_am_dashboard_action(action);
+      was_pressed = true;
+      return;
+    }
   }
 
   if (touch_count >= 2) {
@@ -11322,6 +11501,7 @@ void handle_sdr_touch(int32_t x, int32_t y) {
     handle_fm_dashboard_action(orcsdr::fm::handle_touch(x, y));
     return;
   }
+
   if (rtl_ui_band == RtlBand::am && orcsdr::am::active()) {
     handle_am_dashboard_action(orcsdr::am::handle_touch(x, y));
     return;
@@ -12532,6 +12712,8 @@ void process_command(char* command) {
       else if (!strcmp(action, "SAVE")) kind=K::preset_save; else if (!strcmp(action, "SOUND")) kind=K::sound_toggle;
       else if (!strcmp(action, "VOL_DOWN")) kind=K::volume_down; else if (!strcmp(action, "VOL_UP")) kind=K::volume_up;
       else if (!strcmp(action, "GRAPHICS")) kind=K::graphics_toggle; else if (!strcmp(action, "RECORD")) kind=K::recording_toggle;
+      else if (!strcmp(action, "GAIN_AUTO")) kind=K::gain_auto; else if (!strcmp(action, "GAIN")) kind=K::gain_tenth_db;
+      else if (!strcmp(action, "SCAN")) kind=K::scan_toggle;
       else if (!strcmp(action, "SETTINGS")) kind=K::open_device_settings; else if (!strcmp(action, "HOME")) kind=K::exit_home;
       if (kind == K::tune_hz &&
           (fields != 3 || value < orcsdr::receiver_bands::kAmBroadcast.min_hz ||
@@ -12541,6 +12723,10 @@ void process_command(char* command) {
       }
       if (kind == K::preset_recall && (fields != 3 || value < 1 || value > 6)) {
         Serial.println("RTL_UI_ACTION_INVALID am_preset_out_of_range");
+        return;
+      }
+      if (kind == K::gain_tenth_db && (fields != 3 || value > 496)) {
+        Serial.println("RTL_UI_ACTION_INVALID am_gain_out_of_range");
         return;
       }
       if (kind != K::none) {
@@ -13195,6 +13381,24 @@ void process_command(char* command) {
   }
   if (strcmp(command, "RTL_DRIVER STATUS") == 0) {
     print_rtl_driver_status();
+    return;
+  }
+  if (strcmp(command, "RTL_AM_SCAN STATUS") == 0) {
+    Serial.printf("RTL_AM_SCAN_STATUS active=%d step=%u total=%u found=%u frequency_hz=%lu\n",
+                  rtl_am_scan_active.load(std::memory_order_relaxed) ? 1 : 0,
+                  static_cast<unsigned>(rtl_am_scan_step.load(std::memory_order_relaxed)),
+                  static_cast<unsigned>(rtl_am_scan_total.load(std::memory_order_relaxed)),
+                  static_cast<unsigned>(rtl_am_scan_found.load(std::memory_order_relaxed)),
+                  static_cast<unsigned long>(rtl_am_scan_freq_hz.load(std::memory_order_relaxed)));
+    return;
+  }
+  if (strcmp(command, "RTL_AM_GAIN STATUS") == 0) {
+    int gain = 0;
+    if (g_rtl != nullptr) (void)esp_rtl_sdr_get_tuner_gain(g_rtl, &gain);
+    Serial.printf("RTL_AM_GAIN_STATUS mode=%s selecting=%d gain_tenth_db=%d target_dbfs=%.1f\n",
+                  rtl_am_gain_auto_enabled.load(std::memory_order_relaxed) ? "AUTO" : "MANUAL",
+                  rtl_am_gain_auto_selecting.load(std::memory_order_relaxed) ? 1 : 0, gain,
+                  static_cast<double>(orcsdr::am::kAutoGainTargetDbfs));
     return;
   }
   if (strcmp(command, "RTL_DRIVER SELF_CHECK") == 0) {

--- a/apps/orcsdr-tab5/ui/navigation_service.cpp
+++ b/apps/orcsdr-tab5/ui/navigation_service.cpp
@@ -6,6 +6,7 @@
 #include <iterator>
 
 #include "adsb_dashboard.hpp"
+#include "am_dashboard.hpp"
 #include "fm_dashboard.hpp"
 #include "lora_dashboard.hpp"
 #include "p25_dashboard.hpp"
@@ -32,6 +33,7 @@ void show_home(bool demo) {
   screens::begin_transition(screens::Id::home, millis());
   if (settings::active()) g_hooks.restore_graphics(g_restore_graphics);
   fm::leave();
+  am::leave();
   p25::leave();
   pocsag::leave();
   adsb::leave();

--- a/apps/orcsdr-tab5/ui/receiver_band_plan.hpp
+++ b/apps/orcsdr-tab5/ui/receiver_band_plan.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <cstdint>
+
+namespace orcsdr::receiver_bands {
+
+struct Profile {
+  uint32_t min_hz;
+  uint32_t max_hz;
+  uint32_t default_hz;
+  uint32_t default_step_hz;
+  uint32_t default_bandwidth_hz;
+};
+
+constexpr Profile kAmBroadcast{520000, 1710000, 1000000, 10000, 10000};
+constexpr Profile kShortwave{1710000, 30000000, 7100000, 1000, 6000};
+
+constexpr bool valid(const Profile& profile) {
+  return profile.min_hz <= profile.default_hz && profile.default_hz <= profile.max_hz &&
+         profile.default_step_hz > 0 && profile.default_bandwidth_hz > 0;
+}
+
+static_assert(valid(kAmBroadcast));
+static_assert(valid(kShortwave));
+static_assert(kAmBroadcast.max_hz <= kShortwave.min_hz);
+
+}  // namespace orcsdr::receiver_bands

--- a/apps/orcsdr-tab5/ui/rf_analysis.cpp
+++ b/apps/orcsdr-tab5/ui/rf_analysis.cpp
@@ -222,8 +222,8 @@ bool analyze_iq(const uint8_t* iq, size_t bytes, Snapshot* next, float* work,
   for (int i = 0; i < n; ++i) {
     const float window = 0.5f - 0.5f * cosf(2.0f * kPi * i / (n - 1));
     coherent_sum += window;
-    work[i * 2] = ((static_cast<int>(iq[i * 2]) - 127.5f) / 127.5f) * window;
-    work[i * 2 + 1] = ((static_cast<int>(iq[i * 2 + 1]) - 127.5f) / 127.5f) * window;
+    work[i * 2] = next->iq_i[i] * window;
+    work[i * 2 + 1] = next->iq_q[i] * window;
   }
   if (dsps_fft2r_fc32_ansi(work, n) != ESP_OK ||
       dsps_bit_rev_fc32_ansi(work, n) != ESP_OK)
@@ -504,8 +504,8 @@ bool self_check() {
   }
   for (size_t i = 0; i < samples; ++i) {
     const float phase = 2.0f * kPi * 32.0f * i / samples;
-    iq[i * 2] = static_cast<uint8_t>(lroundf(127.5f + 80.0f * cosf(phase)));
-    iq[i * 2 + 1] = static_cast<uint8_t>(lroundf(127.5f + 80.0f * sinf(phase)));
+    iq[i * 2] = static_cast<uint8_t>(lroundf(227.5f + 20.0f * cosf(phase)));
+    iq[i * 2 + 1] = static_cast<uint8_t>(lroundf(227.5f + 20.0f * sinf(phase)));
     snapshot->average[i] = -160;
     snapshot->peak[i] = -160;
   }
@@ -518,7 +518,7 @@ bool self_check() {
   const bool analyzed = analyze_iq(iq, samples * 2, snapshot, work, scratch, config);
   const bool valid = analyzed && snapshot->bins == samples &&
                      fabsf(snapshot->strongest_offset_hz - 120000.0f) < 8000.0f &&
-                     snapshot->strongest > -8.0f && snapshot->strongest < 0.0f &&
+                     snapshot->strongest > -20.0f && snapshot->strongest < -12.0f &&
                      snapshot->clipping_percent == 0.0f &&
                      fabsf(snapshot->iq_imbalance_db) < 0.5f &&
                      snapshot->occupied_bandwidth_hz > 0 &&

--- a/apps/orcsdr-tab5/ui/rf_analysis.cpp
+++ b/apps/orcsdr-tab5/ui/rf_analysis.cpp
@@ -388,9 +388,8 @@ bool initialize() {
   for (float& level : g_snapshot->average) level = -160;
   for (float& level : g_snapshot->peak) level = -160;
   if (!initialize_fft()) return false;
-  // Analysis is best-effort display work. Sharing the idle priority guarantees
-  // Core 1's watched idle task can run while continuous radio DSP is active.
-  if (xTaskCreatePinnedToCoreWithCaps(worker, "rf_analysis", 8192, nullptr, tskIDLE_PRIORITY,
+  // Interval throttling leaves idle time; priority 1 prevents high-rate IQ from starving analysis.
+  if (xTaskCreatePinnedToCoreWithCaps(worker, "rf_analysis", 8192, nullptr, tskIDLE_PRIORITY + 1,
                                       &g_task, 1,
                                       MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) != pdPASS)
     return false;

--- a/apps/orcsdr-tab5/ui/rf_visualizer.cpp
+++ b/apps/orcsdr-tab5/ui/rf_visualizer.cpp
@@ -1988,7 +1988,7 @@ void set_runtime(const Runtime& runtime) {
                                 previous.audio_rate_sps != runtime.audio_rate_sps ||
                                 previous.filter_bandwidth_hz != runtime.filter_bandwidth_hz ||
                                 previous.audio_demod != runtime.audio_demod;
-  if (g_initialized && analysis_changed) configure_analysis();
+  if (g_initialized && active() && analysis_changed) configure_analysis();
 }
 
 void offer_iq(const uint8_t* iq, size_t bytes) {

--- a/apps/orcsdr-tab5/ui/screen_controller.cpp
+++ b/apps/orcsdr-tab5/ui/screen_controller.cpp
@@ -51,6 +51,7 @@ const char* name(Id id) {
   switch (id) {
     case Id::home: return "home";
     case Id::fm: return "fm";
+    case Id::am: return "am";
     case Id::p25: return "p25";
     case Id::adsb: return "adsb";
     case Id::lora: return "lora";
@@ -76,7 +77,7 @@ bool self_check() {
   bool settings_return = true;
   uint32_t now = 20;
   for (const Id screen :
-       {Id::home, Id::fm, Id::p25, Id::adsb, Id::lora, Id::wifi_analysis, Id::pocsag}) {
+       {Id::home, Id::fm, Id::am, Id::p25, Id::adsb, Id::lora, Id::wifi_analysis, Id::pocsag}) {
     begin_transition(screen, now++, false);
     finish_transition();
     begin_transition(Id::settings, now++, true);
@@ -97,7 +98,7 @@ bool self_check() {
   begin_transition(Id::rf_lab, now++, false);
   finish_transition();
   const bool rf_lab_owns = owns(Id::rf_lab);
-  const bool restored = g_status.transitions == 26;
+  const bool restored = g_status.transitions == 29;
   g_status = saved;
   g_transitioning = saved_transitioning;
   return entering_blocks_draw && home_owns && settings_return && documentation_owns &&

--- a/apps/orcsdr-tab5/ui/screen_controller.hpp
+++ b/apps/orcsdr-tab5/ui/screen_controller.hpp
@@ -7,7 +7,7 @@ namespace orcsdr::screens {
 // Exactly one surface may own the framebuffer.  Radio/decoder work is not a
 // surface and continues independently of this state.
 enum class Id : uint8_t {
-  none, home, fm, p25, adsb, lora, radio, visualizer, rf_lab, wifi_analysis, pocsag, settings, documentation
+  none, home, fm, p25, adsb, lora, radio, visualizer, rf_lab, wifi_analysis, pocsag, settings, am, documentation
 };
 
 struct Status {

--- a/docs/AM_RESEARCH_AND_PROVENANCE.md
+++ b/docs/AM_RESEARCH_AND_PROVENANCE.md
@@ -1,0 +1,28 @@
+# AM broadcast research and provenance
+
+This record distinguishes research from incorporated source code.
+
+| Source | License / terms | Learning used | Derivation status |
+|---|---|---|---|
+| [FCC 88-82](https://docs.fcc.gov/public/attachments/FCC-88-82A1.pdf) | United States government record | Region 2 AM planning extends the existing medium-wave band and must account for adjacent-channel interference. OrcSDR retains selectable channel spacing and receiver bandwidth. | Requirements reference only; no source code. |
+| [Osmocom `rtl_power`](https://github.com/osmocom/rtl-sdr/blob/master/src/rtl_power.c) | GPL-2.0-or-later | A stepped frequency range with dwell/measurement is an established SDR scanning workflow. | Conceptual cross-check only. OrcSDR reuses its independently implemented `scan_engine`; no Osmocom code or constants were copied. |
+| [Osmocom RTL-SDR API](https://github.com/osmocom/rtl-sdr/blob/master/include/rtl-sdr.h) | GPL-2.0-or-later | Tuner automatic and manual gain are distinct modes; manual gain must be enabled before selecting a gain step. | API behavior cross-check only; OrcSDR uses its own ESP driver API. |
+| [RTL-SDR Blog V4 datasheet](https://www.rtl-sdr.com/wp-content/uploads/2024/12/RTLSDR_V4_Datasheet_V_1_0.pdf) | Vendor documentation | The V4 HF path has adjustable gain, so medium-wave gain policy belongs in OrcSDR rather than being treated as a fixed front end. | Hardware reference only; no source code. |
+
+The first AM station scan is deliberately receiver-relative: it measures every
+channel, estimates the median local RF floor, and offers prominent local peaks.
+It fills empty preset slots only, so a scan cannot erase a user's saved stations.
+
+## AM gain acceptance evidence
+
+On the development receiver with a powered ML30+ antenna, a 1050 kHz sweep
+showed input power flattening above roughly 25 dB of tuner gain. Listening tests
+then found that 1280 kHz sounded best at 0.0 dB; a nearby off-channel case was
+clearer around 8.7 dB. These results reject maximum signal strength and the
+tuner's unbounded hardware AGC as AM quality criteria.
+
+OrcSDR's first bounded AM Auto policy therefore starts at the lowest measured
+tuner step and advances only while the live input remains below -24 dBFS.
+Manual movement disables Auto immediately. This is a receiver-protection and
+usability heuristic, not a claim that firmware can measure perceived clarity;
+further antenna and station listening remains the acceptance gate.

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -9,9 +9,29 @@
 ## Existing implementation and evidence
 
 The standalone driver extraction is complete. OrcSDR pins `esp_rtl_sdr`
-v0.7.9; its public C API, USB/tuner implementation, tests, and
-[`p4_serial_smoke` example](https://github.com/hardcoreerik/esp-rtl-sdr/tree/v0.7.9/examples/p4_serial_smoke)
-live in the driver repository. See the [integration contract](API_ESP_RTL_SDR.md).
+directly to reviewed Git commits; its public C API, USB/tuner implementation,
+tests, and `p4_serial_smoke` example live in the driver repository. See the
+[integration contract](API_ESP_RTL_SDR.md).
+
+### Blog V4 HF-routing integration (2026-09-09)
+
+The Tab5 application moved from driver v0.7.14 commit
+`69e61848008ed0fce5a823ad370aee5cb81d65da` to v0.7.15 commit
+`1cd19d1363daea49b013c2d28a25750fcbfcff78` from branch
+`codex/v0.7.15-v4-hf-routing`. The exact commit pin is intentional while the
+driver change awaits release tagging.
+
+The driver change completes the capture-derived Blog V4 HF route: R828D
+Cable-2 selection and RTL2832 GPIO5 upconverter switching are composed with
+VHF/UHF restoration, manual/AUTO gain state, and Bias-T GPIO0. The previous
+driver already translated RF below 28.8 MHz to the tuner frequency; the defect
+was the incomplete physical RF route.
+
+Upstream source evidence reports 372 host assertions passed and a successful
+ESP32-P4 smoke build. OrcSDR's native ESP-IDF 5.5.4 build also passed with the
+new managed component compiled from the exact commit. No firmware was flashed
+for this integration. GPIO5/Bias-T behavior, raw AM and Shortwave RF, AM audio,
+and VHF/UHF restoration remain separate physical acceptance gates.
 
 Waveshare second-board work has already been performed under OrcSDR. The
 driver's [validation provenance](https://github.com/hardcoreerik/esp-rtl-sdr/blob/9bd59129622e0b978b6a4b1fe748cf37fcc2bc37/docs/AI_DEVELOPMENT_DISCLOSURE.md#provenance-honesty-orcsdr--this-repo)


### PR DESCRIPTION
## Milestone

This PR establishes OrcSDR's first complete AM broadcast receive path on Tab5 and moves the project beyond FM-only listening into working medium-wave/HF modulation support. It connects a first-party `esp-rtl-sdr` HF-routing correction to AM demodulation, audio filtering, antenna-aware gain control, a dedicated dashboard module, and a whole-band station-finder workflow that has been exercised on physical hardware.

## What changed

### First-party driver and HF receive path

- Pins OrcSDR to the `esp-rtl-sdr` revision containing the clean-room HF/direct-sampling routing correction.
- Carries AM tuning through the shared receiver/session path without returning users to stale legacy radio UI.
- Keeps AM receiver state and frequency intact when moving between Home and the AM dashboard.
- Supports the 520-1710 kHz medium-wave range needed for North American and international AM operation.

### Self-contained AM dashboard

- Registers AM Broadcast as its own dashboard and screen-controller module instead of expanding the legacy `main.cpp` window model.
- Provides Listen, Finder, Spectrum, and Settings views.
- Adds touch tuning, fine tuning-step selection, spectrum navigation, bandwidth adjustment, volume/audio controls, recording access, and current signal state.
- Supports a continuous 3-30 kHz AM bandwidth range, including practical 4/6/10 kHz listening checks.
- Preserves the tuned station when entering or leaving the dashboard.

### RF gain and antenna behavior

- Adds direct manual RF gain control across the tuner-supported range.
- Adds bounded automatic gain selection that begins at the lowest gain and advances only while measured signal level remains below the target.
- Avoids the previous behavior where Auto simply drove gain to 100%, which overloaded an amplified ML-30+ loop and produced unnecessary noise.
- Keeps manual control available because passive whips, indoor rabbit ears, powered loops, local transmitters, and installation losses require different gain choices.
- Hardware listening showed useful antenna-specific operating points, including approximately 8.7 dB on one 1050 kHz/ML-30+ setup and 0 dB on a strong 1280 kHz signal; Auto is therefore intentionally a bounded starting point rather than a promise that maximum RF level always sounds best.

### 2.4 MS/s AM Station Finder

- Replaces slow channel-by-channel retuning with one 2.4 MS/s IQ capture centered at 1.122 MHz.
- Covers the complete medium-wave band in a single wideband observation and projects FFT energy onto the selected channel grid.
- Supports the 10 kHz Americas plan (530-1710 kHz) and 9 kHz international plan (531-1701 kHz).
- Ranks channels by local prominence above the measured band baseline and presents up to six strong candidates with frequency and dBFS.
- Temporarily pauses listening during capture, then restores the exact station that was playing before the scan.
- Lets users review, select, discard, or save results. Saving no longer clears the Finder list.
- Publishes scan completion safely from the analyzer task and draws the modal once, preventing the flashing/stuck 43% behavior.
- Reduces the analyzer FFT to the smallest useful 2048-point transform for responsive Tab5 operation while retaining 1024 output bins.

### Presets and daily use

- Saves discovered or manually tuned stations to persistent storage.
- Supports more than one visible bank through paging rather than limiting users to six presets.
- Supports long-press replacement and deletion.
- Keeps saved presets across reboot and avoids duplicate entries when scan results are saved more than once.

### Shared RF-analysis corrections

- Prevents an inactive RF visualizer from reconfiguring the shared analyzer while the AM Finder owns it.
- Runs the RF-analysis worker above idle priority so a full-band capture completes promptly under normal UI load.
- Moves the large analyzer snapshot out of the constrained application-task stack.
- Keeps screen ownership with the active modular dashboard during receiver stop/start transitions.

### Serial control and regression coverage

- Adds AM serial actions for tuning, gain, bandwidth, scan control, regional spacing, and preset management.
- Updates the native Tab5 regression path to wait for a real 2.4 MS/s scan completion and require populated candidates instead of immediately cancelling the scan.
- Retains repeatable 590/1120/1280 kHz coverage with 3/6/10/30 kHz filter validation and streaming-progress checks.

## Hardware validation

Validated on the physical Tab5/RTL-SDR setup:

- Native ESP-IDF firmware build completed successfully.
- Firmware flashed successfully over COM17.
- AM audio was intelligible on real broadcast stations, including 1050 and 1280 kHz.
- Manual and automatic RF gain were exercised with powered ML-30+ and passive antenna configurations.
- External 3.5 mm speaker insertion correctly muted the built-in speaker.
- Final automated Finder run scanned all 119 channels at 2.4 MS/s, found six candidates, restored listening, and reported zero analyzer drops.
- On-device acceptance confirmed that Review displays all six results, Save Selected retains the Finder list, Listen receives the presets, and saved presets survive reboot.

Final scan evidence:

```
RTL_AM_SCAN done mode=wideband rate=2400000 frames=20 analyzer_drops=0 clipping_pct=1.66 added=6 baseline_dbfs=-50.5
RTL_AM_SCAN_STATUS active=0 step=119 total=119 found=6 frequency_hz=1122000
```

## AM/FM/Shortwave station database integration

The shared broadcast database is being developed in parallel and is intentionally not mixed into this PR. This AM milestone provides the receiver and discovery foundation it will consume:

- Finder currently detects and ranks real RF energy without pretending every carrier has a known identity.
- The upcoming shared AM/FM/Shortwave catalog can resolve detected frequencies against region, language, schedule, callsign/station name, and service metadata.
- AM and Shortwave should share the catalog/download/index infrastructure while remaining separate self-contained dashboards because their tuning workflows, modulation choices, propagation, schedules, and user expectations differ.
- A later integration can enrich Finder candidates and presets with station names without coupling basic reception or scanning to network/database availability.

## Scope boundary

This PR does not include the in-progress broadcast catalog generators, downloaded datasets, Settings catalog pagination, generated artifacts, or the separate Shortwave dashboard. Those remain independent follow-up work so this AM receive milestone can be reviewed and merged on its own evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AM Radio dashboard with Listen, Finder, Spectrum, and Settings views.
  * Added AM tuning, scanning, spectrum visualization, bandwidth and gain controls, presets, touch support, and automatic gain.
  * Added headphone detection with automatic internal-speaker muting.
  * Added AM navigation, startup restoration, and web-console integration.

* **Bug Fixes**
  * Improved AM demodulation, spectrum analysis, and recording export reliability.

* **Tests**
  * Added AM broadcast regression coverage.

* **Documentation**
  * Documented AM research, tuning, gain behavior, and hardware-porting details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Pre-merge transition fixes

Physical testing after opening the PR exposed two shared-state problems, both now fixed:

- AM manual RF gain no longer leaks into FM. Leaving AM restores tuner AUTO gain for FM; returning to AM restores the user's prior AM manual/automatic choice.
- AM and FM Spectrum views remove per-window I/Q DC before FFT scaling, and the shared analyzer uses its centered samples. This prevents the zero-frequency artifact from dominating the center bin and hiding real stations.
- AM/FM waterfall history no longer paints an artificial permanent center stripe.
- Regression coverage now includes AM -> Home -> FM and requires a streaming FM receiver in AUTO gain mode.

Hardware evidence: AM MANUAL 7.7 dB -> FM AUTO -> AM MANUAL 7.7 dB, with progressing IQ and zero drops. User acceptance confirmed repeated AM/FM navigation restored FM reception.
