### PR TITLE
docs: remediate documentation truth and add deterministic CI

### DIFF
--- a/.github/workflows/documentation-truth.yml
+++ b/.github/workflows/documentation-truth.yml
@@ -1,0 +1,28 @@
+name: Documentation Truth
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "17 9 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+      - name: Test documentation checker
+        run: python -m unittest discover -s tests -p 'test_documentation_truth.py' -v
+      - name: Check documentation truth
+        run: python tools/check_documentation_truth.py

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,239 +1,119 @@
-# OrcSDR project status
+# OrcSDR current project status
 
-Hardware snapshot date: **2026-08-27**
-Historical snapshot branch: **`codex/esp-rtl-sdr-v0.7.9`**
-Historical mainline baseline: **`fc30c1030f26c8dd034d65917ec50e6880b7a871`**
-Documentation/source review: **2026-09-03**, against `main` at **`3eb67fb`**.
+Current source snapshot: **2026-09-12**, `main` at
+**`c5b3423fbdeb129ebd63d8ffd5c1bced9c913c04`**.
 
-This review reconciles driver/board provenance and current source boundaries;
-it does not rerun hardware acceptance or refresh every historical measurement.
+Current published firmware: **`v0.2.0-beta.6-multidongle-rc4`**. Its exact
+M5Burner package was installed and booted on the owner Tab5 before publication.
+That release evidence does not automatically prove later `main` commits or
+other hardware.
 
-This is the authoritative current-status and roadmap index. Historical design,
-research, and validation documents remain useful evidence, but do not override
-this file when their paths, versions, or completion claims differ.
+This is the authoritative current capability and evidence summary. Release
+notes and validation reports are immutable, dated evidence; they do not
+override this document for current state. Future work belongs in
+[`Roadmap.md`](Roadmap.md).
 
-## Evidence labels
+## Evidence vocabulary
 
-| Label | Meaning |
+| Status | Meaning |
 |---|---|
-| **Hardware-verified** | Observed on the named physical device and recorded |
-| **Build-verified** | Compiled or validated from repository artifacts, without a hardware claim |
-| **Implemented** | Present in source; current hardware acceptance may still be pending |
-| **Recorded upstream** | Prior operation documented in the driver repository; not a new local hardware run or proof of every later release gate |
-| **Planned** | Accepted roadmap work, not implemented |
-| **Deferred** | Intentionally outside the current milestone |
+| **Planned** | No integrated implementation exists. |
+| **Implemented** | An integrated source path exists. |
+| **Build-Verified** | The relevant target compiled or a deterministic validator passed. |
+| **Runtime-Verified** | The feature executed successfully in software or on target. |
+| **Hardware-Verified** | It executed on specifically identified physical hardware. |
+| **RF-Verified** | It was confirmed with a suitable real RF signal/source and recorded evidence. |
+| **Regression-Tested** | A repeatable automated or scripted regression exists. |
+| **Community-Verified** | It was independently demonstrated on externally owned hardware. |
+| **Experimental** | Reliability/support modifier that may accompany an evidence level. |
+| **Unsupported** | Deliberately outside the compatibility contract. |
+| **Not Implemented** | Known missing behavior. |
+| **Historical Evidence** | Valid dated evidence, not a current-version claim. |
 
-## Current snapshot
+## Current platform and dependencies
 
