### PR TITLE
fix(catalog): reject update checks while Wi-Fi is off

### DIFF
--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -669,6 +669,7 @@ function Assert-OfflineCatalogGuard {
       throw "Wi-Fi did not turn off before catalog test: $($wifi.Line)"
     }
 
+    [void](Open-Ui 'FM' 'FM')
     $before = Wait-DriverStreaming 30
     [void](Send-And-Wait 'RTL_CATALOG_CHECK' '^RTL_CATALOG_CHECK_REJECTED$')
     $catalog = Send-And-Wait 'RTL_CATALOG_STATUS' '^RTL_CATALOG_STATUS '

--- a/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
+++ b/apps/orcsdr-tab5/tools/run-tab5-ui-regression.ps1
@@ -23,6 +23,7 @@ param(
   [switch]$WifiCoexistence,
   [switch]$WifiCoexistenceDiagnostic,
   [switch]$DataOnly,
+  [switch]$OfflineCatalog,
   [switch]$C6Update,
   [switch]$RadioScan,
   [switch]$AmBroadcast,
@@ -657,6 +658,36 @@ function Wait-DriverStreaming([int]$Seconds = 30) {
   throw "Radio did not resume streaming: state=$($driver.State) bytes=$($driver.Bytes)"
 }
 
+function Assert-OfflineCatalogGuard {
+  $initialWifi = Get-WifiStatus
+  try {
+    if ($initialWifi.Power -ne 0) {
+      [void](Send-And-Wait 'RTL_UI ACTION SETTINGS WIFI_POWER 0' '^RTL_UI_ACTION_OK$' 20)
+    }
+    $wifi = Get-WifiStatus
+    if ($wifi.Power -ne 0 -or $wifi.Connected -ne 0) {
+      throw "Wi-Fi did not turn off before catalog test: $($wifi.Line)"
+    }
+
+    $before = Wait-DriverStreaming 30
+    [void](Send-And-Wait 'RTL_CATALOG_CHECK' '^RTL_CATALOG_CHECK_REJECTED$')
+    $catalog = Send-And-Wait 'RTL_CATALOG_STATUS' '^RTL_CATALOG_STATUS '
+    if ($catalog -notmatch 'busy=0 .*message="Connect Wi-Fi before downloading"') {
+      throw "Offline catalog request was not safely rejected: $catalog"
+    }
+    Start-Sleep -Milliseconds 750
+    $after = Get-DriverStatus
+    if ($after.State -ne 'STREAMING' -or $after.Bytes -le $before.Bytes) {
+      throw "Offline catalog request interrupted radio streaming: before=$($before.Bytes) after=$($after.Bytes) state=$($after.State)"
+    }
+    Write-SoakLine "RTL_OFFLINE_CATALOG_RESULT pass=1 message=wifi_required radio_state=$($after.State) bytes_before=$($before.Bytes) bytes_after=$($after.Bytes)"
+  } finally {
+    if ($initialWifi.Power -ne 0) {
+      [void](Send-And-Wait 'RTL_UI ACTION SETTINGS WIFI_POWER 1' '^RTL_UI_ACTION_OK$' 20)
+    }
+  }
+}
+
 function Assert-DataServices {
   $wifi = Get-WifiStatus
   if ($wifi.Power -eq 0) {
@@ -817,8 +848,8 @@ if ($SelfCheck) { Invoke-SelfCheck; exit 0 }
 if (($InstallLaneMap -or $InstallFaaAircraft) -and !$DataOnly) {
   throw '-InstallLaneMap and -InstallFaaAircraft require -DataOnly.'
 }
-if (@($Run, $Soak, $Driver080Rc2, $WifiOnly, $WifiCoexistence, $WifiCoexistenceDiagnostic, $DataOnly, $C6Update, $RadioScan, $AmBroadcast).Where({ $_ }).Count -gt 1) {
-  throw 'Choose only one of -Run, -Soak, -Driver080Rc2, -WifiOnly, -WifiCoexistence, -WifiCoexistenceDiagnostic, -DataOnly, -C6Update, -RadioScan, or -AmBroadcast.'
+if (@($Run, $Soak, $Driver080Rc2, $WifiOnly, $WifiCoexistence, $WifiCoexistenceDiagnostic, $DataOnly, $OfflineCatalog, $C6Update, $RadioScan, $AmBroadcast).Where({ $_ }).Count -gt 1) {
+  throw 'Choose only one of -Run, -Soak, -Driver080Rc2, -WifiOnly, -WifiCoexistence, -WifiCoexistenceDiagnostic, -DataOnly, -OfflineCatalog, -C6Update, -RadioScan, or -AmBroadcast.'
 }
 
 function Get-C6UpdateStatus {
@@ -1247,6 +1278,12 @@ try {
     Wait-DeviceReady 60 11000
     Connect-Authenticated
     Assert-DataServices
+    exit 0
+  }
+  if ($OfflineCatalog) {
+    Wait-DeviceReady 60 11000
+    Connect-Authenticated
+    Assert-OfflineCatalogGuard
     exit 0
   }
   if ($C6Update) { Invoke-C6UpdateTest; exit 0 }

--- a/apps/orcsdr-tab5/ui/catalog_sync.cpp
+++ b/apps/orcsdr-tab5/ui/catalog_sync.cpp
@@ -697,7 +697,7 @@ void worker(void*) {
   vTaskDelete(nullptr);
 }
 
-bool request(Operation operation, uint8_t pack_index, bool needs_wifi) {
+bool request(Operation operation, uint8_t pack_index) {
   if (g_fs == nullptr) {
     set_message("SD storage unavailable");
     return false;
@@ -706,7 +706,7 @@ bool request(Operation operation, uint8_t pack_index, bool needs_wifi) {
     set_message("Catalog operation already running");
     return false;
   }
-  if (needs_wifi && !orcsdr::wifi::connected()) {
+  if (operation != Operation::remove && !orcsdr::wifi::connected()) {
     set_message("Connect Wi-Fi before downloading");
     return false;
   }
@@ -750,9 +750,9 @@ void poll(bool) {
   // the UI loop races the worker's File operations as soon as a manifest is
   // accepted, which can reset the shared SDMMC host.
 }
-bool request_check(bool wifi_connected) { return request(Operation::check, 0, wifi_connected); }
-bool request_install(uint8_t pack_index, bool wifi_connected) { return request(Operation::install, pack_index, wifi_connected); }
-bool request_remove(uint8_t pack_index) { return request(Operation::remove, pack_index, false); }
+bool request_check() { return request(Operation::check, 0); }
+bool request_install(uint8_t pack_index) { return request(Operation::install, pack_index); }
+bool request_remove(uint8_t pack_index) { return request(Operation::remove, pack_index); }
 
 State state() {
   State copy{};

--- a/apps/orcsdr-tab5/ui/catalog_sync.hpp
+++ b/apps/orcsdr-tab5/ui/catalog_sync.hpp
@@ -37,8 +37,8 @@ struct State {
 // never USB/IQ/audio callbacks.
 void begin(orcsdr::storage::FileSystem* filesystem, uint64_t free_bytes = 0);
 void poll(bool wifi_connected);
-bool request_check(bool wifi_connected);
-bool request_install(uint8_t pack_index, bool wifi_connected);
+bool request_check();
+bool request_install(uint8_t pack_index);
 bool request_remove(uint8_t pack_index);
 State state();
 

--- a/apps/orcsdr-tab5/ui/main.cpp
+++ b/apps/orcsdr-tab5/ui/main.cpp
@@ -10790,7 +10790,10 @@ void handle_global_settings_action(const orcsdr::settings::Action& action) {
         orcsdr::catalog::begin(g_sd_fs, sd_total_bytes() -
             orcsdr::storage::used_bytes());
         (void)orcsdr::offline_map::load(g_sd_fs);
-        if (!pause_radio_for_catalog() || !orcsdr::catalog::request_check(wifi_connected)) {
+        if (!orcsdr::wifi::connected()) {
+          (void)orcsdr::catalog::request_check();
+          Serial.println("ORC_CATALOG_CHECK_REJECTED");
+        } else if (!pause_radio_for_catalog() || !orcsdr::catalog::request_check()) {
           resume_radio_after_catalog();
           Serial.println("ORC_CATALOG_CHECK_REJECTED");
         }
@@ -10809,8 +10812,11 @@ void handle_global_settings_action(const orcsdr::settings::Action& action) {
     case orcsdr::settings::ActionKind::catalog_install:
       if (orcsdr::catalog::state().busy) {
         Serial.println("ORC_CATALOG_INSTALL_REJECTED");
+      } else if (!orcsdr::wifi::connected()) {
+        (void)orcsdr::catalog::request_install(static_cast<uint8_t>(action.value));
+        Serial.println("ORC_CATALOG_INSTALL_REJECTED");
       } else if (!pause_radio_for_catalog() ||
-          !orcsdr::catalog::request_install(static_cast<uint8_t>(action.value), wifi_connected)) {
+          !orcsdr::catalog::request_install(static_cast<uint8_t>(action.value))) {
         resume_radio_after_catalog();
         Serial.println("ORC_CATALOG_INSTALL_REJECTED");
       }


### PR DESCRIPTION
## Summary

- reject catalog checks and data-pack installs whenever Wi-Fi is not connected
- enforce that rule inside the shared catalog service so callers cannot bypass it
- reject the settings action before pausing the radio
- add an `-OfflineCatalog` hardware regression that checks the message, process survival, and continued IQ streaming

Fixes #87.

## Root cause

The current connection state was passed into a parameter named `needs_wifi`. When Wi-Fi was off, `false` accidentally disabled the Wi-Fi guard. The worker then attempted DNS before lwIP had a valid TCP/IP mailbox and the Tab5 rebooted with `Invalid mbox`.

## Validation completed

- `run-tab5-ui-regression.ps1 -SelfCheck`: passed
- native Tab5 build: passed
- ESP-IDF: 5.5.4
- esp-rtl-sdr: `26e3857cb6a2cc7c09a7197ce07c46c29becd4e0`
- embedded ESP-Hosted C6 image SHA-256: `cfde3cb2d604695a21613cefb2ac62291f6bb4cab220aeefd4249596a77060de`
- candidate application SHA-256: `b161454161d8af45bf7d23041df72272a45cadcdfbb427092eb7ca4973c4ef3e`

## Hardware gate still open

This candidate has not been flashed. Before #87 is closed, install this exact build on the Tab5, boot with Wi-Fi off, press **Check for Updates**, and confirm:

- no blue screen or reboot;
- the screen asks for a Wi-Fi connection;
- no catalog worker starts;
- the radio continues receiving normally.

This PR targets the tested RC3 branch so its diff remains limited to the repair. It must not be merged until the hardware gate passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an offline catalog validation mode for UI regression testing.
  * Catalog checks and installations now provide a clear rejection message when Wi‑Fi is unavailable.
  * Radio streaming continues while offline catalog access is rejected.

* **Bug Fixes**
  * Catalog operations now consistently detect the current Wi‑Fi connection state before proceeding.
  * Wi‑Fi state is restored automatically after offline validation completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->