-| Area | State | Evidence boundary |
-|---|---|---|
-| `esp_rtl_sdr` API | **Hardware-verified, v0.7.9** | Immutable GitHub dependency; callback-only delivery on Tab5 |
-| Blog V4 USB identity and 960 kS/s stream | **Hardware-verified** | Tab5 + Blog V4 on the measured USB host path |
-| Multi-URB stream and metrics | **Hardware-verified** | Three 32-KiB transfers; OrcSDR does not allocate the pull ring |
-| In-stream hot retune | **Hardware-verified** | `esp_rtl_sdr` v0.7.9; settle-time measurement remains pending |
-| Core split | **Implemented** | USB core 0; IQ delivery and app work on core 1 |
-| Native Tab5 build | **Hardware-verified** | Native ESP-IDF 5.5.4 build; ESP-Hosted host/C6 firmware matched at 3.0.6 on COM17. |
-| Tab5 radio shell | **Implemented** | FM/AM/WX/CB/LoRa, radio/scope/capture tabs, sound/GFX toggles |
-| Screen ownership controller | **Hardware-verified** | `ScreenController` is the sole display-route owner for Home, FM, P25, ADS-B, LoRa, generic Radio/Scope/Capture, Settings, and documentation mode. The Tab5 transition check passed after the final UI-loop handoff; documentation capture now claims and restores its controller identity. |
-| CB channel dashboard | **Flashed; operator acceptance pending** | 40-channel AM/USB/LSB plan, 2/3 scope, touch channel dial, clarifier, squelch, live S/RF bar |
-| LoRa/Meshtastic receive path | **Native implementation present; historical hardware evidence not refreshed here** | `lora_native_decoder` performs capture decoding and feeds the dashboard; the serial `LORA_PACKET` bridge remains separate. The earlier snapshot recorded flashed 250 ms pre-roll, adaptive 9 dB energy capture, SD bridge, and synthetic/COM17 checks, with live-RF acceptance pending. Source review does not refresh that hardware verdict. |
-| SDR navigation | **Implemented; Home-first migration in progress** | Full 24–1766 MHz tune range, US band/use guide, direct entry, pinch, peak find, and FM auto tune. The legacy Browse surface is retired from user navigation; Home is the interim workspace for bands without a dedicated dashboard. |
-| Browse demodulation | **Partial** | NFM spectrum/listen path; AM/SSB/digital mode selection and sub-24 MHz direct sampling remain open |
-| Variant-4 splash | **Implemented on this branch** | Looping SD asset playback and static ready/button overlay |
-| Final splash smoothness | **Active performance gate** | Compact 24 FPS pack verified; 25 MHz SPI measured 15–16 FPS |
-| Current SD splash asset | **Hardware-verified** | 14,271,890 bytes, 240 frames at 24 FPS; device SHA-256 matches source |
-| Splash/USB core isolation | **Hardware-verified** | SD reader pinned to core 1 with a per-frame WDT yield; 28-second run had no WDT/panic |
-| In-device SD file transfer | **Hardware-verified** | COM17 list/get/put, staged writes, device SHA-256, rollback |
-| Graphics with audio enabled | **Open performance gate** | Establish before/after `RTL_SPECTRUM_FPS` and audio-drop evidence |
-| Audio/graphics optimization pass | **Implemented on this branch** | 10 FPS parity target, lighter DSP hot path, timing counters; hardware A/B pending |
-| FM post-DSP recording quality | **Hardware-verified** | Ten SD WAVs are valid 48 kHz mono PCM with no clipping or digital-zero gaps; a 12-second capture was clean enough for music fingerprinting |
-| Tab5 audio output | **Hardware-verified** | Recorded post-DSP PCM is clean, and operator testing confirmed that the Tab5 3.5 mm output through an external speaker sounds as intended. The built-in speaker's limited fidelity explains the reported quality difference; it is not evidence of a DSP, queue, or DMA defect. |
-| Paired FM IQ/WAV DSP lab | **Planned** | Buffer synchronized raw CU8 IQ, post-DSP PCM, and metadata in PSRAM; write after capture and evaluate filter variants offline |
-| AM/HF fidelity | **Experimental** | Do not claim calibrated HF/direct-sampling support |
-| Second ESP32-P4 board | **Recorded upstream** | Waveshare Module-DEV-KIT operation under OrcSDR is documented by the driver project; [PORTING.md](docs/PORTING.md#existing-implementation-and-evidence) links the provenance and FM application notes. Exact-version soak/recovery acceptance remains separate. |
-| rtl_tcp over Ethernet | **Planned** | App does not exist yet |
-| ADS-B 1090 | **Hardware-verified** | COM17 upload hash-verified. Five-minute 1090 MHz runs sustained approximately 2.048 MS/s with startup-only drops and no later growth. Live CRC-valid DF17 traffic was decoded, cross-checked against an independent track, displayed on the Tab5, and enriched from the SD-backed FAA database. Operator testing confirmed that ADS-B starts and continues receiving normally. The dashboard now displays only live receiver state; an empty sky reports waiting/searching without synthetic aircraft or a `DEMO` fallback. |
-| User guide and media pipeline | **Build-verified** | Native build plus 44-screen manifest, capture tooling, strict MkDocs site, and local narrated-video scripts. Hardware captures, privacy review, voice approval, and rendered media remain pending. |
-| POCSAG pager dashboard | **Build-verified; boot hardware-verified** | `pocsag_decoder_core` (host-testable, no FreeRTOS/M5GFX/USB/SD dependency) implements the full chain: DC-reject + two-stage CIC decimation (960 kS/s to 38.4 kS/s) + FM/FSK discriminator, parallel 512/1200/2400-baud x normal/inverted AUTO search with false-positive-controlled sync correlation, BCH(31,21) syndrome-table correction (0/1/2-bit correct, 3+ reject), even-parity cross-check, and address/numeric/alphanumeric codeword assembly. `tools/test-pocsag-core.ps1` passes both an optimized build and an ASan/UBSan build against deterministic BCH and full synthetic-IQ-to-message round-trip vectors. Wired live: `radio::Band::pocsag`/`Owner::pocsag`, a Home dashboard-catalog entry, and an RTL band-guide quick-launch tune the shared 960 kS/s RTL stream into the decoder inline, publish decoded messages through a mutex-protected ring into a five-tab M5GFX dashboard (`pocsag_dashboard`) routed through `ScreenController`. LIVE/IDS/SIGNAL/ACTIVITY render real content; ARCHIVE remains a placeholder. A "FIND PAGERS" discovery scan (shared `scan_engine`, user-editable `/orcsdr/pocsag_scan.cfg` channel list, BCH-valid-required winner selection) is build-verified but not yet run against a real signal. **Flashed and booted on a physical Tab5**: fixed a real hardware-only boot crash (three `static` objects starving ESP-IDF's early internal-DRAM DMA-pool reservation — undetectable by build/link/host-test, only a flashed boot proved it; see `phasing.md` Phase 10 commit history), then confirmed a clean boot with `RTL_POCSAG_SELF_CHECK_OK` and no abort. One live decode was received on an untested frequency, but its own diagnostics (0% valid codewords, 87.5% uncorrectable, immediate sync loss) show it was very likely a false-positive sync-word lock on noise, not a genuine page — **no message has yet been confirmed as a real, over-the-air POCSAG decode**. No CAPCODE identity store persistence, message archive, or Settings UI exists yet, and the numeric/alphanumeric character-set bit order remains uncross-checked against a live signal or an external oracle. |
-## Roadmap
-
-### P0 — finish the Tab5 product loop
-
-- [ ] Measure graphics-on/audio-off and graphics-on/audio-on FPS for five minutes.
-- [x] Remove the deliberate audio-on render throttle; retain a reduced cadence only when drops rise.
-- [x] Remove the full-URB app copy, software `double` accumulation, and per-sample `tanhf`.
-- [x] Add `dsp_load_pct`, block count, and maximum block time to the FPS log.
-- [ ] Verify the optimized path keeps audio drops near zero on hardware.
-- [ ] Add the paired FM DSP capture described in `docs/FM_DSP_CAPTURE_LAB.md`:
-      5–8 seconds of 960 kS/s CU8 IQ, synchronized 48 kHz PCM, and settings metadata.
-- [ ] Save paired captures after reception stops as SigMF data/metadata plus WAV;
-      do not write to SD in the real-time receive path.
-- [ ] Replay one IQ capture through at least three offline filter variants and
-      compare SNR, bandwidth, clipping, discontinuities, and CPU cost.
-- [x] Compare the built-in speaker with the Tab5 3.5 mm output. External-speaker
-      playback sounds as intended; the reported fidelity difference comes from
-      the built-in speaker rather than the DSP, queue, or DMA path.
-- [ ] Confirm sound defaults off, NAV leaves animation live, and controls remain static.
-- [ ] Accept BROWSE panning/direct entry and US band-guide labels on the physical display.
-- [ ] Accept CB channel snapping, scope taps, dial, AM/USB/LSB voice,
-      clarifier, squelch, S/RF display, and six dashboard controls.
-- [x] Add adaptive energy-triggered LoRa IQ capture and a host watcher that
-      pauses, SHA-256 verifies, decodes, returns text, and resumes the SDR.
-- [ ] Transmit a live Meshtastic packet and record `RTL_LORA_ENERGY` through
-      `LORA_MESSAGE_OK`, then visually accept the readable Tab5 message.
-- [x] Install the final variant-4 SD pack and record stable loop FPS (15–16 FPS at 25 MHz SPI).
-- [x] Soak the splash past Ready for 28 seconds with no `task_wdt` reset or panic.
-- [x] Copy the 14,271,890-byte compact splash pack through COM17; device SHA-256 matched `AA490D5E…BCD1FA`.
-- [ ] Run operator acceptance for FM, WX, AM experimental mode, volume, mute,
-      start/stop, pinch navigation, peak find, and auto tune.
-
-Exit: smooth scope with audio enabled, no control corruption, approximately zero
-audio drops, a serial log attached to the validation record, and a repeatable
-paired IQ/WAV dataset that can drive FM filter decisions without tuning by ear.
-
-### P1 — close driver reliability and portability
-
-- [ ] Prove 960 kS/s for five minutes at at least 95% effective sample rate with
-      zero fatal USB errors.
-- [ ] Unplug/replug during streaming and recover to Ready without reboot.
-- [ ] Record retune settle time and recovery behavior after a failed retune.
-- [x] Retire the legacy in-app USB path: enabling it is a compile-time error; `esp_rtl_sdr` is the only live implementation.
-- [ ] Delete the remaining disabled legacy source blocks in a separate code change.
-- [x] Move standalone smoke ownership to the `esp-rtl-sdr` repository.
-- [x] Record existing Waveshare second-board operation with upstream provenance.
-- [ ] Attach exact-version sustained-rate and unplug/replug evidence for the boards covered by a release; prior operation alone does not close these gates.
-
-Exit: release-specific driver acceptance is recorded for both P4 boards and
-the Tab5 app has no remaining duplicate USB implementation. Prior Waveshare
-operation is already recorded; disabled legacy code still needs deletion.
-
-### P2 — network transport
-
-- [ ] Add a single-client `rtl_tcp` app over Ethernet.
-- [ ] Sustain at least 1.0 MS/s for ten minutes and document drop rate.
-- [ ] Add mDNS discovery; evaluate Wi-Fi IQ only after Ethernet is stable.
-
-### P3 — ADS-B 1090
-
-- [x] Remove the bring-up-only synthetic aircraft and `DEMO` dashboard path;
-      Radar, List, Target, RF Stats, and Settings now show live receiver state.
-- [x] Measure the 2.048 MS/s driver path at 1090 MHz for five minutes.
-- [x] Complete replay-tested Mode-S/DF17 decode: validated 56-bit DF11 and
-      112-bit DF17 extraction, CRC/ICAO, identity/altitude/velocity, global
-      CPR, captured-waveform replay, and bounded 64-aircraft state.
-- [x] Connect the decoder table to a revisioned live dashboard snapshot.
-- [x] Add SD-backed FAA registration, model, and registered-owner enrichment
-      without dropping the complete source database or blocking the IQ callback.
-- [x] Accept live aircraft against an independent receiver on the Tab5.
-
-Detailed gates and clean-room boundaries live in `phasing.md` Phase 6.
-
-### P4 — global Settings and optional connectivity
-
-- [x] Add a build-verified isolated eight-category Settings shell with a
-      persistent gear and ADS-B contextual deep link.
-- [x] Preserve `orclink` and migrate the current single Wi-Fi credential into
-      slot zero of a bounded four-profile layout.
-- [x] Persist the first local display/audio/radio/location defaults without
-      exposing stored passwords or presenting unsupported controls as active.
-- [x] Apply the isolated ESP-Hosted A–F coexistence result in the production
-      path: do not stop RTL reception for Wi-Fi scan/connect; keep SDIO pin
-      setup before station mode, clean `WiFi.mode(WIFI_OFF)` teardown, USB host
-      on core 0, and DSP/audio/UI/Hosted control on core 1.
-- [ ] Hardware-verify navigation, bounded repaint, reception coexistence, and
-      reboot migration, including `RTL_WIFI_COEX` sample-rate, USB-drop,
-      audio-drop, DSP-block, UI-cadence, and scan/connect-latency evidence.
-- [ ] Complete Wi-Fi editing/keyboard, safe manifest downloads, maps/storage,
-      BLE feasibility, optional Companion, and M5Launcher phases.
-
-### P4.1 — U.S. data catalog
-
-- [x] Add build-verified manual Settings catalog UI and a signed GitHub Release
-      manifest client for independent FAA aircraft, FAA aviation, NOAA Weather
-      Radio, and FCC FM/AM SD packs.
-- [x] Stream catalog artifacts through hash-verified `.part` files with atomic
-      activation/backup and keep P25 configuration outside catalog ownership.
-- [ ] Publish rights-reviewed data assets and hardware-verify download,
-      rollback, source archive retention, and concurrent RTL/Wi-Fi behavior.
-
-Detailed gates live in `phasing.md` Phase 7. Build verification is not live
-network, BLE, Companion, Launcher, or hardware acceptance evidence.
-
-### P5 — public user guide and media
-
-- [x] Add firmware-owned documentation screen IDs and build-time coverage checks.
-- [x] Add authenticated, hash-reported 1280x720 SD capture and state restoration.
-- [x] Add the manifest-driven Pages, annotation, narration, caption, transcript,
-      thumbnail, and video pipeline.
-- [ ] Capture and privacy-review every view on hardware.
-- [ ] Approve the voice sample, render the suite, and review Pages before deploy.
-
-Detailed gates live in `phasing.md` Phase 8.
-
-### Deferred until measurements justify them
-
-- Bias tee, direct sampling/HF, gain/PPM controls, SpyServer, WebSDR, 978 MHz UAT,
-  multi-client IQ fanout, and ESP32-S2/S3 production-rate claims.
-- LP-core DSP offload: the P4 LP core is intended for low-power service work and
-  is not the first choice for the 960 kS/s floating-point demodulation path.
-- P4 PIE/ESP-DSP assembly kernels: adopt only for a profiler-identified FFT,
-  FIR, or vector hot spot with an A/B quality and throughput check.
-- P4 PPA: evaluate for framebuffer fill/blend/scale work only; it does not
-  replace RF demodulation.
-
-## Commit-derived history
-
-| Date | Commit | Delivered |
-|---|---|---|
-| 2026-08-06 | `96e0370` | Initial monorepo, Tab5 app, clean-room driver skeleton, specs |
-| 2026-08-06 | `fc9678b` | Peer analysis and gap-closing implementation plan |
-| 2026-08-06 | `4948c8e` | Hardened standalone public API contract |
-| 2026-08-07 | `ba6ffc3` | Gate-2 multi-URB streaming, IQ delivery, component-backed Tab5 radio |
-| 2026-08-07 | `bda29fd` | FM quality work and portable radio/scope/capture shell |
-| 2026-08-08 | `84cf9a1` | Variant-4 animated boot splash |
-| 2026-08-08 | `f972eb3` | Pinch span and filter navigation |
-| 2026-08-08 | `f28b131` | FM auto tune and peak controls |
-| 2026-08-08 | `0c76bf1` | SDR navigation drawer |
-| 2026-08-08 | `269b191` | Muted-mode scope performance prioritization |
-| 2026-08-08 | `20441dc` | Scope animation remains live with navigation open |
-| 2026-08-08 | `cc463bb` | LoRa dashboard/decoder and CB sideband, clarifier, squelch |
-
-The entries after `bda29fd` are branch work until merged into `main`; a commit is not
-hardware proof and a branch is not considered landed until its merge is verified.
-
-## Verification commands
-
-Use the repository's native ESP-IDF 5.5.4 workflow; PlatformIO is not the
-production Tab5 build path:
-
-```powershell
-Set-Location F:\Ai\OrcSDR\apps\orcsdr-tab5
-.\tools\build-tab5-idf.ps1
-```
-
-Required runtime lines for the next performance record:
-
-```text
-RTL_INSTALL ok v0.7.9 ...
-RTL_CORE_SPLIT usb=core0 iq_demod+ui=core1 ...
-RTL_SPECTRUM_FPS fps=... audio_dropped=... audio_chunks=...
-                    dsp_load_pct=... dsp_blocks=... dsp_block_us_max=...
-SPLASH_FPS ...
-```
-
-## Documentation map
-
-| Document | Role |
+| Item | Current state |
 |---|---|
-| `PROJECT_STATUS.md` | Current truth, priorities, and evidence boundary |
-| `architecture.md` | Implemented runtime ownership, ScreenController contract, and dashboard drawing boundary |
-| `docs/IMPLEMENTATION_FROM_PEER_RESEARCH.md` | Detailed workstreams and design rationale |
-| `docs/PORTING.md` | Driver extraction and target gates |
-| `docs/API_ESP_RTL_SDR.md` | Pinned driver integration contract; complete public API maintained upstream |
-| `docs/API_SERIAL_CLI.md` | Tab5 serial CLI — tuning, telemetry, RDS status, presets, file transfer |
-| `docs/M5TAB5_VALIDATION_REPORT.md` | Historical hardware evidence |
-| `docs/GATE2_IMPLEMENTATION_LOCK.md` | Historical Gate-2 handoff snapshot |
-| `docs/OrcSDR_Splash_README.md` | Splash asset and playback contract |
-| `docs/cb/README.md` | CB channel, sideband, clarifier, squelch, and asset controls |
-| `docs/lora/README.md` | Native LoRa capture/decoder boundary and serial regression bridge |
-| `docs/FM_DSP_CAPTURE_LAB.md` | Measured FM WAV evidence and paired IQ/WAV DSP-lab implementation plan |
+| Firmware policy | Native ESP-IDF only; PlatformIO files are historical and unsupported. |
+| ESP-IDF | 5.5.4 |
+| ESP-Hosted host/C6 | 3.0.6 / 3.0.6 over Tab5 SDIO at the qualified 10 MHz clock |
+| M5Unified / M5GFX | 0.2.20 / 0.2.27 |
+| `esp-rtl-sdr` | 0.8.0-rc2, immutable pin `b175dfea6782faa97e512d4a2408767c75977527` in the manifest and lock file |
+| USB implementation | Current `esp-rtl-sdr` path; the legacy USB source is compiled out but remains in source. |
+| Radio policy | Receive-only. Transmission is Not Implemented. |
+
+## Receiver evidence
+
+| Receiver | Status | Boundary |
+|---|---|---|
+| RTL-SDR Blog V4 | **RF-Verified / tested baseline** | Primary release receiver. |
+| RTL-SDR Blog V3C | **RF-Verified / Experimental** | One V3C passed RC4 detection, initialization, streaming, FM/RDS, retune, hotplug, and USB/battery boot. Gain and sensitivity comparisons remain provisional. |
+| Earlier RTL-SDR Blog V3 variants | **Implemented / Experimental** | Profile exists; the V3C result is not a blanket earlier-V3 compatibility claim. |
+| Nooelec NESDR SMArt V5 | **Implemented / Experimental** | Detection and streaming are provisional; repeatable RF reception is Not Verified. |
+| RTL-SDR Blog V4L | **Not Verified** | No explicit profile acceptance evidence was found. |
+| Other receivers | **Unsupported / Not Verified** | Generic RTL2832 compatibility is not claimed. |
+
+## Capability and evidence matrix
+
+| Capability | Status | Evidence boundary and limitations |
+|---|---|---|
+| FM receive, stereo, RDS, presets | **RF-Verified / Regression-Tested** | Verified on Blog V4 and V3C. Results remain bounded to the tested dongle, antenna, band, and setup. |
+| AM broadcast dashboard and 119-channel scan | **Hardware-Verified / Experimental** | The exact RC4 package exercised the dashboard and scan. General reception quality and gain calibration are not established. |
+| NOAA Weather Radio | **Implemented** | Current-release RF acceptance is Not Verified. |
+| CB | **Implemented / Runtime-Verified** | Flashed and exercised; operator/RF acceptance is still pending. |
+| Shortwave | **Implemented / Experimental** | Routes to the generic Browse/NFM workspace. A complete calibrated HF AM/SSB experience is Not Implemented. |
+| Airband | **Implemented / Experimental** | Routes to generic Browse near 121.5 MHz using NFM. Proper AM aviation voice is Not Implemented. |
+| Marine | **Implemented / Experimental** | Generic NFM routing exists; no dedicated dashboard or current RF acceptance is recorded. |
+| Satellite | **Implemented / Experimental** | Generic Browse routing near 137.5 MHz exists. No dedicated satellite decoder/dashboard is implemented. |
+| P25 Phase I | **RF-Verified / Hardware-Verified / Regression-Tested** | Documented control, clear voice, encrypted-call detection/muting, and follow behavior. System compatibility remains evidence-bounded. |
+| P25 Phase II | **Implemented / Runtime-Verified / Regression-Tested / Experimental** | Grant transport, burst sync, complete-burst retention, DUID classification, and hardware observation exist. Payload decode and AMBE+2 voice/audio are Not Implemented. |
+| ADS-B 1090 | **RF-Verified / Hardware-Verified / Regression-Tested** | Live CRC-valid traffic was independently track-compared and FAA-enriched. It is live-only and reception depends on antenna, location, and traffic. |
+| LoRa/Meshtastic receive | **Hardware-Verified / Experimental** | Native receive and dashboard paths exist and traffic has been observed. Reliability, missed-packet rate, backlog behavior, and antenna coverage remain bounded experiments. |
+| POCSAG | **RF-Verified at 1200 baud / Regression-Tested** | `TEST` for CAPCODE 1234560 was decoded on Tab5 from an in-house 433.920 MHz source and independently on a Flipper Zero. 512/2400 are host-tested only. Identity/message state is RAM-only; persistent searchable archive is Not Implemented. |
+| RF Lab and RF Visualizer | **Implemented / Regression-Tested** | Integrated screens and self-check/regression tooling exist; they do not prove RF calibration. |
+| Wi-Fi analysis | **Implemented / Hardware-Verified / Experimental** | ESP-Hosted 3.0.6 and access-point survey work on the owner Tab5. Scan, connect, power-off, and catalog I/O deliberately pause and then resume radio reception. |
+| Signed data catalog | **Hardware-Verified / Experimental** | Public `data-catalog-v1` exists; FAA catalog reinstall and radio recovery are recorded. This does not mean every proposed pack is published or accepted. |
+| LAN web console | **Implemented / Experimental** | Opt-in HTTP telemetry, audio, spectrum, tuning, volume/mute, span/step, and dashboard actions. No TLS or authentication; trusted LAN only. |
+| Android TV client | **Implemented / Experimental** | LAN client only; the Tab5 remains the radio. |
+| Global Settings and documentation capture | **Implemented / Hardware-Verified** | Current screens are integrated under the display owner; exact capture coverage remains release/evidence specific. |
+
+## Automated validation
+
+| Workflow/check | Current coverage |
+|---|---|
+| P25 core | Optimized and ASan/UBSan host tests plus data-catalog validation. |
+| Radio scan core | Optimized and ASan/UBSan radio-session/scan tests. |
+| User guide | Help-media validation, documentation validation, and strict MkDocs build. |
+| Documentation Truth | Deterministic dependency/doc coherence, CI claims, architecture measurement, local links, screen/dashboard enums, resolved stale claims, and history/prompt hygiene. |
+
+Current CI does **not** compile the native Tab5 consumer firmware. POCSAG core
+and store scripts are not currently wired into GitHub Actions. CI also does not
+prove hardware operation, RF reception, antenna suitability, display/touch
+behavior, release-package installation, or long-duration soak behavior.
+
+## Current evidence boundaries and open limitations
+
+- The physical Tab5 evidence is for the owner unit, ESP32-P4 revision 1.3. Other
+  Tab5/display revisions are Not Verified.
+- Current `main` is source-reviewed at the snapshot above; RC4 hardware evidence
+  applies to the immutable RC4 package, not automatically to post-release commits.
+- Post-RC4 receiver-recovery behavior, current M5Burner search visibility, V4L,
+  broad earlier-V3 support, repeatable Nooelec RF, and long current-main soak are
+  Not Verified from committed public evidence.
+- Shortwave, Airband, Marine, Satellite, and CB do not have broad current-release
+  RF acceptance. P25 Phase II voice/audio is Not Implemented.
+- Wi-Fi credentials and signing material are private and are not documentation
+  or CI inputs.
+
+## Authoritative document map
+
+| Purpose | Document |
+|---|---|
+| Public summary | [`README.md`](README.md) |
+| Current evidence | This file |
+| Software ownership | [`architecture.md`](architecture.md) |
+| User operation and safety | [`docs/user-guide/`](docs/user-guide/index.md) |
+| Security | [`SECURITY.md`](SECURITY.md) |
+| Developer contracts | [`docs/API_ESP_RTL_SDR.md`](docs/API_ESP_RTL_SDR.md), [`docs/TAB5_BUILD_POLICY.md`](docs/TAB5_BUILD_POLICY.md), [`docs/RADIO_CONFIGURATION.md`](docs/RADIO_CONFIGURATION.md) |
+| Future work | [`Roadmap.md`](Roadmap.md) |
+| Exact-version evidence | [`docs/releases/`](docs/releases/v0.2.0-beta.6-multidongle-rc4.md) and dated validation reports |

--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ Current release images include the matching ESP-Hosted C6 firmware used by the T
 - **Home:** tune and listen while viewing the live spectrum, waterfall, signal level, receiver status, and recently used dashboards.
 - **FM Radio:** receive broadcast FM with stereo audio, RDS station information, presets, and station tuning tools.
 - **AM Radio:** receive broadcast AM with region-aware channel steps, presets, automatic tuning, and a full-band station scan.
-- **Shortwave:** explore HF signals with a general-purpose shortwave receiver workspace and selectable demodulation modes.
+- **Shortwave:** enter the generic Browse/NFM workspace for experimental HF exploration; calibrated HF and complete AM/SSB modes are not yet available.
 - **Weather:** quickly tune the standard NOAA weather-radio channels.
-- **Airband:** listen to VHF aviation voice channels and use saved airport and frequency presets.
+- **Airband:** opens generic Browse near 121.5 MHz. Proper AM aviation voice reception is not yet implemented.
 - **Marine:** listen across the standard VHF marine channel plan.
 - **CB Radio:** tune the 40-channel Citizens Band service using AM or supported sideband modes.
 - **P25 Radio:** monitor trunked P25 control channels and follow supported voice traffic.
 - **ADS-B:** receive 1090 MHz aircraft broadcasts and show decoded aircraft, position, altitude, and flight details.
 - **LoRa:** passively monitor LoRa and Meshtastic traffic with spectrum, packet, node, traffic, map, and RF-health views.
-- **POCSAG:** receive pager traffic, identify CAPCODEs, and retain decoded messages in a local archive.
-- **Satellite:** provides a dedicated workspace for receiving and inspecting satellite signals.
+- **POCSAG:** receive pager traffic and inspect bounded RAM-only CAPCODE/message state. A persistent searchable archive is not implemented.
+- **Satellite:** opens generic Browse near 137.5 MHz; no dedicated satellite decoder or dashboard is implemented.
 - **RF Lab:** make live RF measurements, inspect receiver behavior, record IQ data, and open full-screen visualization tools.
 - **2.4 GHz Wi-Fi:** survey nearby access points, channels, signal strength, and advertised network security using the Tab5 wireless co-processor.
 - **Settings:** manage audio, display, Wi-Fi, storage, data packs, firmware information, and device updates.

--- a/Roadmap.md
+++ b/Roadmap.md
@@ -1,211 +1,77 @@
 # OrcSDR roadmap
 
-This file tracks externally-sourced review feedback and the gaps it surfaces,
-as accepted roadmap items. `PROJECT_STATUS.md` remains the authoritative
-current-state and evidence-boundary document — this file exists to hold
-review-derived findings that are not yet folded into that snapshot, and to
-point at `phasing.md` for how each item gets implemented.
+This file contains future work only. Current capability and evidence live in
+[`PROJECT_STATUS.md`](PROJECT_STATUS.md); completed milestones remain in tagged
+release notes and dated validation reports.
 
-## Evidence labels
+## Near-term product gaps
 
-Same convention as `PROJECT_STATUS.md`: **Hardware-verified**,
-**Build-verified**, **Implemented**, **Recorded upstream**, **Planned**, **Deferred**.
+### Reduce `main.cpp` ownership
 
-## External review: Grok code review (2026-08-10)
+Continue moving receiver lifecycle, band policy, Wi-Fi/catalog orchestration,
+web commands, and screen/touch routing behind the modules that already exist.
+The endpoint remains a small application-wiring file. Preserve one receiver
+owner and one framebuffer owner during each extraction.
 
-A third-party review (Grok, reviewing `hardcoreerik/OrcSDR` on GitHub) assessed
-the driver, the Tab5 application, and project documentation. It rated the
-driver design, documentation discipline, and evidence-labeling practice as
-strong — comparable to production embedded driver contracts — and flagged
-five structural gaps. None of these are DSP-correctness bugs; they are
-maintainability, portability, and process gaps that get more expensive to fix
-the longer they're deferred.
+### Compile the native Tab5 firmware in CI
 
-### Gap 1 — `main.cpp` is a single ~266 KB translation unit
+The repository has P25, radio-scan, user-guide, and Documentation Truth
+workflows. The remaining CI gap is a reproducible native ESP-IDF Tab5 consumer
+build; hardware, RF, flash, and physical UI acceptance remain separate gates.
 
-DSP (demodulators, AGC, filter state), UI drawing (spectrum, waterfall,
-dashboards, controls, touch routing), the radio/band/capture state machine,
-and the serial host protocol (SD transfer, journal, auth) all live in one
-file. The review's framing: this is the embedded equivalent of collapsing an
-entire MVC stack — model, view, controller, and service layer — into one
-class. Concretely, it already makes review diffs hard to scope (a touch-
-handler change and a DSP change land in the same file with no compiler-
-enforced boundary), and it will only get worse as more radio modes/tools are
-added. RDS decoding is now implemented in `main.cpp`; ADS-B, P25, LoRa,
-RF analysis, and several UI services already have separate modules. The
-remaining task is incremental separation of shared DSP/session state, not
-recreating those existing modules.
+### Finish P25 Phase II receive
 
-**Status: Planned.** See `phasing.md` Phase 1.
+Grant transport, sync, complete-burst retention, DUID classification, and
+hardware observation already exist. Future work is payload decoding and a
+lawful AMBE+2 audio path, followed by bounded hardware/RF validation. Do not
+label Phase II voice complete before those gates pass.
 
-### Gap 2 — dual USB code paths (`RTL_USE_LEGACY_USB`)
+### Complete band-specific receiver experiences
 
-`esp_rtl_sdr` is the only live USB implementation. `main.cpp` forces
-`RTL_USE_LEGACY_USB=0` and rejects attempts to enable it, but disabled legacy
-implementation blocks remain in the source.
+- Shortwave: add correct AM/SSB modes and calibrated HF/direct-sampling evidence.
+- Airband: add proper AM aviation voice behavior and suitable-antenna RF evidence.
+- Marine: decide whether a dedicated workflow is justified and collect RF evidence.
+- Satellite: define a specific receive/decoder target before adding a dedicated UI.
+- CB: complete operator and RF acceptance with a suitable antenna/source.
 
-**Status: Runtime duplication resolved; source cleanup remains.** Track the
-remaining deletion under `PROJECT_STATUS.md` P1, separately from driver or
-DSP behavior changes.
+Generic Browse routing is already implemented and is not a substitute for these
+band-specific outcomes.
 
-### Gap 3 — no CI
+### Add POCSAG persistence deliberately
 
-The driver build, host policy tests, and standalone P4 smoke example now live
-in the `esp-rtl-sdr` repository. OrcSDR still needs consumer-build CI for the
-Tab5 application; it must not duplicate the driver's test harness.
+Current live and identity/message views are bounded RAM state. Future work may
+add persistent CAPCODE identities, an SD-backed searchable archive, and editing
+UI. Keep 512/2400 baud at host-tested status until live RF evidence exists.
 
-**Status: Partially resolved.** Driver CI is upstream; OrcSDR consumer CI remains
-planned. See `phasing.md` Phase 2.
+### Expand receiver acceptance
 
-### Gap 4 — open performance gates (already tracked, cross-referenced here)
+Collect repeatable, versioned evidence for earlier Blog V3 variants, Nooelec
+NESDR SMArt V5 RF reception, Blog V4L, and other explicitly selected devices.
+Do not generalize the single V3C result or infer compatibility from detection.
 
-The review independently re-derived the same P0 gates already open in
-`PROJECT_STATUS.md`: graphics+audio simultaneous FPS/drop-rate measurement,
-the live-speaker-vs-recorded-PCM discrepancy, and hot-plug/second-board
-validation. Waveshare operation has since been recorded upstream; see
-[PORTING.md](docs/PORTING.md). Exact-version sustained-rate and recovery gates
-remain distinct from that completed board milestone. Historical performance
-observations require their own measured acceptance, not a blanket reset to
-"not started."
+### Improve Wi-Fi/radio coexistence
 
-**Status: Already tracked** — `PROJECT_STATUS.md` P0/P1. No duplicate entry.
+The current safe implementation pauses reception for scan/connect/power and
+catalog operations. Remove that pause only if resource ownership and physical
+regression evidence show concurrent operation is reliable.
 
-### Gap 5 — monolithic touch/draw logic; no tool-shell abstraction
+### Complete data-pack coverage
 
-Touch hit-testing, button dispatch, spectrum drawing, and per-band dashboard
-painting are interwoven inside the same functions per band (e.g.
-`handle_cb_touch`, `handle_lora_touch`, `handle_fm_touch`, each hand-rolling
-its own hit-test geometry against shared screen constants). The review's
-concern: every new tool (Analyzer, Gain Lab, IQ dump, the in-flight RDS
-panel) keeps growing the same call sites rather than plugging into a shared
-shape. This is the same root cause as Gap 1, scoped down to the touch/draw
-surface specifically.
+The signed public `data-catalog-v1` and FAA reinstall evidence establish the
+catalog mechanism, not every proposed pack. Publish additional FAA, NOAA, FCC,
+map, or P25 packs only after provenance, redistribution, size, install,
+rollback, and radio-recovery gates pass.
 
-**Status: Planned.** See `phasing.md` Phase 1 (module split) and Phase 3
-(tool-shell abstraction, sequenced after the split lands so it has stable
-module boundaries to plug into).
+## Evidence still needed
 
-## Product initiative — ADS-B 1090 dashboard
+- Current M5Burner search/catalog visibility.
+- Post-RC4 receiver-recovery behavior on hardware.
+- Other Tab5/display revisions beyond the owner ESP32-P4 revision 1.3 unit.
+- Long-duration current-main soak and repeatable receiver recovery.
+- Current-release RF acceptance for Shortwave, Airband, Marine, Satellite, and CB.
 
-The supplied four-panel concept is accepted as the product contract for an
-on-device **1090 MHz Mode-S/ADS-B** tool: Radar, Aircraft List, selected
-Target, and RF Statistics share one aircraft snapshot and one selected ICAO.
-Settings is a fifth control view for receiver coordinates and radar range,
-not another data panel. The first implementation is deliberately marked
-`DEMO`; it exercises navigation and persistence without claiming live RF.
+## Follow-up cleanup
 
-Peer projects establish useful boundaries:
-
-- [T-Display-P4 ADS-B](https://github.com/jstockdale/T-Display-P4) proves the
-  ESP32-P4 + RTL-SDR vertical-app shape and informs product/reliability goals.
-- [dump1090](https://github.com/antirez/dump1090) and
-  [readsb](https://github.com/wiedehopf/readsb) inform frame validation,
-  bounded recently-seen aircraft state, and replay-first decoder checks.
-- [tar1090](https://github.com/wiedehopf/tar1090) reinforces the separation
-  between decoder state and selectable radar/list/detail views.
-
-These are architecture and behavior references only. OrcSDR does not copy
-GPL tuner, decoder, or UI source, and it does not bundle airline logos or
-aircraft photos. The 2.048 MS/s path is implemented and hardware-measured. The
-clean-room decoder, bounded state table, and live snapshot path are flashed;
-the dashboard keeps its `DEMO` badge until a newly received frame passes CRC,
-so replay and build evidence cannot be mistaken for current live aircraft.
-
-**Status: Live pipeline flashed; physical acceptance pending.** See `phasing.md`
-Phase 6.1 for the shell and Phase 6.2–6.6 for high-rate input, decoding,
-enrichment, and hardware acceptance.
-
-## Product initiative — global Settings and connectivity
-
-OrcSDR will provide one on-device Settings application for connectivity,
-receiver location, data/maps, display/audio, radio defaults, storage,
-optional Companion integration, and system information. A persistent gear
-opens it without stopping ordinary reception; disruptive SD/network work must
-use an explicit pause/resume confirmation. The existing `orclink` NVS namespace
-is retained, including migration of the legacy single Wi-Fi credential into
-the first of four bounded profile slots.
-
-Phone, BLE, GPS, map building, and TheOrc/HIVE are not prerequisites. BLE is
-shown only after the Tab5 ESP32-C6 SDIO path is proven, and M5Launcher remains
-the firmware/partition owner.
-
-**Status: Build-verified foundation; hardware acceptance and service phases
-pending.** See `phasing.md` Phase 7.
-
-### U.S. data catalog and SD sync
-
-Settings will expose a user-initiated U.S. data catalog backed by signed GitHub
-Release assets, not a permanent OrcSDR data service. Each approved pack carries
-a compact runtime index and its source archive, provenance, source date,
-license/redistribution review, size, and SHA-256. The initial packs are FAA
-aircraft registration, FAA aviation/NASR, NOAA Weather Radio, and FCC FM/AM.
-P25 remains a user-owned editable SD profile unless a future source explicitly
-permits redistribution; maps remain imported/validated separately.
-
-**Status: Build-verified catalog client and pack-publishing tooling; no public
-catalog release or hardware install evidence yet.** See `phasing.md` Phase 7.2.
-
-## Product initiative — automated guide and media
-
-OrcSDR will maintain one versioned screen manifest covering every usable view.
-Authenticated serial capture writes exact 1280x720 frames to SD, while a local
-Windows pipeline retrieves and hashes them, creates annotated PNGs, builds the
-Material for MkDocs guide, and renders captioned Kokoro-narrated videos. Live
-data is preferred only when a bounded condition is met; otherwise the capture
-is visibly labeled `DEMO`. Generated MP4 files remain outside Git history.
-
-**Status: Build-verified tooling and firmware interface; hardware capture,
-privacy review, and voice approval pending.** See `phasing.md` Phase 8.
-
-## Product initiative — native Meshtastic receive
-
-LoRa becomes a passive five-panel M5GFX dashboard: Overview, Nodes, Traffic,
-Map, and RF Health. One bounded snapshot drives every panel; absent fields use
-`—`, unknown encrypted frames remain `ENCRYPTED`, and no topology or location
-is inferred. The first protocol target is Meshtastic US LongFast receive only;
-MeshCore, transmit, pairing, and remote control are deferred.
-
-The gate sequence is recorded IQ sync/FEC/CRC, public LongFast parsing,
-authorized-key decryption, bounded queue/error handling, then an authorized
-Heltec network comparison. The 902–928 MHz survey is an explicit occupancy
-tool that restores the monitor; it is not a packet-capture substitute.
-
-**Status: Native decoder and five-panel UI implemented.** Source includes
-capture decoding, initialization/self-checks, and packet publication. Keep
-recorded-IQ and live-air acceptance tied to named evidence; this documentation
-review does not establish a new hardware pass. The serial regression bridge
-is not the native decoding implementation.
-
-## Product initiative — POCSAG pager dashboard
-
-A receive-only POCSAG pager monitor: native FSK/BCH decode, an in-memory
-CAPCODE identity table, a RAM-only session list, and a five-view
-M5GFX dashboard (LIVE/IDS/SIGNAL/ACTIVITY/SESSION), architected like P25 —
-a pure host-testable protocol/DSP core, a thin runtime adapter, and a
-`ScreenController`-routed dashboard that only ever renders a snapshot.
-POCSAG rides the existing hardware-verified 960 kS/s RTL front end rather
-than adding a second high-rate IQ path. Frequency and baud are a
-user-edited SD scan profile (`/orcsdr/pocsag_scan.cfg`), not a hardcoded default —
-POCSAG channels vary by country and carrier.
-
-**Status: Hardware-verified at 1200 baud.** The Tab5 decoded an in-house
-433.920 MHz `TEST` transmission on CAPCODE 1234560; the same transmission was
-independently decoded by a Flipper Zero. LIVE, IDS, SIGNAL, ACTIVITY, and
-SESSION render bounded live data. SD persistence, editing UI, searchable
-archive, profile editor, and broader RF acceptance remain open. See
-`phasing.md` Phase 10.
-
-## Summary table
-
-| Gap | New or already tracked | Phase |
-|---|---|---|
-| `main.cpp` monolith | New | Phase 1 |
-| Dual USB paths | Already tracked (`PROJECT_STATUS.md` P1) | Linked into Phase 1 |
-| No CI | New | Phase 2 |
-| Open performance gates | Already tracked (`PROJECT_STATUS.md` P0/P1) | Unchanged |
-| No tool-shell abstraction | New | Phase 3 |
-| ADS-B 1090 dashboard | Product initiative | Phase 6 |
-| Global Settings and connectivity | Product initiative | Phase 7 |
-| Automated guide and media | Product initiative | Phase 8 |
-| Native Meshtastic receive | Product initiative | Phase 9 |
-| POCSAG pager dashboard | Product initiative | Phase 10 |
+`apps/orcsdr-tab5/tools/patch_m5gfx.py` appears to retain obsolete
+PlatformIO/NEONDRIVE-era assumptions. Confirm it has no native build dependency
+before removing it in a separate source/tool cleanup change.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,12 @@
 
 OrcSDR is a receive-only, local-first SDR application for the M5Stack Tab5
 (ESP32-P4) and RTL-SDR Blog V4. It does not provide a public cloud service.
-An optional LAN web console can be enabled in Settings → Companion; it is
-off by default and bindable only while Wi-Fi is connected. It serves the Home
-visual plus local tune/volume/dashboard actions. It does not expose passwords,
-pairing material, or coordinates. There is no TLS in this slice.
+An optional LAN web console can be enabled in Settings → Companion; it is off
+by default and bindable only while Wi-Fi is connected. It serves the Home
+visual plus tune, volume/mute, span/step, and dashboard actions over HTTP port
+80. It does not expose passwords, pairing material, or coordinates, but it has
+no application authentication or TLS. Treat it as trusted-LAN-only and do not
+expose it to the Internet.
 
 ## Supported code
 

--- a/apps/orcsdr-tab5/README.md
+++ b/apps/orcsdr-tab5/README.md
@@ -1,6 +1,8 @@
 # OrcSDR Tab5 app (portable RF shell + radio)
 
-Measured M5Stack **Tab5** (ESP32-P4) + official RTL-SDR Blog V4 USB host path.
+M5Stack **Tab5** (ESP32-P4) native ESP-IDF application. RTL-SDR Blog V4 is the
+tested baseline; V3/V3C and Nooelec profiles have narrower experimental
+evidence boundaries documented below.
 
 Direction: not only an FM radio — a **portable RF tool shell** where listen,
 scope, and capture are first tabs, and later tools (band scan, IQ dump, gain
@@ -46,8 +48,16 @@ Driver component (portable USB/stream):
 immutable release by `main/idf_component.yml` and `dependencies.lock`. Do not
 substitute a local component path or a moving branch.
 
-Hard rules: clean-room V4 only; no librtlsdr; do not claim calibrated OTA RF
-from UI features alone.
+Hard rules: clean-room `esp-rtl-sdr` integration; no librtlsdr; do not claim
+calibrated OTA RF or general receiver compatibility from UI/detection alone.
+
+| Receiver | Current evidence |
+|---|---|
+| Blog V4 | RF-Verified tested baseline. |
+| Blog V3C | RF-Verified/Experimental on one RC4 unit; gain/sensitivity provisional. |
+| Earlier Blog V3 | Implemented/Experimental; broad compatibility Not Verified. |
+| Nooelec NESDR SMArt V5 | Implemented/Experimental; repeatable RF Not Verified. |
+| Blog V4L and other receivers | Not Verified/Unsupported unless explicitly profiled and accepted. |
 
 ## Build (native ESP-IDF)
 

--- a/architecture.md
+++ b/architecture.md
@@ -1,210 +1,104 @@
-# OrcSDR Architecture
+# OrcSDR current architecture
 
-## Purpose and truth source
+This describes `main` at
+`c5b3423fbdeb129ebd63d8ffd5c1bced9c913c04` on 2026-09-12. Historical plans
+and validation reports explain how the design arrived here but are not current
+architecture contracts.
 
-This document describes the implemented runtime boundaries for the Tab5
-application. It is an architecture reference, not a release-acceptance record.
-[`PROJECT_STATUS.md`](PROJECT_STATUS.md) remains the authoritative project-truth
-document for build, flash, and hardware evidence.
+## Platform and dependency boundary
 
-## Driver, DSP, and board boundaries
+OrcSDR's production Tab5 firmware is a native ESP-IDF 5.5.4 application for
+ESP32-P4. The onboard ESP32-C6 runs matching ESP-Hosted 3.0.6 firmware and uses
+4-bit SDIO at the qualified 10 MHz clock. PlatformIO configurations are
+historical and unsupported.
 
-OrcSDR consumes the standalone `esp_rtl_sdr` v0.7.9 component through its C
-API. The driver owns USB/tuner control and IQ delivery; its implementation,
-tests, and P4 serial example live upstream. The Tab5 app selects callback-only
-IQ delivery and owns the downstream DSP queues and outputs. Its `radio_session`
-service records the current application owner, band, frequency, sample rate,
-and receiver state. Generation tokens reject retunes from an owner that has
-already been replaced. See the [driver integration contract](docs/API_ESP_RTL_SDR.md).
+The portable receiver boundary is the external `esp-rtl-sdr` component,
+0.8.0-rc2, pinned immutably at
+`b175dfea6782faa97e512d4a2408767c75977527` by
+`apps/orcsdr-tab5/main/idf_component.yml` and
+`apps/orcsdr-tab5/dependencies.lock`. OrcSDR uses callback delivery and owns
+DSP, UI, storage, and product behavior above that driver. The old local USB
+implementation is forced off, although disabled source blocks remain.
 
-ADS-B, P25, LoRa, and RF analysis have separate modules and interfaces. The
-P25 C4FM protocol/FEC receiver in `p25_decoder_core` accepts caller-provided
-timestamps and IQ and has no FreeRTOS, display, M5, USB, SD, or speaker
-dependency. `p25_voice` similarly owns only IMBE/FEC state and bounded 48 kHz
-PCM production. The thin `p25_decoder` adapter owns the FreeRTOS-safe snapshot
-and voice queue. `ui/main.cpp` still owns P25 tuning/follow policy, task
-scheduling, IQ capture/replay transport, and speaker delivery.
+## Application ownership
 
-The core also decodes the clear LDU2 Encryption Sync field with its inner
-Hamming and outer Reed-Solomon protection. It tags bounded voice frames with
-the validated algorithm/key state. The Tab5 follow policy mutes protected
-frames and optionally returns to the control channel; no decryption exists.
+`apps/orcsdr-tab5/ui/main.cpp` remains the top-level application and still owns
+substantial cross-cutting behavior: startup and tasks; receiver lifecycle and
+hotplug; tuning and stream ownership; generic band routing; FM, AM, WX, CB and
+Browse DSP/audio policy; RDS; P25, ADS-B, LoRa and POCSAG runtime integration;
+Wi-Fi pause/resume orchestration; catalog operations; serial and authenticated
+device commands; SD/IQ/audio transfers; LAN console command dispatch;
+documentation capture; screen transitions; and top-level touch routing.
 
-These modules still compile into the Tab5 application component. `ui/main.cpp`
-also retains FM/AM processing, RDS, driver lifecycle, other DSP policy, and
-speaker integration; `rf_analysis.cpp` still depends on M5Unified timing.
-This first P25 boundary is host-testable, but it does not yet establish a
-complete board-independent OrcSDR engine or display/audio HAL.
+main.cpp measurement (Git-normalized): 713,890 bytes (~697.2 KiB), 15,751 lines.
 
-Tab5 display, touch, speaker, and USB power setup remain application concerns.
-The task/screen boundaries below describe runtime ownership, not independently
-linkable portable components. Prior Waveshare operation and the evidence needed
-to assess shared DSP reuse are documented in [PORTING.md](docs/PORTING.md).
+The measurement uses LF-normalized repository bytes so it is stable across
+Windows and Linux checkouts. The intended modular endpoint—roughly 500 lines of
+application wiring, setup, loop, and task creation—has not been reached. This
+documentation task does not refactor it.
 
-## Runtime ownership
+## Display and dashboard ownership
 
-The native ESP-IDF application separates deterministic radio work from display
-work:
+`screen_controller` is the single framebuffer owner. A transition grants one
+screen permission to draw while radio/decoder work continues independently.
+`navigation_service` owns Home/Settings handoff mechanics; feature dashboards
+render snapshots rather than owning receiver state.
 
-- **Core 0:** USB Host and RTL-SDR bulk IQ ownership.
-- **Core 1:** DSP/audio queueing, touch, UI service, and ESP-Hosted/Wi-Fi
-  control.
-- **DMA/I2S:** audio playback proceeds independently once audio blocks are
-  queued. UI work must not run in the IQ or audio callback path.
-- **ScreenController:** owns which one application surface may write to the
-  framebuffer and receive screen-specific touch handling.
+ScreenController IDs: `none`, `home`, `fm`, `p25`, `adsb`, `lora`, `radio`, `visualizer`, `rf_lab`, `wifi_analysis`, `pocsag`, `settings`, `am`, `documentation`.
 
-Radio, decoder, Wi-Fi, SD, and audio state may continue to update in the
-background. They provide snapshots to a visible screen; they do not draw.
+Dashboard IDs: `home`, `fm`, `p25`, `adsb`, `shortwave`, `weather`, `cb`, `lora`, `airband`, `marine`, `satellite`, `utilities`, `settings`, `rf_lab`, `wifi_analysis`, `pocsag`, `am`.
 
-## Radio session and scan ownership
+The current screen modules include Home, FM, AM, P25, ADS-B, LoRa, POCSAG, RF
+Lab, RF Visualizer, Wi-Fi analysis, Settings, documentation capture, and the
+shared Radio/Scope/Capture surface. Dashboard catalog entries for Shortwave,
+Airband, Marine, and Satellite route into that shared receiver surface; catalog
+labels do not imply dedicated decoders or complete demodulation modes.
 
-`apps/orcsdr-tab5/ui/radio_session.{hpp,cpp}` is the application-level tuner
-ownership record. FM, P25, ADS-B, LoRa, the general radio, RF Lab, and RF
-Visualizer acquire a new generation when they take control. A retune carries
-the captured owner and generation; once another consumer acquires the tuner,
-the old token can no longer change the recorded frequency. Starting another
-radio mode cancels an active scan without restoring the old scan frequency.
+## Receiver and DSP ownership
 
-`apps/orcsdr-tab5/ui/scan_engine.{hpp,cpp}` is a bounded asynchronous state
-machine for channel lists, frequency ranges, and future window sweeps. It owns
-target order, retune/settle/advance timing, cancellation, completion,
-restoration, and progress. Callbacks retain all feature policy: FM decides
-whether a peak becomes a preset, while P25 evaluates RF and decoder results.
-No allocation, delay, filesystem work, or display work occurs in the engine.
+- `radio_session` serializes receiver ownership and generation changes.
+- `scan_engine` supplies bounded scan behavior shared by supported modes.
+- `fm_dashboard`, `am_dashboard`, `p25_dashboard`, `adsb_dashboard`,
+  `lora_dashboard`, and `pocsag_dashboard` own presentation for their modes.
+- Protocol/DSP cores hold host-testable decode logic where already separated.
+- `main.cpp` still adapts IQ callbacks, mode policy, audio, tune changes, and
+  snapshots into those modules.
 
-FM preset scanning and P25 control-channel survey use this shared engine. The
-existing LoRa survey remains in `main.cpp` because its current cadence samples
-before each retune and labels that value with the next span center. Migrating it
-to settle-then-measure semantics would change observable behavior, so that
-correction and migration require a separate hardware-validated change.
+Receiver profiles are selected inside the single driver API. Blog V4 is the
+tested baseline; Blog V3/V3C and Nooelec profiles exist with experimental
+evidence boundaries. V4L and arbitrary RTL2832 receivers are not accepted by
+inference.
 
-## ScreenController contract
+## Wi-Fi, catalog, and LAN console
 
-`apps/orcsdr-tab5/ui/screen_controller.{hpp,cpp}` is the single runtime owner
-of display routing. Its screen IDs are Home, FM, P25, ADS-B, LoRa, generic
-Radio/Scope/Capture, Settings, and documentation mode.
+ESP-Hosted starts on demand from Settings or deferred saved-profile connection.
+The production path intentionally pauses an active radio session around Wi-Fi
+scan/connect/power changes and signed catalog I/O, then attempts to restore it.
+Documentation must not describe these operations as concurrent uninterrupted
+reception.
 
-Every transition follows one sequence:
+The optional LAN console starts an ESP-IDF HTTP server on port 80 and advertises
+`orcsdr.local`. It serves telemetry, spectrum and audio plus POST
+`/api/action` commands for tune, volume/mute, span/step, and dashboard opening.
+The server has no TLS or application authentication; it is a trusted-LAN
+feature, not a public-network control plane.
 
-1. Select the next screen and, when opening Settings, remember the exact
-   return screen.
-2. Deactivate the previous display owner and clear the framebuffer once.
-3. Enter and draw the new screen's static chrome once.
-4. Finish the transition; only the active screen may perform bounded dynamic
-   repaint or screen-specific touch handling.
+The catalog client downloads signed manifests and hash-verifies staged files
+before atomic activation. Catalog ownership is bounded: user P25 configuration
+remains user-owned, and publication of one catalog does not imply every planned
+pack exists.
 
-Settings is a full-screen route, not an overlay. Closing it restores the exact
-previous surface: Home, FM, P25, ADS-B, LoRa, or generic radio.
+## Build and verification boundary
 
-`may_draw()` rejects dynamic display work during a transition or from an
-inactive screen. `is_active()` permits the one intentional static draw while a
-new screen is being entered. This distinction prevents stale dashboards,
-waterfalls, meters, and Settings content from drawing over a newly selected
-surface.
+GitHub Actions currently runs P25 core, radio-scan core, user-guide, and
+Documentation Truth workflows. Native Tab5 firmware is not currently compiled
+in CI. Host tests and documentation checks do not prove a physical Tab5,
+receiver, antenna, RF signal, display, touch path, or release package.
 
-Timed radio, recording, and retune events use the active-screen refresh
-dispatcher. They may request a bounded repaint, but they never select a
-dashboard from the current band or draw a legacy header directly.
-The RTL application task likewise posts a screen-transition request; the UI
-loop alone consumes it and writes the framebuffer.
-
-## Dashboard responsibilities
-
-Each dashboard owns only its static renderer, bounded dynamic update regions,
-and touch behavior while selected:
-
-| Surface | Owner responsibilities |
-|---|---|
-| Home | Aggregate spectrum/waterfall and navigation snapshot |
-| FM / P25 | Listening controls and active radio presentation |
-| ADS-B / LoRa | Decoder snapshot presentation; no IQ parsing or capture work in UI |
-| Generic Radio | Radio, Scope, and Capture presentation and controls |
-| Settings | Full-screen configuration and exact-route return |
-| Documentation | Temporary capture routing with state restoration |
-
-No inactive dashboard may animate, repaint, poll touch, or modify display
-state. A future dashboard must register a screen ID and route entry, update,
-and touch through `ScreenController` before it writes display primitives.
-
-## Shared radio UI service
-
-`apps/orcsdr-tab5/ui/radio_ui_service.{hpp,cpp}` owns the shared generic
-spectrum grid, axis, filter-edge, waterfall-color, and control-row geometry.
-`main.cpp` supplies compact frequency/span/filter snapshots and performs the
-state-changing radio actions after service action classification. The service
-has no RTL, USB, DSP, or touch-polling ownership, keeping live radio state
-deterministic.
-
-## Navigation service
-
-`apps/orcsdr-tab5/ui/navigation_service.{hpp,cpp}` owns Home and Settings
-screen handoff: it clears the framebuffer once, enters the selected surface,
-and restores the exact `ScreenController` return target after Settings closes.
-`main.cpp` supplies current radio/settings snapshots and the bounded renderer
-for the restored screen; it remains the owner of receiver state, NVS writes,
-and audio/DSP lifecycle.
-
-## Device status service
-
-`apps/orcsdr-tab5/ui/device_status_service.{hpp,cpp}` is the read-only source
-for displayable power, Wi-Fi, and RTL readiness data. Home and global Settings
-consume the same bounded snapshot; collecting it neither starts Wi-Fi nor
-touches SD, radio, or decoder state.
-
-The former generic **Browse** screen is retired as a user route. Until a band
-has a dedicated dashboard, tuning AM, WX, CB, airband, marine, satellite, or
-other general receiver ranges presents the shared Home workspace instead. The
-underlying radio/scope/capture services remain internal implementation support,
-not a competing navigation surface.
-
-## Header constraint
-
-The persistent header baseline is **Home**, **Device Settings**, **Battery /
-Power**, and **Volume**. `dashboard_audio_control` is the single owner of the
-Home, Settings, and FM/P25 volume-control geometry; it also owns their touch
-hitboxes and overlap self-check.
-
-- **Home:** routes to the Home screen. It may be omitted only when Home itself
-  is the active surface.
-- **Device Settings:** every user-facing dashboard reserves the 58 by 58 pixel
-  rectangle at `(1211, 8)` for the settings gear. Status content must terminate
-  before that rectangle; it may compress, but it may not cover, move, or omit
-  the control. Closing Settings returns to the exact originating screen.
-- **Battery / Power:** a readable battery state belongs in the top status area.
-- **Volume:** FM and P25 use the shared global volume/mute control today.
-  ADS-B and LoRa reserve the Home and Settings positions but still need their
-  header-status reflow before the same global volume control can be added
-  without covering live telemetry. This is an explicit migration item, not a
-  reason to duplicate a header implementation.
-
-New dashboard headers must preserve those rectangles and their touch routing.
-New header controls must extend `dashboard_audio_control` rather than add a
-second geometry or touch implementation.
-
-## Diagnostics and validation
-
-At boot, `ScreenController::self_check()` verifies transition blocking and
-Settings return for Home, FM, P25, ADS-B, and LoRa. `radio_session` checks stale
-owner rejection, and `scan_engine` deterministically checks plan validation,
-target order, virtual dwell timing, progress, completion, cancellation,
-restoration, single-target operation, and retune failure. Documentation capture
-also claims the `documentation` identity while it freezes a rendered surface,
-then restores the original controller identity before normal updates resume.
-Self-check failures emit a named serial marker during boot.
-
-The P25 core and voice modules also run in optimized and sanitizer-enabled host
-tests. Device validation uses authenticated P25 status, bounded control-channel
-IQ capture, and stopped-radio replay commands so control identity, grants,
-voice production, drop counters, heap floor, and voice-task stack headroom can
-be checked without display scraping.
-
-`RTL_SCREEN_STATUS` reports the active and return screens plus transition,
-rejected-draw, and visible-update counters. It is read-only and performs no
-periodic allocation or catalog work.
-
-Build evidence for this controller pass is native ESP-IDF compilation. The
-remaining evidence gate is on-device transition acceptance across Home, FM,
-P25, ADS-B, LoRa, generic Radio/Scope/Capture, and Settings. Until that gate
-is recorded, this is implemented source architecture rather than a new
-hardware-verified release claim.
+The Documentation Truth workflow is deterministic and does not invoke an AI
+model or consume AI/API credits. It checks dependency/document coherence,
+architecture measurement drift, workflow claims, local links, selected file
+references, source/document screen IDs, resolved stale claims, and history or
+prompt hygiene. It does **not** prove hardware functionality, RF reception,
+decoder correctness, antenna suitability, physical display/touch behavior,
+feature completeness, software authorship, or whether code was AI-generated.

--- a/docs/API_ESP_RTL_SDR.md
+++ b/docs/API_ESP_RTL_SDR.md
@@ -2,25 +2,30 @@
 
 The public driver API is maintained in
 [`hardcoreerik/esp-rtl-sdr`](https://github.com/hardcoreerik/esp-rtl-sdr).
-OrcSDR obtains the immutable `v0.7.9` release through ESP-IDF's component
-manager and records the resolved commit and content hash in
+Current OrcSDR uses driver **0.8.0-rc2** at immutable commit
+`b175dfea6782faa97e512d4a2408767c75977527`. The same SHA is recorded in
+`apps/orcsdr-tab5/main/idf_component.yml` and
 `apps/orcsdr-tab5/dependencies.lock`.
 
-OrcSDR's Tab5 integration deliberately overrides these defaults:
+## Receiver evidence
 
-- `delivery_mode = ESP_RTL_SDR_DELIVERY_CALLBACK`; OrcSDR does not consume the
-  synchronous read ring.
-- Three 32-KiB USB transfers.
-- USB task pinned to core 0.
-- Borrowed IQ event data is consumed or copied during the callback and is not
-  retained.
+| Receiver | Current boundary |
+|---|---|
+| RTL-SDR Blog V4 | RF-Verified tested baseline. |
+| RTL-SDR Blog V3C | RF-Verified/Experimental on one RC4 unit for detection, startup, streaming, FM/RDS, retune, hotplug, and USB/battery boot; gain and sensitivity remain provisional. |
+| Earlier Blog V3 variants | Implemented/Experimental; V3C evidence does not establish broad compatibility. |
+| Nooelec NESDR SMArt V5 | Implemented/Experimental; detection/streaming provisional and repeatable RF Not Verified. |
+| Blog V4L | Not Verified; no explicit acceptance evidence. |
+| Other receivers | Unsupported/Not Verified unless a named profile and evidence are added. |
 
-Do not add a local component override, copy the driver into this repository, or
-patch generated `managed_components`. Driver defects are reported and fixed in
-the driver repository, released under a new immutable tag, then adopted by
-updating the manifest and lockfile.
+OrcSDR deliberately selects callback delivery, three 32-KiB USB transfers, and
+USB task core 0. Borrowed IQ event data is consumed or copied during the
+callback and is never retained.
+
+Do not add a local driver copy or patch generated `managed_components`. Driver
+fixes belong upstream, followed by adoption of a new immutable pin here.
 
 Streaming gain, AUTO, RTL AGC, and bias setters are asynchronous requests.
-`ESP_OK` means accepted, and getters expose software shadow state. Hardware
-register latching requires an external USB protocol analyzer or equivalent bus
-evidence. Windows USBPcap on the PC cannot observe the USB bus hosted by Tab5.
+`ESP_OK` means accepted; getters expose software shadow state. Hardware
+register latching requires bus-level evidence. Historical documents may name
+older driver versions only as dated Historical Evidence.

--- a/docs/M5TAB5_VALIDATION_REPORT.md
+++ b/docs/M5TAB5_VALIDATION_REPORT.md
@@ -1,5 +1,8 @@
 # M5Tab5 validation report
 
+> **Historical Evidence.** This dated report applies only to the named build,
+> board, and test setup. It is not the current project-status document.
+
 Date: 2026-07-18
 
 Target: M5Stack Tab5 on COM17

--- a/docs/OrcSDR TV Mission-Control Experience.md
+++ b/docs/OrcSDR TV Mission-Control Experience.md
@@ -1,3 +1,9 @@
+# OrcSDR TV Mission-Control design prompt
+
+> **Historical Design / superseded prompt material.** The imperative text below
+> is preserved as design provenance. It is not current architecture,
+> implementation status, or instructions for contributors or automation.
+
 You are redesigning the **OrcSDR LAN Console for a large-screen Android TV**.
 
 This is NOT simply a larger version of the M5Stack Tab5 interface.

--- a/docs/P25_PHASE2_WORKPHASE.md
+++ b/docs/P25_PHASE2_WORKPHASE.md
@@ -1,5 +1,11 @@
 # P25 Phase II work phase
 
+> **Historical Evidence / superseded work plan.** This records the branch and
+> gate sequence used to land the current Phase II transport, sync, complete
+> burst retention, and DUID classification stages. Branch names below are not
+> the current worktree. Current gaps are payload decode and AMBE+2 audio; see
+> [`PROJECT_STATUS.md`](../PROJECT_STATUS.md) and [`Roadmap.md`](../Roadmap.md).
+
 This work adds clear-voice P25 Phase II in small, independently testable pull
 requests while preserving the working Phase I receiver. Public status remains
 **P25 WIP** until live Phase II audio passes.

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1,5 +1,9 @@
 # Porting `esp_rtl_sdr` to ESP32 devices
 
+> **Current OrcSDR dependency (2026-09-12):** driver 0.8.0-rc2 at immutable
+> pin `b175dfea6782faa97e512d4a2408767c75977527`. Older pins below are retained
+> as Historical Evidence for the integration that was actually tested then.
+
 ## Goals
 
 1. **Standalone driver** ([`hardcoreerik/esp-rtl-sdr`](https://github.com/hardcoreerik/esp-rtl-sdr)) usable without OrcSDR UI.

--- a/docs/recordings/2026-08-08-last-recording-analysis.md
+++ b/docs/recordings/2026-08-08-last-recording-analysis.md
@@ -1,5 +1,8 @@
 # Last pre-restart recording analysis
 
+> **Historical Evidence.** This analysis applies to the named 2026-08-08
+> recording and must not be read as current-release RF acceptance.
+
 Source on Tab5: `/orcsdr/rec_001_FM_91900000.wav`
 
 The file was retrieved through the USB SD readback protocol and its local

--- a/docs/releases/v0.2.0-beta.6-multidongle-rc4.md
+++ b/docs/releases/v0.2.0-beta.6-multidongle-rc4.md
@@ -1,5 +1,10 @@
 # OrcSDR v0.2.0-beta.6 Multi-Dongle RC4
 
+> **Final publication result (2026-09-12):** the exact merged M5Burner package
+> described here passed its install/boot gate and was published as immutable tag
+> `v0.2.0-beta.6-multidongle-rc4`. Candidate requirements below preserve their
+> pre-publication chronology.
+
 RC4 is an experimental prerelease for receiver testing. It replaces RC3 for
 multi-dongle testing and adds the hardware-verified RTL-SDR Blog V3C tuning
 repair.

--- a/docs/user-guide/dashboards/other-bands.md
+++ b/docs/user-guide/dashboards/other-bands.md
@@ -1,9 +1,17 @@
-# AM, WX, CB, and Browse
+# AM, WX, CB, and shared receiver routes
 
-These bands share three tools:
+The current application has dedicated AM and CB presentation plus a shared
+Radio/Scope/Capture receiver surface. Weather and the dashboard-catalog entries
+for Shortwave, Airband, Marine, and Satellite route into that shared surface;
+they are not separate full decoder applications.
 
-- **Radio** — listen and tune with band-appropriate demodulation.
-- **Scope** — inspect spectrum and waterfall activity.
-- **Capture** — record the post-demodulated audio path for review.
+- **Radio** tunes and listens with the mode currently implemented for the route.
+- **Scope** shows spectrum and waterfall activity.
+- **Capture** records the post-demodulated audio path.
 
-AM uses the broadcast-band step and filter. WX uses narrow FM on a configured NOAA weather channel. CB exposes channel, mode, clarifier, and squelch controls. Browse is the general direct-tuning surface; reception legality and local band plans remain the operator's responsibility.
+AM uses broadcast-band tuning and filtering. WX uses NFM on a configured NOAA
+weather channel. CB exposes its channel-oriented controls. Shortwave, Airband,
+Marine, and Satellite currently use generic Browse/NFM routing, so this UI does
+not establish correct shortwave AM/SSB, aviation AM voice, or a satellite
+decoder. The older standalone Browse navigation entry is retired; the shared
+surface remains the implementation used by these band-entry routes.

--- a/docs/user-guide/downloads.md
+++ b/docs/user-guide/downloads.md
@@ -1,11 +1,20 @@
 # Downloads and releases
 
-Use GitHub Releases for notes and tags. The current native 5.5.4 / ESP-Hosted
-3.0.6 migration is not yet a release acceptance path: use
-[`Tab5 ESP-Hosted 3.0.6 migration`](tab5-esp-hosted-3-migration.md) for
-the exact build and hardware status. Legacy tagged releases retain their own
-2.12.6 instructions. Verify SHA-256 before trusting extra SD data packs.
-Generated MP4 walkthroughs are upload-ready artifacts and are not stored in
-normal Git history.
+For ordinary installation, use the published
+[`v0.2.0-beta.6-multidongle-rc4`](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.6-multidongle-rc4)
+M5Burner package. It contains the native ESP-IDF 5.5.4 P4 application and the
+matching ESP-Hosted 3.0.6 C6 firmware; the exact merged package was installed
+and booted on the owner Tab5 before publication.
 
-The Pages site is deployed only from merged `main`. A pull request build validates the guide but cannot publish it.
+Use GitHub Releases for immutable notes, assets, hashes, and tags. Verify the
+published SHA-256 before trusting firmware or optional SD data packs. The
+release's hardware result is exact-version evidence, not proof of later `main`
+commits, every receiver, or every Tab5 revision.
+
+Developers building from source should follow the
+[developer reference](reference/developer.md) and the
+[ESP-Hosted 3.0.6 technical record](tab5-esp-hosted-3-migration.md). Legacy
+tags retain their original dependency-specific instructions.
+
+The Pages site is deployed only from merged `main`. Pull requests validate the
+guide but do not publish it.

--- a/docs/user-guide/feature-status.md
+++ b/docs/user-guide/feature-status.md
@@ -1,15 +1,33 @@
 # Feature status
 
-| Feature | Status | Notes |
+These labels describe evidence, not marketing maturity. **Experimental** may
+coexist with an evidence level. Historical hardware results do not automatically
+apply to later source snapshots.
+
+| Feature | Current status | Boundary |
 |---|---|---|
-| FM receive, stereo audio, presets, and health | Implemented | Live hardware verified |
-| FM RDS decoding | Implemented | Sequential A–B–C–D groups, confirmed PS, voted PTY, Radio Text. Needs a 260 kHz FM filter. This dongle uses a +13 kHz LO bias that is not shown as the channel. |
-| P25 control and clear voice following | WIP | Phase I clear voice verified; wider system compatibility in progress. Encrypted voice is not decoded. |
-| ADS-B 1090 dashboard and aircraft database | Implemented | Live hardware verified; coverage depends on antenna, location, and valid position messages |
-| LoRa receive, packet views, and capture | Experimental | No transmit path |
-| AM, WX, CB, and Browse tools | Experimental | Shared radio/scope/capture foundation |
-| Global on-device Settings | Implemented | Wi-Fi and Companion remain optional |
-| Offline personalized map packs | Deferred | Import/status shell precedes the builder workflow |
-| Bluetooth speaker audio | Unavailable | Tab5 C6 supports BLE, not ordinary Classic Bluetooth A2DP output |
-| Companion phone integration | Deferred | On-device operation never depends on it |
-| LAN web console + Android TV viewer | Experimental | Opt-in Mission Control display (not a Tab5 clone); no TLS. Sideload `apps/orcsdr-tv` on Android 9 TV. Unplug the PC flash/JTAG USB cable after flashing — that cable, not general power, is the bench brownout trigger. |
+| FM audio, presets, stereo, RDS | **RF-Verified / Regression-Tested** | Verified on RTL-SDR Blog V4 and one V3C with suitable FM setups. |
+| AM broadcast and 119-channel scan | **Hardware-Verified / Experimental** | Exact RC4 package exercised the dashboard and scan; general reception quality remains Experimental. |
+| NOAA Weather Radio | **Implemented** | Current-release RF acceptance is Not Verified. |
+| CB | **Implemented / Runtime-Verified** | Flashed and exercised; operator/RF acceptance remains open. |
+| Shortwave | **Implemented / Experimental** | Generic Browse/NFM workspace only; complete AM/SSB and calibrated HF reception are Not Implemented. |
+| Airband | **Implemented / Experimental** | Generic Browse near 121.5 MHz using NFM; not a complete AM aviation voice receiver. |
+| Marine | **Implemented / Experimental** | Generic NFM routing; no dedicated dashboard/current RF acceptance evidence. |
+| Satellite | **Implemented / Experimental** | Generic routing near 137.5 MHz; no dedicated satellite decoder/dashboard. |
+| P25 Phase I | **RF-Verified / Hardware-Verified / Regression-Tested** | Documented control, follow, clear/encrypted behavior; encrypted audio is not decoded. |
+| P25 Phase II | **Implemented / Runtime-Verified / Regression-Tested / Experimental** | Grants, sync, complete bursts, DUID classification, and hardware observation exist. Payload and AMBE+2 audio are Not Implemented. |
+| ADS-B 1090 | **RF-Verified / Hardware-Verified / Regression-Tested** | Live CRC-valid traffic, independent track comparison, and FAA enrichment; live-only. |
+| LoRa/Meshtastic | **Hardware-Verified / Experimental** | Native receive path and observed traffic; reliability and coverage are not broadly established. |
+| POCSAG | **RF-Verified at 1200 / Regression-Tested** | `TEST`, CAPCODE 1234560, and Flipper cross-check. 512/2400 are host-tested only; persistence/searchable archive is Not Implemented. |
+| RF Lab / RF Visualizer | **Implemented / Regression-Tested** | Integrated self-check/regression tooling; not RF calibration proof. |
+| Wi-Fi analysis | **Implemented / Hardware-Verified / Experimental** | Real AP survey through ESP-Hosted 3.0.6; Wi-Fi and catalog I/O pause active reception. |
+| Receiver profiles | **Evidence varies** | Blog V4 baseline; V3C RF-Verified/Experimental; earlier V3 and Nooelec provisional; V4L and generic receivers Not Verified. |
+| Global Settings | **Implemented / Hardware-Verified** | Wi-Fi, radio defaults, storage, display/audio, catalog, and Companion controls. |
+| LAN console | **Implemented / Experimental** | Opt-in read/write HTTP surface; tune/audio/navigation controls, no TLS or authentication. Trusted LAN only. |
+| Android TV | **Implemented / Experimental** | LAN client; Tab5 remains the receiver. |
+| Signed data catalog | **Hardware-Verified / Experimental** | Public catalog and FAA reinstall evidence; not every proposed data pack is published. |
+| Transmission | **Not Implemented** | OrcSDR is receive-only. |
+
+Build, runtime, hardware, and RF evidence are different claims. See the
+authoritative [project status](https://github.com/hardcoreerik/OrcSDR/blob/main/PROJECT_STATUS.md) for exact release,
+receiver, CI, and remaining-evidence boundaries.

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -2,36 +2,36 @@
 
 ## Hardware
 
-1. Seat the Tab5 securely and connect a supported RTL-SDR Blog V4 to the USB-A host port.
-2. Attach the antenna appropriate for the band you intend to receive.
-3. Insert the prepared microSD card for databases, maps, captures, and screenshots.
-4. Use a stable power source. A depleted external battery can remain an electrical load even when USB is attached. After flashing, unplug the PC USB Serial/JTAG cable (the COM port used by `install-orcsdr.ps1`). Leaving that cable connected can brownout the Tab5 under Wi-Fi + RTL load even when battery or wall power is otherwise fine.
-5. Press the Tab5 power button and allow the staged USB-host and receiver startup to finish.
+1. Seat the Tab5 securely and connect an accepted receiver. RTL-SDR Blog V4 is
+   the tested baseline; see [feature status](feature-status.md) for experimental
+   receiver boundaries.
+2. Attach an antenna appropriate for the band you intend to receive.
+3. Insert the prepared microSD card if you need databases, maps, captures, or screenshots.
+4. Use stable power. After installation, disconnect the PC USB Serial/JTAG
+   cable; on the tested bench it can contribute to brownout under Wi-Fi plus RTL load.
+
+## Install with M5Burner
+
+The current supported user package is
+[`v0.2.0-beta.6-multidongle-rc4`](https://github.com/hardcoreerik/OrcSDR/releases/tag/v0.2.0-beta.6-multidongle-rc4).
+Open M5Burner, select the OrcSDR Tab5 package, and burn it without erasing user
+settings unless recovery instructions require an erase. The package carries
+matching ESP-Hosted 3.0.6 firmware for the onboard C6.
+
+Current M5Burner search visibility was not independently reverified during the
+documentation audit. If the entry is not visible, use the exact release page
+above rather than an older 2.12.6 installer path.
 
 ## First boot
 
-Boot lands on Home. If Auto-start reception is on, the last FM station can run in the background. Wi-Fi and phone pairing are optional; reception does not require either.
+Boot lands on Home. Receiver and Wi-Fi startup are staged. Reception does not
+require Wi-Fi; optional Wi-Fi scan/connect/catalog actions temporarily pause an
+active radio session and then attempt to restore it.
 
-## Installation
+## Developer build
 
-Current development uses ESP-IDF 5.5.4 and ESP-Hosted 3.0.6. The native P4
-application/radio path is working, but the permanent P4-to-C6 Wi-Fi handshake
-is still under acceptance. Follow the exact build, flash, and status guidance
-in [`Tab5 ESP-Hosted 3.0.6 migration`](tab5-esp-hosted-3-migration.md).
-
-Do not use the legacy 2.12.6 installer flow as a 3.0.6 verification step.
-For a native build:
-
-```powershell
-$env:IDF_PYTHON_ENV_PATH = 'C:\Espressif\python_env\idf5.5_py3.14_env'
-. 'C:\Espressif\frameworks\esp-idf-v5.5.4\export.ps1'
-Set-Location .\apps\orcsdr-tab5
-idf.py reconfigure
-idf.py build
-```
-
-The Tab5 C6 must run matching ESP-Hosted **3.0.6**. A normal P4 application
-flash does not update the C6. Do not claim Wi-Fi accepted until serial prints
-the three `I OrcSDR` C6/version/transport lines in the migration document.
-
-Do not use PlatformIO for Tab5 firmware. Preserve a recovery image before replacing known-good firmware.
+Source builds use native ESP-IDF 5.5.4 and matching ESP-Hosted 3.0.6. Do not use
+PlatformIO. Follow the [developer reference](reference/developer.md) and
+[migration/acceptance record](tab5-esp-hosted-3-migration.md). A P4-only flash
+does not prove or necessarily replace the C6 image, and a successful build is
+not hardware or RF acceptance.

--- a/docs/user-guide/reference/developer.md
+++ b/docs/user-guide/reference/developer.md
@@ -28,7 +28,8 @@ callbacks.
 - Do not add a PSRAM sprite plus a full-frame memcpy for high-rate rendering.
   It competes with the radio/audio pipeline and regresses frame pacing.
 - M5GFX's Tab5 double-framebuffer support is a pinned local patch. Native and
-  M5Burner builds apply it through `tools/apply-m5gfx-tab5-pageflip.ps1`.
+  M5Burner builds apply it through
+  `apps/orcsdr-tab5/tools/apply-m5gfx-tab5-pageflip.ps1`.
   Update the tracked patch with any M5GFX component upgrade; never edit only
   the ignored `managed_components` copy.
 

--- a/docs/user-guide/settings.md
+++ b/docs/user-guide/settings.md
@@ -17,4 +17,7 @@ Saved Wi-Fi passwords are masked and never returned through the Settings UI or d
 
 Companion → ENABLE starts the TV Mission Control page at `http://<tab5-ip>/` and
 advertises `orcsdr.local`. Use that URL from a browser or the sideloaded
-`apps/orcsdr-tv` app. The console does not accept tune or volume commands.
+`apps/orcsdr-tv` app. This is a read/write HTTP control surface, not only a
+viewer: it can tune, change volume or mute state, adjust span/step, and open
+dashboards. It has no TLS or application authentication. Enable it only on a
+trusted LAN, and do not expose port 80 to the Internet.

--- a/docs/user-guide/tab5-esp-hosted-3-migration.md
+++ b/docs/user-guide/tab5-esp-hosted-3-migration.md
@@ -1,6 +1,6 @@
-# Tab5 native ESP-Hosted 3.0.6 migration
+# Tab5 native ESP-Hosted 3.0.6 technical record
 
-This is the source of truth for the M5Stack Tab5 P4/C6 migration. It replaces
+This records the M5Stack Tab5 P4/C6 migration and current locked transport. It replaces
 the old 2.12.6 pairing guidance for current development. Historical release
 notes remain historical records, not current installation instructions.
 
@@ -27,7 +27,7 @@ pin map for the other.
 
 | Function | Controller / slot | Pins |
 | --- | --- | --- |
-| C6 ESP-Hosted SDIO | SDMMC Slot 1, 4-bit, 40 MHz | CLK 12, CMD 13, D0 11, D1 10, D2 9, D3 8 |
+| C6 ESP-Hosted SDIO | SDMMC Slot 1, 4-bit, qualified at 10 MHz | CLK 12, CMD 13, D0 11, D1 10, D2 9, D3 8 |
 | C6 reset | ESP-Hosted board profile | GPIO 15, active high |
 | removable microSD | SDMMC Slot 0, 4-bit | CLK 43, CMD 44, D0 39, D1 40, D2 41, D3 42 |
 | Wi-Fi antenna selector | Tab5 I/O expander 0 (`0x43`) | pin 0: low internal, high external MMCX |
@@ -74,7 +74,10 @@ RTL_WIFI_BOOT_STATUS station=1 hosted_match=1 stage=none error=0x0
 
 This proves C6 enumeration, the 4-bit SDIO transport, exact version
 pairing, and P4 Wi-Fi station initialization. A live AP scan and visual screen
-acceptance remain separate checks.
+acceptance remain separate checks. The exact
+`v0.2.0-beta.6-multidongle-rc4` M5Burner package subsequently passed its
+install/boot gate and was published; that result does not promote later source
+or other hardware to Hardware-Verified.
 
 Hosted auto-init is deliberately disabled
 (`CONFIG_ESP_HOSTED_AUTO_CALL_INIT_BEFORE_APP_MAIN=n`). A checked run with it

--- a/phasing.md
+++ b/phasing.md
@@ -1,5 +1,10 @@
 # Implementation phasing: Grok review gaps
 
+> **Historical execution ledger.** Completed and superseded phases are retained
+> for chronology; this file is not the current capability source or future
+> roadmap. Use [`PROJECT_STATUS.md`](PROJECT_STATUS.md) for current evidence and
+> [`Roadmap.md`](Roadmap.md) for remaining work.
+
 Implementation plan for the gaps tracked in `Roadmap.md`. Follows the same
 phase/exit-criteria shape as `PROJECT_STATUS.md`'s P0/P1/P2 roadmap. Each
 phase is scoped to land independently and keep the firmware building and

--- a/tests/test_documentation_truth.py
+++ b/tests/test_documentation_truth.py
@@ -1,0 +1,111 @@
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from tools.check_documentation_truth import run_checks
+
+
+PIN = "b175dfea6782faa97e512d4a2408767c75977527"
+
+
+class DocumentationTruthTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.root = Path(self.temp.name)
+        self.write("apps/orcsdr-tab5/main/idf_component.yml", f"  esp_rtl_sdr:\n    version: {PIN}\n")
+        self.write("apps/orcsdr-tab5/dependencies.lock", f"  esp-rtl-sdr:\n    version: {PIN}\n")
+        self.write("apps/orcsdr-tab5/ui/main.cpp", "one\ntwo\nthree\n")
+        self.write(
+            "apps/orcsdr-tab5/ui/screen_controller.hpp",
+            "enum class Id : uint8_t { none, home, fm };\n",
+        )
+        self.write(
+            "apps/orcsdr-tab5/ui/dashboard_registry.hpp",
+            "enum class Id : uint8_t { home, fm, count };\n",
+        )
+        self.write(".github/workflows/core.yml", "name: Core\n")
+        current = f"Current esp-rtl-sdr pin: `{PIN}` (0.8.0-rc2).\n"
+        self.write("PROJECT_STATUS.md", current)
+        self.write("docs/API_ESP_RTL_SDR.md", current)
+        self.write(
+            "architecture.md",
+            current
+            + "main.cpp measurement (Git-normalized): 14 bytes (~0.0 KiB), 3 lines.\n"
+            + "ScreenController IDs: `none`, `home`, `fm`.\n"
+            + "Dashboard IDs: `home`, `fm`.\n",
+        )
+        self.write("README.md", "[Status](PROJECT_STATUS.md)\n")
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def write(self, relative, text):
+        path = self.root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def report(self):
+        return run_checks(self.root)
+
+    def test_correct_current_state_passes(self):
+        self.assertEqual([], self.report().errors)
+
+    def test_stale_current_driver_pin_fails(self):
+        self.write("PROJECT_STATUS.md", "Current esp-rtl-sdr driver is v0.7.9.\n")
+        self.assertTrue(any(item.code == "driver-pin" for item in self.report().errors))
+
+    def test_historical_old_driver_version_does_not_fail(self):
+        self.write("docs/history/old.md", "Historical Evidence: this snapshot used v0.7.9.\n")
+        self.assertEqual([], self.report().errors)
+
+    def test_unqualified_no_ci_claim_fails_when_workflows_exist(self):
+        self.write("PROJECT_STATUS.md", "OrcSDR has no CI.\n")
+        self.assertTrue(any(item.code == "no-ci" for item in self.report().errors))
+
+    def test_precise_native_firmware_ci_gap_passes(self):
+        self.write(
+            "PROJECT_STATUS.md",
+            f"Current esp-rtl-sdr pin: `{PIN}`. Native Tab5 firmware is not currently compiled in CI.\n",
+        )
+        self.assertEqual([], self.report().errors)
+
+    def test_broken_local_markdown_link_fails(self):
+        self.write("README.md", "[Missing](docs/missing.md)\n")
+        self.assertTrue(any(item.code == "local-link" for item in self.report().errors))
+
+    def test_valid_local_markdown_link_passes(self):
+        self.write("README.md", "[Status](PROJECT_STATUS.md)\n")
+        self.assertEqual([], self.report().errors)
+
+    def test_small_main_cpp_measurement_drift_passes(self):
+        self.write("apps/orcsdr-tab5/ui/main.cpp", "x" * 99 + "\n")
+        text = (self.root / "architecture.md").read_text(encoding="utf-8")
+        text = re.sub(
+            r"14 bytes \(~0\.0 KiB\), 3 lines",
+            "96 bytes (~0.1 KiB), 1 lines",
+            text,
+        )
+        self.write("architecture.md", text)
+        self.assertFalse(any(item.code == "main-measurement" for item in self.report().errors))
+
+    def test_excessive_main_cpp_measurement_drift_fails(self):
+        text = (self.root / "architecture.md").read_text(encoding="utf-8")
+        self.write("architecture.md", text.replace("14 bytes", "7 bytes"))
+        self.assertTrue(any(item.code == "main-measurement" for item in self.report().errors))
+
+    def test_prompt_residue_warns_without_failing(self):
+        self.write("README.md", "Your job is to implement the following.\n")
+        report = self.report()
+        self.assertEqual([], report.errors)
+        self.assertTrue(any(item.code == "prompt-residue" for item in report.warnings))
+
+    def test_history_prompt_is_not_current_prose(self):
+        self.write("docs/history/prompt.md", "Historical Evidence\n\nYou are Codex. Your job is to implement the following.\n")
+        report = self.report()
+        self.assertEqual([], report.errors)
+        self.assertFalse(any(item.code == "prompt-residue" for item in report.warnings))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/check_documentation_truth.py
+++ b/tools/check_documentation_truth.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Deterministic, standard-library checks for high-confidence documentation drift."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+
+CURRENT_DRIVER_DOCS = ("PROJECT_STATUS.md", "architecture.md", "docs/API_ESP_RTL_SDR.md")
+CURRENT_DOCS = (
+    "README.md",
+    "PROJECT_STATUS.md",
+    "architecture.md",
+    "Roadmap.md",
+    "SECURITY.md",
+    "apps/orcsdr-tab5/README.md",
+    "docs/API_ESP_RTL_SDR.md",
+    "docs/TAB5_BUILD_POLICY.md",
+    "docs/RADIO_CONFIGURATION.md",
+)
+HISTORICAL_DOCS = (
+    "docs/OrcSDR TV Mission-Control Experience.md",
+    "docs/P25_PHASE2_WORKPHASE.md",
+    "docs/M5TAB5_VALIDATION_REPORT.md",
+    "docs/M5TAB5_INTEGRATION.md",
+    "docs/M5TAB5_RTL_RADIO_NEXT_STEPS.md",
+    "docs/ESP32_RTL_SDR_DRIVER_PLAN.md",
+    "docs/IMPLEMENTATION_FROM_PEER_RESEARCH.md",
+    "docs/PEER_USB_PIPELINE_DEEP_DIVE.md",
+    "docs/GATE2_IMPLEMENTATION_LOCK.md",
+    "docs/recordings/2026-08-08-last-recording-analysis.md",
+)
+PROMPT_PATTERNS = (
+    re.compile(r"\byour job is to\b", re.I),
+    re.compile(r"\byou are (?:codex|claude)\b", re.I),
+    re.compile(r"\bimplement the following\b", re.I),
+    re.compile(r"<instructions?>", re.I),
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class Diagnostic:
+    level: str
+    code: str
+    path: str
+    line: int
+    message: str
+
+
+@dataclasses.dataclass
+class Report:
+    errors: list[Diagnostic] = dataclasses.field(default_factory=list)
+    warnings: list[Diagnostic] = dataclasses.field(default_factory=list)
+    passes: list[str] = dataclasses.field(default_factory=list)
+
+    def add(self, level: str, code: str, path: str, line: int, message: str) -> None:
+        item = Diagnostic(level, code, path, line, message)
+        (self.errors if level == "ERROR" else self.warnings).append(item)
+
+
+def _text(root: Path, relative: str) -> str | None:
+    path = root / relative
+    return path.read_text(encoding="utf-8") if path.is_file() else None
+
+
+def _line(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def _current_markdown(root: Path) -> list[Path]:
+    paths = [root / item for item in CURRENT_DOCS]
+    guide = root / "docs/user-guide"
+    if guide.is_dir():
+        paths.extend(guide.rglob("*.md"))
+    return sorted({path for path in paths if path.is_file()})
+
+
+def _dependency_pin(root: Path, report: Report) -> str | None:
+    manifest_path = "apps/orcsdr-tab5/main/idf_component.yml"
+    manifest = _text(root, manifest_path)
+    if manifest is None:
+        report.add("ERROR", "driver-pin", manifest_path, 1, "dependency manifest is missing")
+        return None
+    block = re.search(r"esp[-_]rtl[-_]sdr\s*:\s*(.*?)(?=\n\s{0,2}\S|\Z)", manifest, re.S)
+    match = re.search(r"version\s*:\s*[\"']?([0-9a-f]{40})", block.group(1) if block else "")
+    if not match:
+        report.add("ERROR", "driver-pin", manifest_path, 1, "immutable esp-rtl-sdr SHA not found")
+        return None
+    pin = match.group(1)
+    lock_path = "apps/orcsdr-tab5/dependencies.lock"
+    lock = _text(root, lock_path)
+    if lock is not None and not re.search(rf"version\s*:\s*[\"']?{pin}\b", lock):
+        report.add("ERROR", "driver-pin", lock_path, 1, f"lock file does not contain manifest pin {pin}")
+    return pin
+
+
+def _check_driver(root: Path, report: Report) -> None:
+    pin = _dependency_pin(root, report)
+    if pin is None:
+        return
+    for relative in CURRENT_DRIVER_DOCS:
+        text = _text(root, relative)
+        if text is None:
+            report.add("ERROR", "driver-pin", relative, 1, "authoritative driver document is missing")
+        elif pin not in text:
+            report.add("ERROR", "driver-pin", relative, 1, f"current immutable pin {pin} is not documented")
+        else:
+            stale = re.search(r"current[^\n]{0,80}(?:v?0\.7\.9)|(?:v?0\.7\.9)[^\n]{0,80}current", text, re.I)
+            if stale:
+                report.add("ERROR", "driver-pin", relative, _line(text, stale.start()), "stale current driver version claim")
+    if not any(item.code == "driver-pin" for item in report.errors):
+        report.passes.append(f"Current esp-rtl-sdr pin documented correctly ({pin})")
+
+
+def _check_ci_claims(root: Path, report: Report) -> None:
+    workflows = list((root / ".github/workflows").glob("*.y*ml"))
+    if not workflows:
+        return
+    pattern = re.compile(r"\b(?:orcsdr\s+has\s+)?no\s+(?:github actions\s+)?ci\b", re.I)
+    for path in _current_markdown(root):
+        text = path.read_text(encoding="utf-8")
+        for match in pattern.finditer(text):
+            report.add("ERROR", "no-ci", path.relative_to(root).as_posix(), _line(text, match.start()), "unqualified no-CI claim conflicts with existing workflows")
+    if not any(item.code == "no-ci" for item in report.errors):
+        report.passes.append(f"CI description matches {len(workflows)} workflow files")
+
+
+def _check_measurement(root: Path, report: Report) -> None:
+    source_path = root / "apps/orcsdr-tab5/ui/main.cpp"
+    architecture = _text(root, "architecture.md")
+    if not source_path.is_file() or architecture is None:
+        report.add("ERROR", "main-measurement", "architecture.md", 1, "main.cpp or architecture measurement is missing")
+        return
+    data = source_path.read_bytes().replace(b"\r\n", b"\n")
+    actual_bytes, actual_lines = len(data), len(data.splitlines())
+    match = re.search(r"main\.cpp measurement \(Git-normalized\):\s*([\d,]+) bytes\s*\(~[\d.]+ KiB\),\s*([\d,]+) lines", architecture, re.I)
+    if not match:
+        report.add("ERROR", "main-measurement", "architecture.md", 1, "standard main.cpp measurement line is missing")
+        return
+    documented_bytes = int(match.group(1).replace(",", ""))
+    documented_lines = int(match.group(2).replace(",", ""))
+    byte_drift = abs(actual_bytes - documented_bytes) / max(actual_bytes, 1) * 100
+    line_drift = abs(actual_lines - documented_lines) / max(actual_lines, 1) * 100
+    detail = (f"actual {actual_bytes:,} bytes ({actual_bytes / 1024:.1f} KiB), {actual_lines:,} lines; "
+              f"documented {documented_bytes:,} bytes, {documented_lines:,} lines; "
+              f"drift {byte_drift:.1f}% bytes/{line_drift:.1f}% lines")
+    if max(byte_drift, line_drift) > 5:
+        report.add("ERROR", "main-measurement", "architecture.md", _line(architecture, match.start()), detail)
+    elif max(byte_drift, line_drift) > 3:
+        report.add("WARNING", "main-measurement", "architecture.md", _line(architecture, match.start()), detail)
+    else:
+        report.passes.append(f"main.cpp architecture measurement ({detail})")
+
+
+def _enum_values(text: str) -> list[str] | None:
+    match = re.search(r"enum class Id\s*:\s*\w+\s*\{(.*?)\}", text, re.S)
+    if not match:
+        return None
+    return [item.strip().split("=")[0].strip() for item in match.group(1).split(",") if item.strip()]
+
+
+def _documented_ids(text: str, label: str) -> list[str] | None:
+    match = re.search(rf"^{re.escape(label)}:\s*(.+)$", text, re.M)
+    return re.findall(r"`([a-z0-9_]+)`", match.group(1)) if match else None
+
+
+def _check_screens(root: Path, report: Report) -> None:
+    architecture = _text(root, "architecture.md")
+    if architecture is None:
+        return
+    contracts = (
+        ("apps/orcsdr-tab5/ui/screen_controller.hpp", "ScreenController IDs", set()),
+        ("apps/orcsdr-tab5/ui/dashboard_registry.hpp", "Dashboard IDs", {"count"}),
+    )
+    for source, label, excluded in contracts:
+        source_text = _text(root, source)
+        actual = _enum_values(source_text or "")
+        documented = _documented_ids(architecture, label)
+        if actual is None or documented is None:
+            report.add("WARNING", "screen-drift", "architecture.md", 1, f"could not compare {label}")
+            continue
+        actual_set = set(actual) - excluded
+        documented_set = set(documented)
+        if actual_set != documented_set:
+            missing = sorted(actual_set - documented_set)
+            removed = sorted(documented_set - actual_set)
+            report.add("ERROR", "screen-drift", "architecture.md", 1, f"{label} mismatch; missing={missing}, removed={removed}")
+    if not any(item.code == "screen-drift" for item in report.errors + report.warnings):
+        report.passes.append("Screen and dashboard IDs match source enums")
+
+
+def _check_links(root: Path, report: Report) -> None:
+    link_re = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+    for path in _current_markdown(root):
+        text = path.read_text(encoding="utf-8")
+        for match in link_re.finditer(text):
+            raw = match.group(1).strip().split()[0].strip("<>")
+            if not raw or raw.startswith(("#", "http://", "https://", "mailto:")):
+                continue
+            target = unquote(raw.split("#", 1)[0].split("?", 1)[0])
+            resolved = (root / target.lstrip("/")) if target.startswith("/") else (path.parent / target)
+            if not resolved.exists():
+                report.add("ERROR", "local-link", path.relative_to(root).as_posix(), _line(text, match.start()), f"local link target does not exist: {raw}")
+    if not any(item.code == "local-link" for item in report.errors):
+        report.passes.append("Repository-local Markdown links resolve")
+
+
+def _check_file_references(root: Path, report: Report) -> None:
+    pattern = re.compile(r"`((?:apps|docs|tests|tools|\.github)/[^`*{}<>]+\.[A-Za-z0-9]+)`")
+    for path in _current_markdown(root):
+        text = path.read_text(encoding="utf-8")
+        for match in pattern.finditer(text):
+            reference = match.group(1)
+            if not (root / reference).exists():
+                report.add("ERROR", "file-reference", path.relative_to(root).as_posix(), _line(text, match.start()), f"referenced repository file does not exist: {reference}")
+    if not any(item.code == "file-reference" for item in report.errors):
+        report.passes.append("High-confidence documented file references resolve")
+
+
+def _check_resolved_claims(root: Path, report: Report) -> None:
+    guards = {
+        "docs/user-guide/settings.md": (r"does not accept tune or volume commands",),
+        "docs/user-guide/downloads.md": (r"3\.0\.6 migration is not yet a release acceptance path",),
+        "PROJECT_STATUS.md": (r"no message has yet been confirmed as a real, over-the-air POCSAG decode",),
+        "README.md": (r"retain decoded messages in a local archive", r"dedicated workspace for receiving and inspecting satellite signals"),
+        "Roadmap.md": (r"no public catalog release or hardware install evidence yet",),
+    }
+    for relative, patterns in guards.items():
+        text = _text(root, relative)
+        if text is None:
+            continue
+        for pattern in patterns:
+            match = re.search(pattern, text, re.I)
+            if match:
+                report.add("ERROR", "resolved-claim", relative, _line(text, match.start()), "known obsolete current-state claim resurfaced")
+    if not any(item.code == "resolved-claim" for item in report.errors):
+        report.passes.append("Resolved high-risk claims remain absent")
+
+
+def _check_prompt_residue(root: Path, report: Report) -> None:
+    for path in _current_markdown(root):
+        text = path.read_text(encoding="utf-8")
+        for pattern in PROMPT_PATTERNS:
+            match = pattern.search(text)
+            if match:
+                report.add("WARNING", "prompt-residue", path.relative_to(root).as_posix(), _line(text, match.start()), f"possible prompt residue: {match.group(0)}")
+
+
+def _check_history_labels(root: Path, report: Report) -> None:
+    for relative in HISTORICAL_DOCS:
+        text = _text(root, relative)
+        if text is not None and not re.search(r"Historical|Superseded", text[:800], re.I):
+            report.add("WARNING", "history-label", relative, 1, "historical document lacks a visible historical/superseded notice")
+    history = root / "docs/history"
+    if history.is_dir():
+        for path in history.rglob("*.md"):
+            text = path.read_text(encoding="utf-8")
+            if not re.search(r"Historical|Superseded", text[:800], re.I):
+                report.add("WARNING", "history-label", path.relative_to(root).as_posix(), 1, "docs/history file lacks a visible historical/superseded notice")
+
+
+def run_checks(root: Path) -> Report:
+    root = root.resolve()
+    report = Report()
+    for check in (_check_driver, _check_ci_claims, _check_measurement, _check_links,
+                  _check_file_references, _check_screens, _check_resolved_claims,
+                  _check_prompt_residue, _check_history_labels):
+        check(root, report)
+    return report
+
+
+def _render(report: Report) -> str:
+    lines = ["OrcSDR Documentation Truth Check", "================================"]
+    lines.extend(f"PASS  {message}" for message in report.passes)
+    for item in report.warnings:
+        lines.append(f"WARN  {item.path}:{item.line}: {item.message}")
+    for item in report.errors:
+        lines.append(f"ERROR {item.path}:{item.line}: {item.message}")
+    lines.extend(("", f"{len(report.errors)} errors", f"{len(report.warnings)} warnings"))
+    return "\n".join(lines)
+
+
+def _github_output(report: Report, rendered: str) -> None:
+    for item in report.errors + report.warnings:
+        level = "error" if item.level == "ERROR" else "warning"
+        print(f"::{level} file={item.path},line={item.line}::{item.message}")
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a", encoding="utf-8") as handle:
+            handle.write("```text\n" + rendered + "\n```\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    report = run_checks(args.root)
+    rendered = _render(report)
+    if args.json:
+        print(json.dumps(dataclasses.asdict(report), indent=2))
+    else:
+        print(rendered)
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        _github_output(report, rendered)
+    return 1 if report.errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- correct current project, receiver, security, installation, and feature documentation against source and release evidence
- separate current status and future roadmap from historical plans and validation records
- add a deterministic, standard-library Documentation Truth checker with fixture tests and a read-only GitHub Actions workflow

## Validation

- `python -m unittest discover -s tests -p 'test_documentation_truth.py' -v` — 11 passed
- `python tools/check_documentation_truth.py` — 0 errors, 0 warnings
- `python tools/help_media.py validate` — passed
- `python tools/validate-help-docs.py` — passed, 45 screens
- `python -m mkdocs build --strict` — passed
- `git diff --check origin/main..HEAD` — passed

## Boundaries

- no production firmware source was changed
- no firmware build, flash, serial session, hardware operation, or RF test was performed
- the Documentation Truth workflow uses standard Python and GitHub-hosted Ubuntu only; it calls no AI service and requires no AI credentials
- this PR does not claim unverified receiver, Tab5 revision, or RF compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated installation guidance for the published v0.2.0-beta.6-multidongle-rc4 package.
  - Clarified supported receiver hardware, current feature evidence, and experimental capabilities.
  - Added historical-status labels to older reports and design documents.
  - Documented the LAN console’s tuning, volume, span, step, and dashboard controls, including its trusted-LAN-only security requirements.
  - Clarified that several band-specific modes currently use shared generic receiver views rather than dedicated decoders.

- **Quality**
  - Added automated checks for documentation consistency, links, version references, and status claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->